### PR TITLE
Scope serve profile transport routers

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -5,7 +5,7 @@ import { existsSync, readFileSync } from "fs";
 import { api } from "../api";
 import { feedBuffer, feedListeners } from "../api/feed";
 import { setupTriggerListener } from "./runtime/trigger-listener";
-import { createTransportRouter } from "../transports";
+import { createScopedTransportRouter } from "../transports";
 import { isProtected, setBunServer } from "../lib/elysia-auth";
 import { runServeLifecycleHooks } from "../plugin/lifecycle";
 import { discoverLocalPluginDirs } from "../plugin/registry-helpers";
@@ -288,7 +288,7 @@ export async function startBunGatewayServer(
   // side effects relative to dispatch, trigger listeners, and feed plugin setup.
   if (profile.transports === undefined || profile.transports.length > 0) {
     try {
-      const router = createTransportRouter(profile.transports);
+      const router = createScopedTransportRouter(profile.transports);
       router.connectAll().catch(err => log.error("[transport] connect failed:", err));
       engine.setTransportRouter(router);
     } catch (err) {

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -49,22 +49,16 @@ function transportProfileKey(transports?: string[]): string {
   return transports === undefined ? "all" : [...new Set(transports)].sort().join(",");
 }
 
-/** Build transport router from maw.config.json */
-export function createTransportRouter(transports?: string[]): TransportRouter {
-  const profileKey = transportProfileKey(transports);
-  if (router && routerProfileKey === profileKey) return router;
-  if (router) router.disconnectAll().catch(() => {});
-
+function buildTransportRouter(transports?: string[]): TransportRouter {
   const config = loadConfig();
   const enabledTransports = transports === undefined ? null : new Set(transports);
-  router = new TransportRouter(config.broadcastTo ?? []);
-  routerProfileKey = profileKey;
+  const nextRouter = new TransportRouter(config.broadcastTo ?? []);
 
   // 1. Always register tmux (local fast path) by default — auto-connected
   if (transportEnabled(enabledTransports, "tmux")) {
     const tmux = new TmuxTransport();
     tmux.connect().catch(() => {}); // tmux is always available locally
-    router.register(tmux);
+    nextRouter.register(tmux);
   }
 
   const discovery = discoveryTransport(config);
@@ -80,7 +74,7 @@ export function createTransportRouter(transports?: string[]): TransportRouter {
       autoPair: true,
     });
     scout.connect().catch(() => {});
-    router.register(scout);
+    nextRouter.register(scout);
   }
 
   // 2.5b. Zenoh Scout — opt-in discovery/presence provider only.
@@ -89,7 +83,7 @@ export function createTransportRouter(transports?: string[]): TransportRouter {
   if (transportEnabled(enabledTransports, "zenoh-scout") && (discovery === "zenoh" || discovery === "both")) {
     const zenohScout = new PluginTransportAdapter(ZENOH_SCOUT_PLUGIN, ZENOH_SCOUT_TRANSPORT_FACTORY, config);
     zenohScout.connect().catch(() => {});
-    router.register(zenohScout);
+    nextRouter.register(zenohScout);
   }
 
   // 2.6. Zenoh transport — pub/sub + auto-discovery (dynamic import — WASM)
@@ -100,13 +94,13 @@ export function createTransportRouter(transports?: string[]): TransportRouter {
         node: config.node ?? "local",
       });
       zt.connect().catch((e) => console.warn(`[zenoh] connect failed: ${e}`));
-      router!.register(zt);
+      nextRouter.register(zt);
     }).catch((e) => console.warn(`[zenoh] load failed: ${e}`));
   }
 
   // 3. HTTP federation as fallback
   if (transportEnabled(enabledTransports, "http") && config.peers && config.peers.length > 0) {
-    router.register(
+    nextRouter.register(
       new HttpTransport({
         peers: config.peers,
         selfHost: config.node ?? "local",
@@ -115,8 +109,24 @@ export function createTransportRouter(transports?: string[]): TransportRouter {
   }
 
   // 4. NanoClaw (external chat channels — Telegram, Discord, etc.)
-  if (transportEnabled(enabledTransports, "nanoclaw")) router.register(new NanoclawTransport());
+  if (transportEnabled(enabledTransports, "nanoclaw")) nextRouter.register(new NanoclawTransport());
 
+  return nextRouter;
+}
+
+/** Build a fresh transport router scoped to one serve profile lifecycle. */
+export function createScopedTransportRouter(transports?: string[]): TransportRouter {
+  return buildTransportRouter(transports);
+}
+
+/** Build or reuse the legacy singleton transport router from maw.config.json. */
+export function createTransportRouter(transports?: string[]): TransportRouter {
+  const profileKey = transportProfileKey(transports);
+  if (router && routerProfileKey === profileKey) return router;
+  if (router) router.disconnectAll().catch(() => {});
+
+  router = buildTransportRouter(transports);
+  routerProfileKey = profileKey;
   return router;
 }
 

--- a/test/isolated/core-server-more-coverage-2.test.ts
+++ b/test/isolated/core-server-more-coverage-2.test.ts
@@ -68,6 +68,9 @@ mock.module(import.meta.resolve("../../src/core/runtime/trigger-listener"), () =
   setupTriggerListener: () => {},
 }));
 mock.module(import.meta.resolve("../../src/transports"), () => ({
+  createScopedTransportRouter: () => ({
+    connectAll: () => connectShouldReject ? Promise.reject(new Error("connect rejected")) : Promise.resolve(),
+  }),
   createTransportRouter: () => ({
     connectAll: () => connectShouldReject ? Promise.reject(new Error("connect rejected")) : Promise.resolve(),
   }),

--- a/test/isolated/coverage-core-shared-server.test.ts
+++ b/test/isolated/coverage-core-shared-server.test.ts
@@ -19,11 +19,16 @@ let apiPaths: string[] = [];
 let proxiedPaths: string[] = [];
 let lifecyclePayloads: unknown[] = [];
 let transportProfiles: unknown[] = [];
+let transportRouters: unknown[] = [];
+let engineRouters: unknown[] = [];
 let healthPolls = 0;
 let tmp = "";
 
 class FakeEngine {
-  setTransportRouter() { engineCalls.push("router"); }
+  setTransportRouter(router: unknown) {
+    engineCalls.push("router");
+    engineRouters.push(router);
+  }
   handleOpen() { engineCalls.push("open"); }
   handleMessage() { engineCalls.push("message"); }
   handleClose() { engineCalls.push("close"); }
@@ -51,11 +56,16 @@ mock.module(import.meta.resolve("../../src/views/index"), () => ({
   mountViews: (views: Hono) => { views.get("/throws", () => { throw new Error("view failed"); }); },
 }));
 mock.module(import.meta.resolve("../../src/core/runtime/trigger-listener"), () => ({ setupTriggerListener: () => {} }));
+function createFakeTransportRouter(transports?: string[]) {
+  const router = { transports, connectAll: () => Promise.resolve() };
+  transportProfiles.push(transports);
+  transportRouters.push(router);
+  return router;
+}
+
 mock.module(import.meta.resolve("../../src/transports"), () => ({
-  createTransportRouter: (transports?: string[]) => {
-    transportProfiles.push(transports);
-    return { connectAll: () => Promise.resolve() };
-  },
+  createScopedTransportRouter: createFakeTransportRouter,
+  createTransportRouter: createFakeTransportRouter,
   getTransportRouter: () => null,
   resetTransportRouter: () => {},
 }));
@@ -154,6 +164,8 @@ beforeEach(() => {
   proxiedPaths = [];
   lifecyclePayloads = [];
   transportProfiles = [];
+  transportRouters = [];
+  engineRouters = [];
   healthPolls = 0;
   Bun.serve = ((opts: any) => {
     serveCalls.push(opts);
@@ -346,6 +358,18 @@ describe("coverage core shared server", () => {
       profile: { views: false, apiRouters: ["identity"] },
     });
     expect(serveCalls).toHaveLength(1);
+  });
+
+  test("startServer scopes transport routers to sequential ServeProfiles without state bleed", async () => {
+    await startServer(4912, { transports: ["tmux"], views: false, intervals: false });
+    await startServer(4913, { transports: ["http"], views: false, intervals: false });
+
+    expect(transportProfiles).toEqual([["tmux"], ["http"]]);
+    expect(transportRouters).toHaveLength(2);
+    expect(transportRouters[0]).not.toBe(transportRouters[1]);
+    expect(engineRouters).toEqual(transportRouters);
+    expect(engineRouters[0]).toMatchObject({ transports: ["tmux"] });
+    expect(engineRouters[1]).toMatchObject({ transports: ["http"] });
   });
 
 });

--- a/test/isolated/serve-routes-golden-master.test.ts
+++ b/test/isolated/serve-routes-golden-master.test.ts
@@ -83,6 +83,7 @@ afterEach(() => {
 
 mock.module(import.meta.resolve("../../src/core/runtime/trigger-listener"), () => ({ setupTriggerListener: () => {} }));
 mock.module(import.meta.resolve("../../src/transports"), () => ({
+  createScopedTransportRouter: () => ({ connectAll: () => Promise.resolve(), onMessage: () => {} }),
   createTransportRouter: () => ({ connectAll: () => Promise.resolve(), onMessage: () => {} }),
   getTransportRouter: () => null,
   resetTransportRouter: () => {},


### PR DESCRIPTION
Closes #2625

## Summary
- added a scoped transport router factory for serve profile lifecycles
- switched server startup to create a fresh router per ServeProfile instead of the legacy module singleton
- added regression coverage for sequential profiles with different transports and refreshed server transport mocks

## Tests
- bash scripts/test-isolated.sh test/isolated/coverage-core-shared-server.test.ts test/isolated/serve-routes-golden-master.test.ts test/isolated/core-server-more-coverage-2.test.ts test/isolated/transports-index-function-coverage.test.ts test/isolated/coverage-plugin-transport-router.test.ts test/isolated/coverage-100-plugin-transport-oracle.test.ts
- bun test test/transports-index-default.test.ts --path-ignore-patterns '**/agents/**'\n- bun run build\n- git diff --check