### PR TITLE
Fix maw-gateway default port and macOS signing

### DIFF
--- a/packages/maw-gateway/Makefile
+++ b/packages/maw-gateway/Makefile
@@ -1,0 +1,41 @@
+CARGO ?= cargo
+TARGET ?= target/release/maw-gateway
+SMOKE_PORT ?= 3456
+UNAME_S := $(shell uname -s)
+
+.PHONY: build release sign test smoke clean
+
+build: release sign
+
+release:
+	$(CARGO) build --release
+
+sign:
+ifeq ($(UNAME_S),Darwin)
+	codesign -s - "$(TARGET)"
+else
+	@echo "codesign skipped: $(UNAME_S) is not Darwin"
+endif
+
+test:
+	$(CARGO) test
+
+smoke: build
+	@set -e; \
+	log="$$(mktemp)"; \
+	"$(TARGET)" serve --port "$(SMOKE_PORT)" >"$$log" 2>&1 & \
+	pid="$$!"; \
+	trap 'kill "$$pid" >/dev/null 2>&1 || true; rm -f "$$log"' EXIT; \
+	for _ in 1 2 3 4 5 6 7 8 9 10; do \
+		if grep -q "listening on :$(SMOKE_PORT)" "$$log"; then break; fi; \
+		sleep 0.2; \
+	done; \
+	grep -q "listening on :$(SMOKE_PORT)" "$$log"; \
+	curl -fsS "http://127.0.0.1:$(SMOKE_PORT)/api/health" >/dev/null; \
+	kill "$$pid" >/dev/null 2>&1 || true; \
+	wait "$$pid" >/dev/null 2>&1 || true; \
+	rm -f "$$log"; \
+	trap - EXIT
+
+clean:
+	$(CARGO) clean

--- a/packages/maw-gateway/src/main.rs
+++ b/packages/maw-gateway/src/main.rs
@@ -49,7 +49,7 @@ async fn log_request(request: Request<Body>, next: Next) -> Response {
 }
 
 fn usage() -> ! {
-    eprintln!("usage: maw-gateway serve --port PORT");
+    eprintln!("usage: maw-gateway serve [--port PORT]");
     process::exit(2);
 }
 
@@ -77,7 +77,27 @@ fn parse_port(args: &[String]) -> u16 {
         index += 1;
     }
 
-    port.unwrap_or_else(|| usage())
+    port.unwrap_or(3456)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_port;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_port_defaults_to_3456() {
+        assert_eq!(parse_port(&args(&["serve"])), 3456);
+    }
+
+    #[test]
+    fn parse_port_accepts_space_and_equals_forms() {
+        assert_eq!(parse_port(&args(&["serve", "--port", "8080"])), 8080);
+        assert_eq!(parse_port(&args(&["serve", "--port=9090"])), 9090);
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Closes #2635

## Summary
- default `maw-gateway serve` to port 3456 when `--port` is omitted
- add Rust unit coverage for default, `--port PORT`, and `--port=PORT` parsing
- add `packages/maw-gateway/Makefile` with release build, macOS ad-hoc `codesign -s -`, test, and smoke targets

## Tests
- `cd packages/maw-gateway && cargo fmt && cargo test`
- `cd packages/maw-gateway && make build`
- `cd packages/maw-gateway && target/release/maw-gateway serve` attempted default `:3456` and failed only because the port was already occupied
- `cd packages/maw-gateway && make smoke SMOKE_PORT=38080`
- `codesign -dv packages/maw-gateway/target/release/maw-gateway` showed ad-hoc signature
- `cd packages/maw-gateway && make test`
- `git diff --check`