### PR TITLE
Clear Rust gateway port before binding

### DIFF
--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -68,11 +68,11 @@ type ServeStatusTools = {
 
 type ServeStartTools = {
   acquirePidLock: (instanceName: string | null, opts: { forceTakeover: boolean }) => void;
-  startServer: (port: number, options?: { verbosity?: ServeVerbosity; gateway?: GatewayKind }) => Promise<void> | void;
+  startServer: (port: number, options?: { verbosity?: ServeVerbosity; gateway?: GatewayKind; forceTakeover?: boolean }) => Promise<void> | void;
 };
 
 type CoreServerTools = {
-  startServer: (port: number, options?: { verbosity?: ServeVerbosity; gateway?: GatewayKind }) => Promise<void> | void;
+  startServer: (port: number, options?: { verbosity?: ServeVerbosity; gateway?: GatewayKind; forceTakeover?: boolean }) => Promise<void> | void;
 };
 type CoreServerLoader = () => Promise<CoreServerTools>;
 
@@ -203,7 +203,7 @@ export function createDefaultRouteToolsDeps(loadCoreServer?: CoreServerLoader): 
       const { acquirePidLock } = await import("./instance-pid");
       return {
         acquirePidLock,
-        startServer: async (port: number, options?: { verbosity?: ServeVerbosity; gateway?: GatewayKind }) => {
+        startServer: async (port: number, options?: { verbosity?: ServeVerbosity; gateway?: GatewayKind; forceTakeover?: boolean }) => {
           const { startServer } = loadCoreServer ? await loadCoreServer() : await import("../core/server");
           await startServer(port, options);
         },
@@ -385,7 +385,7 @@ export async function routeToolsWithDeps(cmd: string, args: string[], deps: Rout
     const instanceName = asIdx === -1 ? null : serveArgs[asIdx + 1];
     acquirePidLock(instanceName, { forceTakeover: forceIdx !== -1 });
     if (noScoutIdx !== -1) process.env.MAW_NO_SCOUT = "1";
-    await startServer(portArg ? +portArg : 3456, { verbosity: serveVerbosity, gateway });
+    await startServer(portArg ? +portArg : 3456, { verbosity: serveVerbosity, gateway, forceTakeover: forceIdx !== -1 });
     return true;
   }
   return false;

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -107,7 +107,7 @@ function rustGatewayEnv(source: NodeJS.ProcessEnv, port: number): NodeJS.Process
 
 async function cleanupGatewayPort(port: number): Promise<void> {
   try {
-    execSync(`lsof -ti :${port} | xargs kill 2>/dev/null`, { stdio: "ignore" });
+    execSync(`lsof -ti :${port} | xargs kill`, { stdio: "ignore" });
   } catch {
     // lsof exits non-zero when the port is free, or may be unavailable on a
     // minimal system. Either case should not block gateway startup.

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { execSync, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { accessSync, constants } from "node:fs";
 import { delimiter, isAbsolute, join } from "node:path";
 import type { MawConfig } from "../config/types";
@@ -105,6 +105,16 @@ function rustGatewayEnv(source: NodeJS.ProcessEnv, port: number): NodeJS.Process
   return env;
 }
 
+async function cleanupGatewayPort(port: number): Promise<void> {
+  try {
+    execSync(`lsof -ti :${port} | xargs kill 2>/dev/null`, { stdio: "ignore" });
+  } catch {
+    // lsof exits non-zero when the port is free, or may be unavailable on a
+    // minimal system. Either case should not block gateway startup.
+  }
+  await new Promise(resolve => setTimeout(resolve, 500));
+}
+
 class RustGateway implements Gateway {
   readonly kind = "rust" as const;
 
@@ -112,6 +122,8 @@ class RustGateway implements Gateway {
 
   async start(port: number): Promise<ChildProcessWithoutNullStreams> {
     if (!this.binary) throw new UserError("maw-gateway binary not found");
+
+    await cleanupGatewayPort(port);
 
     const child = spawn(this.binary, ["serve", "--port", String(port)], {
       stdio: ["ignore", "pipe", "pipe"],

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -50,6 +50,8 @@ export type StartServerOptions = {
   gateway?: GatewayKind;
   /** Optional serve composition profile; default preserves today's full wiring. */
   profile?: ServeProfile;
+  /** Request takeover behavior for gateway implementations that can clear a bound port. */
+  forceTakeover?: boolean;
 };
 
 type ServeLogger = {

--- a/test/isolated/gateway-rust-port-cleanup.test.ts
+++ b/test/isolated/gateway-rust-port-cleanup.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const calls: string[] = [];
+
+class FakeStream extends EventEmitter {
+  off(eventName: string, listener: (...args: unknown[]) => void) {
+    return super.off(eventName, listener);
+  }
+}
+
+class FakeChild extends EventEmitter {
+  stdout = new FakeStream();
+  stderr = new FakeStream();
+  killed = false;
+  kill() {
+    this.killed = true;
+    queueMicrotask(() => this.emit("exit", null, "SIGTERM"));
+    return true;
+  }
+}
+
+mock.module("node:child_process", () => ({
+  execSync: (cmd: string, opts: unknown) => {
+    calls.push(`exec:${cmd}:${JSON.stringify(opts)}`);
+  },
+  spawn: (cmd: string, args: string[], opts: unknown) => {
+    calls.push(`spawn:${cmd}:${JSON.stringify(args)}:${JSON.stringify(opts)}`);
+    const child = new FakeChild();
+    queueMicrotask(() => child.stdout.emit("data", Buffer.from(`listening on :4788\n`)));
+    return child;
+  },
+}));
+
+const { selectGateway } = await import("../../src/core/gateway.ts?gateway-rust-port-cleanup");
+
+describe("RustGateway port cleanup", () => {
+  test("runs lsof kill cleanup before spawning maw-gateway", async () => {
+    calls.length = 0;
+    const tmp = mkdtempSync(join(tmpdir(), "maw-gateway-cleanup-"));
+    const binary = join(tmp, "maw-gateway");
+    const previous = process.env.MAW_GATEWAY_BIN;
+    writeFileSync(binary, "#!/bin/sh\n");
+    chmodSync(binary, 0o755);
+    process.env.MAW_GATEWAY_BIN = binary;
+    try {
+      const child = await selectGateway({ cliGateway: "rust" }).start(4788) as FakeChild;
+
+      expect(calls[0]).toContain("exec:lsof -ti :4788 | xargs kill");
+      expect(calls[0]).toContain('{"stdio":"ignore"}');
+      expect(calls[1]).toContain(`spawn:${binary}:["serve","--port","4788"]`);
+
+      child.kill();
+    } finally {
+      if (previous === undefined) delete process.env.MAW_GATEWAY_BIN;
+      else process.env.MAW_GATEWAY_BIN = previous;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/isolated/gateway-selector.test.ts
+++ b/test/isolated/gateway-selector.test.ts
@@ -91,7 +91,7 @@ describe("gateway selector (#2566)", () => {
     await expect(routeToolsWithDeps("serve", ["serve", "--gateway", "rust", "4567", "--force-takeover"], routeDeps(calls))).resolves.toBe(true);
 
     expect(calls).toContainEqual({ type: "lock", instanceName: null, opts: { forceTakeover: true } });
-    expect(calls).toContainEqual({ type: "start", port: 4567, options: { verbosity: 1, gateway: "rust" } });
+    expect(calls).toContainEqual({ type: "start", port: 4567, options: { verbosity: 1, gateway: "rust", forceTakeover: true } });
   });
 
   test("maw serve accepts --gateway=bun and preserves --as handling", async () => {
@@ -99,7 +99,7 @@ describe("gateway selector (#2566)", () => {
     await expect(routeToolsWithDeps("serve", ["serve", "--gateway=bun", "--as", "blue", "4568"], routeDeps(calls))).resolves.toBe(true);
 
     expect(calls).toContainEqual({ type: "lock", instanceName: "blue", opts: { forceTakeover: false } });
-    expect(calls).toContainEqual({ type: "start", port: 4568, options: { verbosity: 1, gateway: "bun" } });
+    expect(calls).toContainEqual({ type: "start", port: 4568, options: { verbosity: 1, gateway: "bun", forceTakeover: false } });
   });
 
   test("RustGateway.start throws UserError when maw-gateway is not found", async () => {

--- a/test/route-tools-default.test.ts
+++ b/test/route-tools-default.test.ts
@@ -282,55 +282,55 @@ describe("routeTools default-suite seams", () => {
     const start = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4567", "--as", "blue", "--force-takeover"], start.deps)).toBe(true);
     expect(start.calls.locks).toEqual([{ instanceName: "blue", opts: { forceTakeover: true } }]);
-    expect(start.calls.servers).toEqual([{ port: 4567, options: { verbosity: 1 } }]);
+    expect(start.calls.servers).toEqual([{ port: 4567, options: { verbosity: 1, gateway: undefined, forceTakeover: true } }]);
 
     const defaultPort = harness();
     expect(await routeToolsWithDeps("serve", ["serve"], defaultPort.deps)).toBe(true);
     expect(defaultPort.calls.locks).toEqual([{ instanceName: null, opts: { forceTakeover: false } }]);
-    expect(defaultPort.calls.servers).toEqual([{ port: 3456, options: { verbosity: 1 } }]);
+    expect(defaultPort.calls.servers).toEqual([{ port: 3456, options: { verbosity: 1, gateway: undefined, forceTakeover: false } }]);
 
     const oldNoScout = process.env.MAW_NO_SCOUT;
     delete process.env.MAW_NO_SCOUT;
     const noScout = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4568", "--no-scout"], noScout.deps)).toBe(true);
-    expect(noScout.calls.servers).toEqual([{ port: 4568, options: { verbosity: 1 } }]);
+    expect(noScout.calls.servers).toEqual([{ port: 4568, options: { verbosity: 1, gateway: undefined, forceTakeover: false } }]);
     expect(process.env.MAW_NO_SCOUT).toBe("1");
     if (oldNoScout === undefined) delete process.env.MAW_NO_SCOUT;
     else process.env.MAW_NO_SCOUT = oldNoScout;
 
     const quiet = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4569", "--quiet"], quiet.deps)).toBe(true);
-    expect(quiet.calls.servers).toEqual([{ port: 4569, options: { verbosity: 0 } }]);
+    expect(quiet.calls.servers).toEqual([{ port: 4569, options: { verbosity: 0, gateway: undefined, forceTakeover: false } }]);
 
     const shortQuiet = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4570", "-q"], shortQuiet.deps)).toBe(true);
-    expect(shortQuiet.calls.servers).toEqual([{ port: 4570, options: { verbosity: 0 } }]);
+    expect(shortQuiet.calls.servers).toEqual([{ port: 4570, options: { verbosity: 0, gateway: undefined, forceTakeover: false } }]);
 
     const verbose = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4571", "--verbose"], verbose.deps)).toBe(true);
-    expect(verbose.calls.servers).toEqual([{ port: 4571, options: { verbosity: 2 } }]);
+    expect(verbose.calls.servers).toEqual([{ port: 4571, options: { verbosity: 2, gateway: undefined, forceTakeover: false } }]);
 
     const shortVerbose = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4572", "-v"], shortVerbose.deps)).toBe(true);
-    expect(shortVerbose.calls.servers).toEqual([{ port: 4572, options: { verbosity: 2 } }]);
+    expect(shortVerbose.calls.servers).toEqual([{ port: 4572, options: { verbosity: 2, gateway: undefined, forceTakeover: false } }]);
 
     const accessVerbose = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4573", "-vv"], accessVerbose.deps)).toBe(true);
-    expect(accessVerbose.calls.servers).toEqual([{ port: 4573, options: { verbosity: 3 } }]);
+    expect(accessVerbose.calls.servers).toEqual([{ port: 4573, options: { verbosity: 3, gateway: undefined, forceTakeover: false } }]);
 
     const frameVerbose = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4574", "-vvv"], frameVerbose.deps)).toBe(true);
-    expect(frameVerbose.calls.servers).toEqual([{ port: 4574, options: { verbosity: 4 } }]);
+    expect(frameVerbose.calls.servers).toEqual([{ port: 4574, options: { verbosity: 4, gateway: undefined, forceTakeover: false } }]);
 
     const repeatedVerbose = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4575", "-v", "-v"], repeatedVerbose.deps)).toBe(true);
-    expect(repeatedVerbose.calls.servers).toEqual([{ port: 4575, options: { verbosity: 3 } }]);
+    expect(repeatedVerbose.calls.servers).toEqual([{ port: 4575, options: { verbosity: 3, gateway: undefined, forceTakeover: false } }]);
 
     const oldServeVerbosity = process.env.MAW_SERVE_VERBOSITY;
     process.env.MAW_SERVE_VERBOSITY = "4";
     const envFrameVerbose = harness();
     expect(await routeToolsWithDeps("serve", ["serve", "4576"], envFrameVerbose.deps)).toBe(true);
-    expect(envFrameVerbose.calls.servers).toEqual([{ port: 4576, options: { verbosity: 4 } }]);
+    expect(envFrameVerbose.calls.servers).toEqual([{ port: 4576, options: { verbosity: 4, gateway: undefined, forceTakeover: false } }]);
     if (oldServeVerbosity === undefined) delete process.env.MAW_SERVE_VERBOSITY;
     else process.env.MAW_SERVE_VERBOSITY = oldServeVerbosity;
 


### PR DESCRIPTION
Closes #2637

## Summary
- clear any listener on the Rust gateway target port before spawning `maw-gateway`
- preserve `--force-takeover` in the serve start options passed through route-tools
- add isolated coverage for the cleanup command running before spawn

## Tests
- `bash scripts/test-isolated.sh test/isolated/gateway-selector.test.ts test/isolated/gateway-rust-port-cleanup.test.ts test/isolated/core-server-more-coverage-2.test.ts test/isolated/coverage-core-shared-server.test.ts`
- `bash scripts/test-isolated.sh test/isolated/gateway-selector.test.ts test/isolated/gateway-rust-port-cleanup.test.ts`
- `bun run build`
- `git diff --check`