### PR TITLE
Fix selective rehydration ANSI escapes

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -575,9 +575,9 @@ export function parseRehydrationSelection(input: string, count: number): number[
 
 function selectAgentsRehydrationPlan(plan: RehydrateWorktreePlan[]): RehydrateWorktreePlan[] {
   if (plan.length === 0 || !_wtPicker.isStdoutTTY()) return plan;
-  console.log(`[36m↻[0m found ${plan.length} saved agent window${plan.length === 1 ? "" : "s"}:`);
+  console.log(`\x1b[36m↻\x1b[0m found ${plan.length} saved agent window${plan.length === 1 ? "" : "s"}:`);
   for (const wt of plan) {
-    console.log(`  [90m${wt.windowName.padEnd(40)} ${formatWorktreeSource(wt.path)}[0m`);
+    console.log(`  \x1b[90m${wt.windowName.padEnd(40)} ${formatWorktreeSource(wt.path)}\x1b[0m`);
   }
   console.log("");
   process.stdout.write(`  Rehydrate? [Y]es all / [n]one / [s]elect: `);
@@ -585,16 +585,16 @@ function selectAgentsRehydrationPlan(plan: RehydrateWorktreePlan[]): RehydrateWo
   if (/^n/i.test(answer)) return [];
   if (!/^s/i.test(answer)) return plan;
 
-  console.log(`[36m↻[0m select saved agent windows:`);
+  console.log(`\x1b[36m↻\x1b[0m select saved agent windows:`);
   plan.forEach((wt, index) => {
-    console.log(`  [36m${index + 1}[0m) ${wt.windowName}  [90m${formatWorktreeSource(wt.path)}[0m`);
+    console.log(`  \x1b[36m${index + 1}\x1b[0m) ${wt.windowName}  \x1b[90m${formatWorktreeSource(wt.path)}\x1b[0m`);
   });
   process.stdout.write(`  → `);
   const rawSelection = _wtPicker.readChoice() || "";
   const selectedIndices = parseRehydrationSelection(rawSelection, plan.length);
   const selectedPlan = selectedIndices.map(index => plan[index]!).filter(Boolean);
   if (selectedPlan.length > 0) {
-    console.log(`[32m✓[0m rehydrating: ${selectedPlan.map(wt => wt.windowName).join(", ")}`);
+    console.log(`\x1b[32m✓\x1b[0m rehydrating: ${selectedPlan.map(wt => wt.windowName).join(", ")}`);
   }
   return selectedPlan;
 }

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -746,8 +746,10 @@ describe("cmdWake main-suite coverage", () => {
         { session: "01-mawjs", name: "mawjs-wezterm", opts: { cwd: worktrees[2]!.path } },
       ]);
       const rendered = logs.join("\n");
-      expect(rendered).toContain("select saved agent windows");
-      expect(rendered).toContain("rehydrating: mawjs-bridge, mawjs-wezterm");
+      expect(rendered).toContain("\x1b[36m↻\x1b[0m select saved agent windows");
+      expect(rendered).toContain("  \x1b[36m1\x1b[0m) mawjs-bridge");
+      expect(rendered).toContain("\x1b[32m✓\x1b[0m rehydrating: mawjs-bridge, mawjs-wezterm");
+      expect(rendered).not.toMatch(/(^|[^\x1b])\[36m/);
       expect(rendered).not.toContain("window: mawjs-white");
     } finally {
       _wtPicker.isStdoutTTY = originalIsStdoutTTY;


### PR DESCRIPTION
Closes #2624

## Summary
- replace literal ESC bytes in selective agent rehydration output with explicit `\x1b[` ANSI escapes
- strengthen the #2604 regression test to require ESC-prefixed color sequences and reject raw `[36m` fragments

## Tests
- bun test test/wake-cmd-cmdwake-coverage.test.ts -t "#2604" --path-ignore-patterns "**/agents/**"
- bun test test/isolated/wake-cmd-branch-coverage.test.ts -t "existing window with prompt" --path-ignore-patterns "**/agents/**"
- bun run build
- git diff --check