### PR TITLE
Forward Rust gateway logs and trace requests

### DIFF
--- a/packages/maw-gateway/Cargo.lock
+++ b/packages/maw-gateway/Cargo.lock
@@ -61,10 +61,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -219,6 +235,7 @@ dependencies = [
  "axum",
  "serde",
  "tokio",
+ "tower-http",
 ]
 
 [[package]]
@@ -353,6 +370,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +427,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",
@@ -427,6 +455,22 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/packages/maw-gateway/Cargo.toml
+++ b/packages/maw-gateway/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 axum = "0.8"
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
+tower-http = { version = "0.6", features = ["trace"] }

--- a/packages/maw-gateway/src/main.rs
+++ b/packages/maw-gateway/src/main.rs
@@ -1,6 +1,15 @@
-use axum::{extract::State, routing::get, Json, Router};
+use axum::{
+    body::Body,
+    extract::State,
+    http::Request,
+    middleware::{self, Next},
+    response::Response,
+    routing::get,
+    Json, Router,
+};
 use serde::Serialize;
-use std::{env, net::SocketAddr, process};
+use std::{env, net::SocketAddr, process, time::Instant};
+use tower_http::trace::TraceLayer;
 
 #[derive(Clone)]
 struct AppState {
@@ -20,6 +29,23 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         gateway: "rust",
         port: state.port,
     })
+}
+
+async fn log_request(request: Request<Body>, next: Next) -> Response {
+    let method = request.method().clone();
+    let path = request.uri().path().to_owned();
+    let started = Instant::now();
+    let response = next.run(request).await;
+    let elapsed_ms = started.elapsed().as_millis();
+
+    println!(
+        "{} {} {} {}ms",
+        method,
+        path,
+        response.status().as_u16(),
+        elapsed_ms
+    );
+    response
 }
 
 fn usage() -> ! {
@@ -54,6 +80,22 @@ fn parse_port(args: &[String]) -> u16 {
     port.unwrap_or_else(|| usage())
 }
 
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut terminate = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {},
+        _ = terminate.recv() => {},
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
@@ -61,6 +103,8 @@ async fn main() {
     let state = AppState { port };
     let app = Router::new()
         .route("/api/health", get(health))
+        .layer(middleware::from_fn(log_request))
+        .layer(TraceLayer::new_for_http())
         .with_state(state);
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = match tokio::net::TcpListener::bind(addr).await {
@@ -72,7 +116,10 @@ async fn main() {
     };
 
     println!("listening on :{}", port);
-    if let Err(error) = axum::serve(listener, app).await {
+    if let Err(error) = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+    {
         eprintln!("server error: {}", error);
         process::exit(1);
     }

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -143,6 +143,8 @@ class RustGateway implements Gateway {
         reject(error);
       };
       const supervise = () => {
+        child.stdout.on("data", (chunk) => process.stdout.write(chunk));
+        child.stderr.on("data", (chunk) => process.stderr.write(chunk));
         child.on("exit", (code, signal) => {
           console.warn("[gateway:rust] process exited", { code, signal });
         });

--- a/test/isolated/gateway-selector.test.ts
+++ b/test/isolated/gateway-selector.test.ts
@@ -103,8 +103,15 @@ describe("gateway selector (#2566)", () => {
   });
 
   test("RustGateway.start throws UserError when maw-gateway is not found", async () => {
-    expect(resolveGatewayBinary({ PATH: "/definitely/missing" })).toBeNull();
-    await expect(selectGateway({ cliGateway: "rust" }).start(4569)).rejects.toThrow("maw-gateway binary not found");
+    const previous = process.env.MAW_GATEWAY_BIN;
+    try {
+      process.env.MAW_GATEWAY_BIN = "/definitely/missing/maw-gateway";
+      expect(resolveGatewayBinary({ PATH: "/definitely/missing" })).toBeNull();
+      await expect(selectGateway({ cliGateway: "rust" }).start(4569)).rejects.toThrow("maw-gateway binary not found");
+    } finally {
+      if (previous === undefined) delete process.env.MAW_GATEWAY_BIN;
+      else process.env.MAW_GATEWAY_BIN = previous;
+    }
   });
 
   test("RustGateway.start passes only allowlisted environment to maw-gateway", async () => {
@@ -115,14 +122,20 @@ describe("gateway selector (#2566)", () => {
       MAW_GATEWAY_BIN: process.env.MAW_GATEWAY_BIN,
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
       GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      stdoutWrite: process.stdout.write,
     };
-    writeFileSync(binary, `#!/bin/sh\nenv > ${JSON.stringify(envFile)}\necho "listening on :$3"\nsleep 30\n`);
+    const forwarded: string[] = [];
+    writeFileSync(binary, `#!/bin/sh\nenv > ${JSON.stringify(envFile)}\necho "listening on :$3"\nsleep 0.1\necho "forwarded after readiness"\nsleep 30\n`);
     chmodSync(binary, 0o755);
 
     try {
       process.env.MAW_GATEWAY_BIN = binary;
       process.env.ANTHROPIC_API_KEY = "secret-anthropic";
       process.env.GITHUB_TOKEN = "secret-github";
+      process.stdout.write = ((chunk: string | Uint8Array) => {
+        forwarded.push(String(chunk));
+        return true;
+      }) as typeof process.stdout.write;
 
       const child = await selectGateway({ cliGateway: "rust" }).start(4570) as { kill: () => void; once: (event: string, cb: () => void) => void };
       const envText = readFileSync(envFile, "utf8");
@@ -131,11 +144,16 @@ describe("gateway selector (#2566)", () => {
       expect(envText).not.toContain("GITHUB_TOKEN");
       expect(envText).not.toContain("secret-anthropic");
       expect(envText).not.toContain("secret-github");
+      for (let i = 0; i < 20 && !forwarded.join("").includes("forwarded after readiness"); i++) {
+        await new Promise(resolve => setTimeout(resolve, 10));
+      }
+      expect(forwarded.join("")).toContain("forwarded after readiness");
       await new Promise<void>((resolve) => {
         child.once("exit", resolve);
         child.kill();
       });
     } finally {
+      process.stdout.write = previous.stdoutWrite;
       if (previous.MAW_GATEWAY_BIN === undefined) delete process.env.MAW_GATEWAY_BIN;
       else process.env.MAW_GATEWAY_BIN = previous.MAW_GATEWAY_BIN;
       if (previous.ANTHROPIC_API_KEY === undefined) delete process.env.ANTHROPIC_API_KEY;


### PR DESCRIPTION
Closes #2633

## Summary
- forward `maw-gateway` stdout/stderr after readiness so `maw serve --gateway rust` keeps child logs visible
- add Rust request logging with `METHOD path status duration` lines
- add graceful shutdown for Ctrl-C/SIGTERM
- add a regression that verifies post-readiness stdout forwarding

## Tests
- bun test test/isolated/gateway-selector.test.ts test/config-validate.test.ts test/route-tools-default.test.ts --path-ignore-patterns "**/agents/**"
- cargo fmt --manifest-path packages/maw-gateway/Cargo.toml --check
- cargo check --manifest-path packages/maw-gateway/Cargo.toml
- cargo run --manifest-path packages/maw-gateway/Cargo.toml -- serve --port 45680 + /api/health/log/SIGTERM smoke
- bun run build
- git diff --check