### PR TITLE
test(isolated): prevent hanging #2639 tests

### DIFF
--- a/test/isolated/absent-lcov-simple-modules.test.ts
+++ b/test/isolated/absent-lcov-simple-modules.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import type { Hono } from "hono";
 import { mountViews } from "../../src/views/index";
 import { federationView } from "../../src/views/federation";
@@ -20,7 +20,27 @@ mock.module(vendorTeamImplPath, () => ({
   cmdTeamLives: () => {},
 }));
 
-describe("absent-from-LCOV simple modules", () => {
+const startedProcesses: Array<ReturnType<typeof Bun.spawn>> = [];
+const originalBunSpawn = Bun.spawn;
+Bun.spawn = ((...args: Parameters<typeof Bun.spawn>) => {
+  const child = originalBunSpawn(...args);
+  startedProcesses.push(child);
+  return child;
+}) as typeof Bun.spawn;
+
+afterAll(() => {
+  for (const child of startedProcesses) {
+    try {
+      child.kill();
+    } catch {
+      // ignore
+    }
+  }
+  startedProcesses.length = 0;
+  Bun.spawn = originalBunSpawn;
+});
+
+describe("absent-from-LCOV simple modules", { timeout: 30000 }, () => {
   test("mountViews wires the standalone browser views", () => {
     const routes: Array<{ path: string; view: Hono }> = [];
     const app = {

--- a/test/isolated/activity-index-coverage.test.ts
+++ b/test/isolated/activity-index-coverage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test, beforeEach } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const activityCalls: Array<{ target: string | undefined; opts: Record<string, unknown> }> = [];
 
@@ -12,6 +12,26 @@ mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/activity/impl"), (
 
 const { command, default: handler } = await import("../../src/vendor/mpr-plugins/activity/index.ts?activity-index-coverage");
 
+const startedProcesses: Array<ReturnType<typeof Bun.spawn>> = [];
+const originalBunSpawn = Bun.spawn;
+Bun.spawn = ((...args: Parameters<typeof Bun.spawn>) => {
+  const child = originalBunSpawn(...args);
+  startedProcesses.push(child);
+  return child;
+}) as typeof Bun.spawn;
+
+afterAll(() => {
+  for (const child of startedProcesses) {
+    try {
+      child.kill();
+    } catch {
+      // ignore
+    }
+  }
+  startedProcesses.length = 0;
+  Bun.spawn = originalBunSpawn;
+});
+
 function ctx(source: "cli" | "api", args: unknown) {
   return { source, args } as never;
 }
@@ -20,7 +40,7 @@ beforeEach(() => {
   activityCalls.length = 0;
 });
 
-describe("maw activity plugin index", () => {
+describe("maw activity plugin index", { timeout: 30000 }, () => {
   test("exports metadata and routes CLI pane flags", async () => {
     expect(command).toEqual({
       name: "activity",


### PR DESCRIPTION
Closes #2639

Add 30s suite timeouts and teardown cleanup for two isolated tests that could hang indefinitely.

- Added suite-level { timeout: 30000 } to
  - test/isolated/absent-lcov-simple-modules.test.ts
  - test/isolated/activity-index-coverage.test.ts
- Added process-tracking + afterAll cleanup to kill any spawned Bun subprocesses.
- Verified targeted tests execute and exit quickly with scripts/test-isolated.sh and bun test.
- Confirmed scripts/test-isolated.sh currently does not pass --timeout to bun test.