### PR TITLE
Restrict gateway implementations to internal API

### DIFF
--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -12,6 +12,7 @@ export type GatewaySelectionInput = {
   cliGateway?: string | null;
   env?: Pick<NodeJS.ProcessEnv, "MAW_GATEWAY">;
   config?: Partial<Pick<MawConfig, "gateway">> | null;
+  log?: Pick<Console, "debug">;
 };
 
 export type Gateway = {
@@ -39,13 +40,17 @@ export function selectGateway(input: GatewaySelectionInput = {}): Gateway {
     ?? normalizeGateway(input.config?.gateway, "config.gateway")
     ?? "bun";
 
+  if (selected !== "bun") {
+    input.log?.debug(`[gateway] selected ${selected} gateway instead of default bun`);
+  }
+
   if (selected === "rust") return new RustGateway();
   // auto remains conservative in Phase 2: preserve the existing Bun/Elysia path
   // until the external maw-gateway binary is production-ready.
   return new BunGateway(selected);
 }
 
-export class BunGateway implements Gateway {
+class BunGateway implements Gateway {
   readonly kind: GatewayKind;
 
   constructor(kind: GatewayKind = "bun") {
@@ -58,7 +63,7 @@ export class BunGateway implements Gateway {
   }
 }
 
-export class RustGateway implements Gateway {
+class RustGateway implements Gateway {
   readonly kind = "rust" as const;
 
   constructor(private readonly binary = process.env.MAW_GATEWAY_BIN || "maw-gateway") {}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -258,8 +258,10 @@ export async function startServer(
   overrideOptions?: StartServerOptions,
 ) {
   const { options } = resolveStartServerInputs(profileOrOptions, overrideOptions);
+  const verbosity = options.verbosity ?? normalizeServeVerbosity(process.env.MAW_SERVE_VERBOSITY);
+  const log = createServeLogger(verbosity);
   const config = loadConfig();
-  const gateway = selectGateway({ cliGateway: options.gateway, env: process.env, config });
+  const gateway = selectGateway({ cliGateway: options.gateway, env: process.env, config, log });
   if (gateway.kind !== "rust") return startBunGatewayServer(port, profileOrOptions, overrideOptions);
   return gateway.start(port, options);
 }

--- a/test/isolated/gateway-selector.test.ts
+++ b/test/isolated/gateway-selector.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { BunGateway, RustGateway, normalizeGateway, selectGateway } from "../../src/core/gateway";
+import { normalizeGateway, selectGateway } from "../../src/core/gateway";
 import { routeToolsWithDeps, type RouteToolsDeps } from "../../src/cli/route-tools";
 
 function routeDeps(calls: Array<Record<string, unknown>>): RouteToolsDeps {
@@ -35,10 +35,50 @@ function routeDeps(calls: Array<Record<string, unknown>>): RouteToolsDeps {
 describe("gateway selector (#2566)", () => {
   test("selectGateway honors CLI > env > config > bun precedence", () => {
     expect(selectGateway({}).kind).toBe("bun");
-    expect(selectGateway({ config: { gateway: "auto" } })).toBeInstanceOf(BunGateway);
-    expect(selectGateway({ config: { gateway: "rust" } })).toBeInstanceOf(RustGateway);
-    expect(selectGateway({ env: { MAW_GATEWAY: "rust" }, config: { gateway: "bun" } })).toBeInstanceOf(RustGateway);
+    expect(selectGateway({ config: { gateway: "auto" } }).kind).toBe("auto");
+    expect(selectGateway({ config: { gateway: "rust" } }).kind).toBe("rust");
+    expect(selectGateway({ env: { MAW_GATEWAY: "rust" }, config: { gateway: "bun" } }).kind).toBe("rust");
     expect(selectGateway({ cliGateway: "bun", env: { MAW_GATEWAY: "rust" }, config: { gateway: "rust" } }).kind).toBe("bun");
+  });
+
+  test("selectGateway returns the correct gateway kind for each accepted input", () => {
+    const cases = [
+      [{ cliGateway: "bun" }, "bun"],
+      [{ cliGateway: "rust" }, "rust"],
+      [{ cliGateway: "auto" }, "auto"],
+      [{ env: { MAW_GATEWAY: "bun" } }, "bun"],
+      [{ env: { MAW_GATEWAY: "rust" } }, "rust"],
+      [{ env: { MAW_GATEWAY: "auto" } }, "auto"],
+      [{ config: { gateway: "bun" } }, "bun"],
+      [{ config: { gateway: "rust" } }, "rust"],
+      [{ config: { gateway: "auto" } }, "auto"],
+    ] as const;
+
+    for (const [input, kind] of cases) {
+      expect(selectGateway(input).kind).toBe(kind);
+    }
+  });
+
+  test("selectGateway logs debug output when a non-default gateway is selected", () => {
+    const debugCalls: string[] = [];
+    const log = { debug: (...args: unknown[]) => debugCalls.push(args.map(String).join(" ")) };
+
+    expect(selectGateway({ cliGateway: "bun", log }).kind).toBe("bun");
+    expect(debugCalls).toEqual([]);
+
+    expect(selectGateway({ cliGateway: "rust", log }).kind).toBe("rust");
+    expect(selectGateway({ cliGateway: "auto", log }).kind).toBe("auto");
+    expect(debugCalls).toEqual([
+      "[gateway] selected rust gateway instead of default bun",
+      "[gateway] selected auto gateway instead of default bun",
+    ]);
+  });
+
+  test("gateway implementation classes stay internal to the module", async () => {
+    const gatewayModule = await import("../../src/core/gateway");
+
+    expect("BunGateway" in gatewayModule).toBe(false);
+    expect("RustGateway" in gatewayModule).toBe(false);
   });
 
   test("rejects invalid gateway values at the selection boundary", () => {


### PR DESCRIPTION
Closes #2626

## Summary
- made BunGateway and RustGateway internal implementation classes
- kept selectGateway() and gateway types as the public gateway seam
- added debug logging when selection chooses a non-default gateway
- expanded selector tests for every accepted input and API-surface expectations

## Tests
- bash scripts/test-isolated.sh test/isolated/gateway-selector.test.ts test/isolated/core-server-more-coverage-2.test.ts test/isolated/coverage-core-shared-server.test.ts
- bun run build
- git diff --check