### PR TITLE
feat(workon): auto-create tmux session when running outside tmux

### DIFF
--- a/src/vendor/mpr-plugins/oracle-workon/index.ts
+++ b/src/vendor/mpr-plugins/oracle-workon/index.ts
@@ -63,16 +63,11 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   };
   try {
     const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const inTmux = Boolean(process.env.TMUX);
 
     if (hasFlag(args, "--help", "-h") || args.length === 0) {
       console.log(HELP);
       return { ok: true, output: logs.join("\n") || undefined };
-    }
-
-    if (!process.env.TMUX) {
-      console.error("⚠ maw oracle-workon requires tmux (splits need a pane to split FROM).");
-      console.error("  Try: tmux attach -t 01-mawjs   or   tmux new -s play");
-      return { ok: false, error: "not in tmux", output: logs.join("\n") || undefined };
     }
 
     const slug = getFlag(args, "--task");
@@ -111,7 +106,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     console.log(`  engine:  ${engine}`);
     console.log(`  agents:  ${agents.length ? agents.join(" ") : "none"}`);
 
-    let leaderCmd = `maw wake ${oracle} --task ${slug} --split --no-attach --engine ${engine}`;
+    let leaderCmd = `maw wake ${oracle} --task ${slug} --engine ${engine}`;
+    if (inTmux) {
+      leaderCmd += " --split --no-attach";
+    } else {
+      leaderCmd += " --work";
+    }
     if (prompt) leaderCmd += ` --prompt '${prompt.replace(/'/g, "'\\''")}'`;
 
     const swarmCmd = agents.length
@@ -121,7 +121,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     if (dryRun) {
       console.log("");
       console.log(`▶ ${leaderCmd}`);
-      if (swarmCmd) console.log(`▶ (in new pane) ${swarmCmd}`);
+      if (swarmCmd && inTmux) console.log(`▶ (in new pane) ${swarmCmd}`);
+      if (swarmCmd && !inTmux) console.log(`⚠ [dry-run] skipped agent spawn outside tmux: ${swarmCmd}`);
       console.log("");
       console.log("[dry-run] no changes made.");
       return { ok: true, output: logs.join("\n") || undefined };
@@ -134,7 +135,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     await new Promise((r) => setTimeout(r, 2000));
 
     let newPane = "";
-    if (agents.length) {
+    if (agents.length && inTmux) {
       const panes = execSync("tmux list-panes -a -F '#{pane_id} #{pane_title}'", { encoding: "utf8" });
       const match = panes
         .split("\n")
@@ -150,6 +151,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       console.log(`▶ (in ${newPane}) ${swarmCmd}`);
       await new Promise((r) => setTimeout(r, 3000));
       execSync(`maw run ${newPane} '${swarmCmd.replace(/'/g, "'\\''")}'`, { stdio: "inherit" });
+    } else if (agents.length) {
+      console.log(`\n⚠ Skipped agent spawn outside tmux: ${swarmCmd}`);
     }
 
     console.log("");

--- a/test/isolated/oracle-workon-index-coverage.test.ts
+++ b/test/isolated/oracle-workon-index-coverage.test.ts
@@ -104,16 +104,43 @@ describe("oracle-workon plugin index", () => {
     expect(execCalls).toEqual([]);
   });
 
-  test("rejects execution outside tmux before parsing task details", async () => {
+  test("auto-creates a tmux session outside tmux", async () => {
     delete process.env.TMUX;
+    fastTimers();
+    const dir = chdirTemp("oracle-workon-outside-");
+    const basename = dir.split(/[\\/]+/).filter(Boolean).at(-1)!;
 
     const result = await handler({ source: "cli", args: ["--task", "ship-fix"] } as any);
 
-    expect(result.ok).toBe(false);
-    expect(result.error).toBe("not in tmux");
-    expect(result.output).toContain("requires tmux");
-    expect(result.output).toContain("tmux attach");
-    expect(execCalls).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain(`maw wake ${basename} --task ship-fix --engine claude47 --work`);
+    expect(result.output).not.toContain("--split");
+    expect(result.output).toContain("✓ oracle-workon complete:");
+    expect(execCalls).toEqual([
+      {
+        cmd: `maw wake ${basename} --task ship-fix --engine claude47 --work`,
+        options: { stdio: "inherit" },
+      },
+    ]);
+  });
+
+  test("skips swarm agents outside tmux", async () => {
+    delete process.env.TMUX;
+    fastTimers();
+
+    const result = await handler({
+      source: "cli",
+      args: ["maw-js", "--task", "ship-fix", "--with", "codex,thclaws"],
+    } as any);
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("⚠ Skipped agent spawn outside tmux: maw swarm codex thclaws");
+    expect(execCalls).toEqual([
+      {
+        cmd: "maw wake maw-js --task ship-fix --engine claude47 --work",
+        options: { stdio: "inherit" },
+      },
+    ]);
   });
 
   test("requires --task once tmux is available", async () => {
@@ -139,7 +166,7 @@ describe("oracle-workon plugin index", () => {
     expect(result.output).toContain(`auto-detected oracle: ${basename} (from cwd)`);
     expect(execCalls).toEqual([
       {
-        cmd: `maw wake ${basename} --task ship-fix --split --no-attach --engine claude47`,
+        cmd: `maw wake ${basename} --task ship-fix --engine claude47 --split --no-attach`,
         options: { stdio: "inherit" },
       },
     ]);
@@ -170,7 +197,7 @@ describe("oracle-workon plugin index", () => {
     expect(result.output).toContain("slug:    ship-fix");
     expect(result.output).toContain("engine:  claude46");
     expect(result.output).toContain("agents:  codex thclaws");
-    expect(result.output).toContain("▶ maw wake arra --task ship-fix --split --no-attach --engine claude46 --prompt 'ship Bob'\\''s fix'");
+    expect(result.output).toContain("▶ maw wake arra --task ship-fix --engine claude46 --split --no-attach --prompt 'ship Bob'\\''s fix'");
     expect(result.output).toContain("▶ (in new pane) maw swarm codex thclaws --tiled");
     expect(result.output).toContain("[dry-run] no changes made.");
     expect(execCalls).toEqual([]);
@@ -190,7 +217,7 @@ describe("oracle-workon plugin index", () => {
     expect(result.output).toContain("cleanup:   maw done pulse-ship-fix");
     expect(execCalls).toEqual([
       {
-        cmd: "maw wake pulse --task ship-fix --split --no-attach --engine claude47",
+        cmd: "maw wake pulse --task ship-fix --engine claude47 --split --no-attach",
         options: { stdio: "inherit" },
       },
     ]);
@@ -207,13 +234,13 @@ describe("oracle-workon plugin index", () => {
     } as any);
 
     expect(result.ok).toBe(true);
-    expect(result.output).toContain("▶ maw wake arra --task long-investigation --split --no-attach --engine claude47");
+    expect(result.output).toContain("▶ maw wake arra --task long-investigation --engine claude47 --split --no-attach");
     expect(result.output).toContain("▶ (in %9) maw swarm codex thclaws");
     expect(result.output).toContain("leader:    %9");
     expect(result.output).toContain("agents:    codex thclaws");
     expect(execCalls).toEqual([
       {
-        cmd: "maw wake arra --task long-investigation --split --no-attach --engine claude47",
+        cmd: "maw wake arra --task long-investigation --engine claude47 --split --no-attach",
         options: { stdio: "inherit" },
       },
       {
@@ -239,7 +266,7 @@ describe("oracle-workon plugin index", () => {
     expect(result.output).toContain("leader is up; swarm skipped");
     expect(execCalls).toEqual([
       {
-        cmd: "maw wake arra --task ship-cache --split --no-attach --engine claude47",
+        cmd: "maw wake arra --task ship-cache --engine claude47 --split --no-attach",
         options: { stdio: "inherit" },
       },
       {
@@ -261,7 +288,7 @@ describe("oracle-workon plugin index", () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toContain("oracle:  arra");
-    expect(result.error).toContain("▶ maw wake arra --task ship-fix --split --no-attach --engine claude47");
+    expect(result.error).toContain("▶ maw wake arra --task ship-fix --engine claude47 --split --no-attach");
     expect(result.output).toBe(result.error);
   });
 });

--- a/test/isolated/plugin-oracle-workon-standalone.test.ts
+++ b/test/isolated/plugin-oracle-workon-standalone.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+const root = join(import.meta.dir, "../..");
+const pluginDir = join(root, "src/vendor/mpr-plugins/oracle-workon");
+
+describe("oracle-workon plugin standalone boundary", () => {
+  test("keeps imports on the standalone SDK boundary", () => {
+    const manifest = JSON.parse(readFileSync(join(pluginDir, "plugin.json"), "utf8"));
+    expect(manifest.name).toBe("oracle-workon");
+    expect(manifest.cli?.command).toBe("oracle-workon");
+
+    const imports = expectStandalonePluginBoundary({
+      plugin: "oracle-workon",
+      requireSdk: false,
+      allowMawJs: ["maw-js/commands/shared/wake-cwd"],
+    });
+
+    expect(imports.map((record) => record.spec)).toContain("maw-js/commands/shared/wake-cwd");
+  });
+});


### PR DESCRIPTION
## Summary
- Auto-create a tmux session for `maw oracle-workon` when called outside tmux using `maw wake --work`.
- Preserve existing in-tmux startup ordering and behavior (`--split --no-attach` + swarm dispatch).
- Skip swarm dispatch outside tmux and log a clear warning message.
- Update isolated coverage for outside-tmux behavior and command ordering changes.

Closes #2621
