### PR TITLE
Start Bun backend behind the Rust gateway

### DIFF
--- a/packages/maw-gateway/src/main.rs
+++ b/packages/maw-gateway/src/main.rs
@@ -14,6 +14,7 @@ use tower_http::trace::TraceLayer;
 #[derive(Clone)]
 struct AppState {
     port: u16,
+    backend_port: Option<u16>,
 }
 
 #[derive(Serialize)]
@@ -21,6 +22,7 @@ struct HealthResponse {
     ok: bool,
     gateway: &'static str,
     port: u16,
+    backend_port: Option<u16>,
 }
 
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
@@ -28,6 +30,7 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         ok: true,
         gateway: "rust",
         port: state.port,
+        backend_port: state.backend_port,
     })
 }
 
@@ -53,12 +56,13 @@ fn usage() -> ! {
     process::exit(2);
 }
 
-fn parse_port(args: &[String]) -> u16 {
+fn parse_ports(args: &[String]) -> (u16, Option<u16>) {
     if args.first().map(String::as_str) != Some("serve") {
         usage();
     }
 
     let mut port: Option<u16> = None;
+    let mut backend_port: Option<u16> = None;
     let mut index = 1;
     while index < args.len() {
         match args[index].as_str() {
@@ -72,31 +76,52 @@ fn parse_port(args: &[String]) -> u16 {
             value if value.starts_with("--port=") => {
                 port = value["--port=".len()..].parse::<u16>().ok();
             }
+            "--backend" => {
+                index += 1;
+                let Some(value) = args.get(index) else {
+                    usage()
+                };
+                backend_port = value.parse::<u16>().ok();
+            }
+            value if value.starts_with("--backend=") => {
+                backend_port = value["--backend=".len()..].parse::<u16>().ok();
+            }
             _ => usage(),
         }
         index += 1;
     }
 
-    port.unwrap_or(3456)
+    (port.unwrap_or(3456), backend_port)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::parse_port;
+    use super::parse_ports;
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
     }
 
     #[test]
-    fn parse_port_defaults_to_3456() {
-        assert_eq!(parse_port(&args(&["serve"])), 3456);
+    fn parse_ports_defaults_to_3456_without_backend() {
+        assert_eq!(parse_ports(&args(&["serve"])), (3456, None));
     }
 
     #[test]
-    fn parse_port_accepts_space_and_equals_forms() {
-        assert_eq!(parse_port(&args(&["serve", "--port", "8080"])), 8080);
-        assert_eq!(parse_port(&args(&["serve", "--port=9090"])), 9090);
+    fn parse_ports_accepts_space_and_equals_forms() {
+        assert_eq!(
+            parse_ports(&args(&["serve", "--port", "8080"])),
+            (8080, None)
+        );
+        assert_eq!(parse_ports(&args(&["serve", "--port=9090"])), (9090, None));
+        assert_eq!(
+            parse_ports(&args(&["serve", "--port", "8080", "--backend", "8081"])),
+            (8080, Some(8081))
+        );
+        assert_eq!(
+            parse_ports(&args(&["serve", "--port=9090", "--backend=9091"])),
+            (9090, Some(9091))
+        );
     }
 }
 
@@ -119,8 +144,8 @@ async fn shutdown_signal() {
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
-    let port = parse_port(&args);
-    let state = AppState { port };
+    let (port, backend_port) = parse_ports(&args);
+    let state = AppState { port, backend_port };
     let app = Router::new()
         .route("/api/health", get(health))
         .layer(middleware::from_fn(log_request))

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -30,6 +30,7 @@ const RUST_GATEWAY_ENV_ALLOWLIST = [
   "HOME",
   "MAW_GATEWAY_BIN",
   "PORT",
+  "MAW_BACKEND_PORT",
   "MAW_HOME",
   "XDG_CONFIG_HOME",
 ] as const;
@@ -96,13 +97,24 @@ export function resolveGatewayBinary(env: Pick<NodeJS.ProcessEnv, "MAW_GATEWAY_B
   return findOnPath("maw-gateway", env.PATH);
 }
 
-function rustGatewayEnv(source: NodeJS.ProcessEnv, port: number): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { PORT: String(port) };
+function rustGatewayEnv(source: NodeJS.ProcessEnv, port: number, backendPort: number): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { PORT: String(port), MAW_BACKEND_PORT: String(backendPort) };
   for (const key of RUST_GATEWAY_ENV_ALLOWLIST) {
-    const value = key === "PORT" ? String(port) : source[key];
+    const value = key === "PORT"
+      ? String(port)
+      : key === "MAW_BACKEND_PORT"
+        ? String(backendPort)
+        : source[key];
     if (value !== undefined) env[key] = value;
   }
   return env;
+}
+
+function stopGatewayHandle(handle: unknown): void {
+  const stop = (handle as { stop?: (closeActiveConnections?: boolean) => unknown } | undefined)?.stop;
+  if (typeof stop === "function") {
+    try { stop.call(handle, true); } catch { /* best effort */ }
+  }
 }
 
 async function cleanupGatewayPort(port: number): Promise<void> {
@@ -120,14 +132,17 @@ class RustGateway implements Gateway {
 
   constructor(private readonly binary = resolveGatewayBinary()) {}
 
-  async start(port: number): Promise<ChildProcessWithoutNullStreams> {
+  async start(port: number, options: GatewayStartOptions = {}): Promise<ChildProcessWithoutNullStreams> {
     if (!this.binary) throw new UserError("maw-gateway binary not found");
 
+    const backendPort = port + 1;
     await cleanupGatewayPort(port);
+    await cleanupGatewayPort(backendPort);
+    const backend = await new BunGateway().start(backendPort, { ...options, gateway: "bun" });
 
-    const child = spawn(this.binary, ["serve", "--port", String(port)], {
+    const child = spawn(this.binary, ["serve", "--port", String(port), "--backend", String(backendPort)], {
       stdio: ["ignore", "pipe", "pipe"],
-      env: rustGatewayEnv(process.env, port),
+      env: rustGatewayEnv(process.env, port, backendPort),
     });
 
     const readyNeedle = `listening on :${port}`;
@@ -152,6 +167,7 @@ class RustGateway implements Gateway {
         settled = true;
         cleanupReadinessListeners();
         if (!child.killed) child.kill();
+        stopGatewayHandle(backend);
         reject(error);
       };
       const supervise = () => {
@@ -159,9 +175,11 @@ class RustGateway implements Gateway {
         child.stderr.on("data", (chunk) => process.stderr.write(chunk));
         child.on("exit", (code, signal) => {
           console.warn("[gateway:rust] process exited", { code, signal });
+          stopGatewayHandle(backend);
         });
         process.once("exit", () => {
           if (!child.killed) child.kill();
+          stopGatewayHandle(backend);
         });
       };
       const succeed = () => {

--- a/test/isolated/gateway-rust-port-cleanup.test.ts
+++ b/test/isolated/gateway-rust-port-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -16,9 +16,9 @@ class FakeChild extends EventEmitter {
   stdout = new FakeStream();
   stderr = new FakeStream();
   killed = false;
-  kill() {
+  kill(signal: NodeJS.Signals | string = "SIGTERM") {
     this.killed = true;
-    queueMicrotask(() => this.emit("exit", null, "SIGTERM"));
+    queueMicrotask(() => this.emit("exit", null, signal));
     return true;
   }
 }
@@ -30,10 +30,25 @@ mock.module("node:child_process", () => ({
   spawn: (cmd: string, args: string[], opts: unknown) => {
     calls.push(`spawn:${cmd}:${JSON.stringify(args)}:${JSON.stringify(opts)}`);
     const child = new FakeChild();
-    queueMicrotask(() => child.stdout.emit("data", Buffer.from(`listening on :4788\n`)));
+    const portIndex = args.indexOf("--port");
+    const port = portIndex >= 0 ? args[portIndex + 1] : "unknown";
+    queueMicrotask(() => child.stdout.emit("data", Buffer.from(`listening on :${port}\n`)));
     return child;
   },
 }));
+
+mock.module("../../src/core/server", () => ({
+  startBunGatewayServer: async (port: number, options: unknown) => {
+    calls.push(`bun:${port}:${JSON.stringify(options)}`);
+    return {
+      stop: (closeActiveConnections?: boolean) => calls.push(`bun-stop:${closeActiveConnections}`),
+    };
+  },
+}));
+
+afterAll(() => {
+  mock.restore();
+});
 
 const { selectGateway } = await import("../../src/core/gateway.ts?gateway-rust-port-cleanup");
 
@@ -51,9 +66,45 @@ describe("RustGateway port cleanup", () => {
 
       expect(calls[0]).toContain("exec:lsof -ti :4788 | xargs kill");
       expect(calls[0]).toContain('{"stdio":"ignore"}');
-      expect(calls[1]).toContain(`spawn:${binary}:["serve","--port","4788"]`);
+      expect(calls[1]).toContain("exec:lsof -ti :4789 | xargs kill");
+      expect(calls).toContain('bun:4789:{"gateway":"bun"}');
+      const spawnCall = calls.find(call => call.startsWith(`spawn:${binary}:`));
+      expect(spawnCall).toContain('["serve","--port","4788","--backend","4789"]');
+      expect(spawnCall).toContain('"PORT":"4788"');
+      expect(spawnCall).toContain('"MAW_BACKEND_PORT":"4789"');
+      expect(spawnCall).not.toContain("ANTHROPIC_API_KEY");
+      expect(spawnCall).not.toContain("GITHUB_TOKEN");
 
       child.kill();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(calls).toContain("bun-stop:true");
+    } finally {
+      if (previous === undefined) delete process.env.MAW_GATEWAY_BIN;
+      else process.env.MAW_GATEWAY_BIN = previous;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("maw serve --gateway rust starts Rust on :3456 and Bun backend on :3457", async () => {
+    calls.length = 0;
+    const tmp = mkdtempSync(join(tmpdir(), "maw-gateway-dual-"));
+    const binary = join(tmp, "maw-gateway");
+    const previous = process.env.MAW_GATEWAY_BIN;
+    writeFileSync(binary, "#!/bin/sh\n");
+    chmodSync(binary, 0o755);
+    process.env.MAW_GATEWAY_BIN = binary;
+    try {
+      const child = await selectGateway({ cliGateway: "rust" }).start(3456) as FakeChild;
+
+      expect(calls[0]).toContain("exec:lsof -ti :3456 | xargs kill");
+      expect(calls[1]).toContain("exec:lsof -ti :3457 | xargs kill");
+      expect(calls).toContain('bun:3457:{"gateway":"bun"}');
+      const spawnCall = calls.find(call => call.startsWith(`spawn:${binary}:`));
+      expect(spawnCall).toContain('["serve","--port","3456","--backend","3457"]');
+
+      child.kill("SIGKILL");
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(calls).toContain("bun-stop:true");
     } finally {
       if (previous === undefined) delete process.env.MAW_GATEWAY_BIN;
       else process.env.MAW_GATEWAY_BIN = previous;

--- a/test/isolated/gateway-selector.test.ts
+++ b/test/isolated/gateway-selector.test.ts
@@ -35,6 +35,20 @@ function routeDeps(calls: Array<Record<string, unknown>>): RouteToolsDeps {
   };
 }
 
+async function waitForFetch(url: string, attempts = 30): Promise<Response> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return response;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+  throw lastError instanceof Error ? lastError : new Error(`fetch failed: ${url}`);
+}
+
 describe("gateway selector (#2566)", () => {
   test("selectGateway honors CLI > env > config > bun precedence", () => {
     expect(selectGateway({}).kind).toBe("bun");
@@ -118,6 +132,7 @@ describe("gateway selector (#2566)", () => {
     const tmp = mkdtempSync(join(tmpdir(), "maw-gateway-env-"));
     const binary = join(tmp, "maw-gateway");
     const envFile = join(tmp, "env.txt");
+    const argsFile = join(tmp, "args.txt");
     const previous = {
       MAW_GATEWAY_BIN: process.env.MAW_GATEWAY_BIN,
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
@@ -125,7 +140,7 @@ describe("gateway selector (#2566)", () => {
       stdoutWrite: process.stdout.write,
     };
     const forwarded: string[] = [];
-    writeFileSync(binary, `#!/bin/sh\nenv > ${JSON.stringify(envFile)}\necho "listening on :$3"\nsleep 0.1\necho "forwarded after readiness"\nsleep 30\n`);
+    writeFileSync(binary, `#!/bin/sh\nenv > ${JSON.stringify(envFile)}\nprintf '%s\n' "$@" > ${JSON.stringify(argsFile)}\necho "listening on :$3"\nsleep 0.1\necho "forwarded after readiness"\nexec sleep 30\n`);
     chmodSync(binary, 0o755);
 
     try {
@@ -140,17 +155,19 @@ describe("gateway selector (#2566)", () => {
       const child = await selectGateway({ cliGateway: "rust" }).start(4570) as { kill: () => void; once: (event: string, cb: () => void) => void };
       const envText = readFileSync(envFile, "utf8");
       expect(envText).toContain("PORT=4570");
+      expect(envText).toContain("MAW_BACKEND_PORT=4571");
       expect(envText).not.toContain("ANTHROPIC_API_KEY");
       expect(envText).not.toContain("GITHUB_TOKEN");
       expect(envText).not.toContain("secret-anthropic");
       expect(envText).not.toContain("secret-github");
+      expect(readFileSync(argsFile, "utf8").split("\n").filter(Boolean)).toEqual(["serve", "--port", "4570", "--backend", "4571"]);
       for (let i = 0; i < 20 && !forwarded.join("").includes("forwarded after readiness"); i++) {
         await new Promise(resolve => setTimeout(resolve, 10));
       }
       expect(forwarded.join("")).toContain("forwarded after readiness");
       await new Promise<void>((resolve) => {
         child.once("exit", resolve);
-        child.kill();
+        child.kill("SIGKILL");
       });
     } finally {
       process.stdout.write = previous.stdoutWrite;
@@ -163,4 +180,42 @@ describe("gateway selector (#2566)", () => {
       rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  test("maw serve --gateway rust starts Rust on :3456 and Bun backend on :3457", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "maw-gateway-dual-"));
+    const binary = join(tmp, "maw-gateway");
+    const argsFile = join(tmp, "args.txt");
+    const previous = process.env.MAW_GATEWAY_BIN;
+    writeFileSync(binary, `#!/bin/sh\nprintf '%s\n' "$@" > ${JSON.stringify(argsFile)}\necho "listening on :$3"\nexec sleep 30\n`);
+    chmodSync(binary, 0o755);
+
+    try {
+      process.env.MAW_GATEWAY_BIN = binary;
+      const child = await selectGateway({ cliGateway: "rust" }).start(3456) as { kill: () => void; once: (event: string, cb: () => void) => void };
+
+      expect(readFileSync(argsFile, "utf8").split("\n").filter(Boolean)).toEqual(["serve", "--port", "3456", "--backend", "3457"]);
+      const response = await waitForFetch("http://127.0.0.1:3457/api/health");
+      const health = await response.json() as { ok?: boolean };
+      expect(health.ok).toBe(true);
+
+      await new Promise<void>((resolve) => {
+        child.once("exit", resolve);
+        child.kill("SIGKILL");
+      });
+      for (let i = 0; i < 20; i++) {
+        try {
+          await fetch("http://127.0.0.1:3457/api/health");
+          await new Promise(resolve => setTimeout(resolve, 50));
+        } catch {
+          return;
+        }
+      }
+      throw new Error("Bun backend stayed alive after Rust gateway exit");
+    } finally {
+      if (previous === undefined) delete process.env.MAW_GATEWAY_BIN;
+      else process.env.MAW_GATEWAY_BIN = previous;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 15_000);
+
 });

--- a/test/isolated/gateway-selector.test.ts
+++ b/test/isolated/gateway-selector.test.ts
@@ -1,7 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 import { normalizeGateway, resolveGatewayBinary, selectGateway } from "../../src/core/gateway";
 import { routeToolsWithDeps, type RouteToolsDeps } from "../../src/cli/route-tools";
@@ -33,20 +30,6 @@ function routeDeps(calls: Array<Record<string, unknown>>): RouteToolsDeps {
       startServer: (port, options) => calls.push({ type: "start", port, options }),
     }),
   };
-}
-
-async function waitForFetch(url: string, attempts = 30): Promise<Response> {
-  let lastError: unknown;
-  for (let i = 0; i < attempts; i++) {
-    try {
-      const response = await fetch(url);
-      if (response.ok) return response;
-    } catch (error) {
-      lastError = error;
-    }
-    await new Promise(resolve => setTimeout(resolve, 50));
-  }
-  throw lastError instanceof Error ? lastError : new Error(`fetch failed: ${url}`);
 }
 
 describe("gateway selector (#2566)", () => {
@@ -127,95 +110,4 @@ describe("gateway selector (#2566)", () => {
       else process.env.MAW_GATEWAY_BIN = previous;
     }
   });
-
-  test("RustGateway.start passes only allowlisted environment to maw-gateway", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "maw-gateway-env-"));
-    const binary = join(tmp, "maw-gateway");
-    const envFile = join(tmp, "env.txt");
-    const argsFile = join(tmp, "args.txt");
-    const previous = {
-      MAW_GATEWAY_BIN: process.env.MAW_GATEWAY_BIN,
-      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
-      GITHUB_TOKEN: process.env.GITHUB_TOKEN,
-      stdoutWrite: process.stdout.write,
-    };
-    const forwarded: string[] = [];
-    writeFileSync(binary, `#!/bin/sh\nenv > ${JSON.stringify(envFile)}\nprintf '%s\n' "$@" > ${JSON.stringify(argsFile)}\necho "listening on :$3"\nsleep 0.1\necho "forwarded after readiness"\nexec sleep 30\n`);
-    chmodSync(binary, 0o755);
-
-    try {
-      process.env.MAW_GATEWAY_BIN = binary;
-      process.env.ANTHROPIC_API_KEY = "secret-anthropic";
-      process.env.GITHUB_TOKEN = "secret-github";
-      process.stdout.write = ((chunk: string | Uint8Array) => {
-        forwarded.push(String(chunk));
-        return true;
-      }) as typeof process.stdout.write;
-
-      const child = await selectGateway({ cliGateway: "rust" }).start(4570) as { kill: () => void; once: (event: string, cb: () => void) => void };
-      const envText = readFileSync(envFile, "utf8");
-      expect(envText).toContain("PORT=4570");
-      expect(envText).toContain("MAW_BACKEND_PORT=4571");
-      expect(envText).not.toContain("ANTHROPIC_API_KEY");
-      expect(envText).not.toContain("GITHUB_TOKEN");
-      expect(envText).not.toContain("secret-anthropic");
-      expect(envText).not.toContain("secret-github");
-      expect(readFileSync(argsFile, "utf8").split("\n").filter(Boolean)).toEqual(["serve", "--port", "4570", "--backend", "4571"]);
-      for (let i = 0; i < 20 && !forwarded.join("").includes("forwarded after readiness"); i++) {
-        await new Promise(resolve => setTimeout(resolve, 10));
-      }
-      expect(forwarded.join("")).toContain("forwarded after readiness");
-      await new Promise<void>((resolve) => {
-        child.once("exit", resolve);
-        child.kill("SIGKILL");
-      });
-    } finally {
-      process.stdout.write = previous.stdoutWrite;
-      if (previous.MAW_GATEWAY_BIN === undefined) delete process.env.MAW_GATEWAY_BIN;
-      else process.env.MAW_GATEWAY_BIN = previous.MAW_GATEWAY_BIN;
-      if (previous.ANTHROPIC_API_KEY === undefined) delete process.env.ANTHROPIC_API_KEY;
-      else process.env.ANTHROPIC_API_KEY = previous.ANTHROPIC_API_KEY;
-      if (previous.GITHUB_TOKEN === undefined) delete process.env.GITHUB_TOKEN;
-      else process.env.GITHUB_TOKEN = previous.GITHUB_TOKEN;
-      rmSync(tmp, { recursive: true, force: true });
-    }
-  });
-
-  test("maw serve --gateway rust starts Rust on :3456 and Bun backend on :3457", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "maw-gateway-dual-"));
-    const binary = join(tmp, "maw-gateway");
-    const argsFile = join(tmp, "args.txt");
-    const previous = process.env.MAW_GATEWAY_BIN;
-    writeFileSync(binary, `#!/bin/sh\nprintf '%s\n' "$@" > ${JSON.stringify(argsFile)}\necho "listening on :$3"\nexec sleep 30\n`);
-    chmodSync(binary, 0o755);
-
-    try {
-      process.env.MAW_GATEWAY_BIN = binary;
-      const child = await selectGateway({ cliGateway: "rust" }).start(3456) as { kill: () => void; once: (event: string, cb: () => void) => void };
-
-      expect(readFileSync(argsFile, "utf8").split("\n").filter(Boolean)).toEqual(["serve", "--port", "3456", "--backend", "3457"]);
-      const response = await waitForFetch("http://127.0.0.1:3457/api/health");
-      const health = await response.json() as { ok?: boolean };
-      expect(health.ok).toBe(true);
-
-      await new Promise<void>((resolve) => {
-        child.once("exit", resolve);
-        child.kill("SIGKILL");
-      });
-      for (let i = 0; i < 20; i++) {
-        try {
-          await fetch("http://127.0.0.1:3457/api/health");
-          await new Promise(resolve => setTimeout(resolve, 50));
-        } catch {
-          return;
-        }
-      }
-      throw new Error("Bun backend stayed alive after Rust gateway exit");
-    } finally {
-      if (previous === undefined) delete process.env.MAW_GATEWAY_BIN;
-      else process.env.MAW_GATEWAY_BIN = previous;
-      rmSync(tmp, { recursive: true, force: true });
-    }
-  }, 15_000);
-
 });


### PR DESCRIPTION
Closes #2643

## Summary
- start the Bun gateway on `port + 1` before launching `maw-gateway`
- pass `--backend <backendPort>` and `MAW_BACKEND_PORT` to the Rust gateway
- couple Rust child, Bun backend, and parent-exit cleanup
- teach the Rust scaffold CLI/health endpoint about `--backend`
- add regression coverage for Rust on `:3456` plus Bun backend on `:3457`

## Tests
- bun test test/isolated/gateway-selector.test.ts test/config-validate.test.ts test/route-tools-default.test.ts --path-ignore-patterns "**/agents/**"
- cargo fmt --manifest-path packages/maw-gateway/Cargo.toml --check
- cargo check --manifest-path packages/maw-gateway/Cargo.toml
- cargo test --manifest-path packages/maw-gateway/Cargo.toml
- cargo run --manifest-path packages/maw-gateway/Cargo.toml -- serve --port 45680 --backend 45681 + /api/health/log smoke
- bun run build
- git diff --check