### PR TITLE
feat(gateway): add reverse proxy to Rust gateway

### DIFF
--- a/packages/maw-gateway/Cargo.lock
+++ b/packages/maw-gateway/Cargo.lock
@@ -15,6 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -33,8 +34,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -61,16 +64,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -81,6 +146,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -107,6 +178,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,10 +207,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
 ]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "http"
@@ -179,6 +316,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -187,6 +325,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -196,12 +335,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -233,8 +387,15 @@ name = "maw-gateway"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "bytes",
+ "futures-util",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "serde",
+ "serde_json",
  "tokio",
+ "tokio-tungstenite",
  "tower-http",
 ]
 
@@ -280,6 +441,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +465,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -370,6 +575,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,11 +635,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -442,6 +679,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -509,16 +771,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "windows-link"
@@ -533,6 +847,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/packages/maw-gateway/Cargo.toml
+++ b/packages/maw-gateway/Cargo.toml
@@ -4,7 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
+bytes = "1"
+hyper = "1"
+hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
+http-body-util = "0.1"
+futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
+tokio-tungstenite = "0.29"
 tower-http = { version = "0.6", features = ["trace"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/packages/maw-gateway/src/main.rs
+++ b/packages/maw-gateway/src/main.rs
@@ -1,36 +1,61 @@
+use std::{env, net::SocketAddr, process, sync::Arc, time::Instant};
+
 use axum::{
     body::Body,
-    extract::State,
-    http::Request,
+    extract::{
+        ws::{CloseCode, CloseFrame, Message as AxumMessage, WebSocketUpgrade},
+        Path, State,
+    },
+    http::{Request, StatusCode, Uri},
     middleware::{self, Next},
-    response::Response,
+    response::{IntoResponse, Response},
     routing::get,
     Json, Router,
 };
+use bytes::Bytes;
+use futures_util::{SinkExt, StreamExt};
+use http_body_util::{BodyExt, Full};
+use hyper::{body::Bytes as HyperBytes, Request as HyperRequest, Uri as HyperUri};
+use hyper_util::client::legacy::{connect::HttpConnector, Client};
+use hyper_util::rt::TokioExecutor;
 use serde::Serialize;
-use std::{env, net::SocketAddr, process, time::Instant};
+use tokio::sync::broadcast;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{
+        http::Request as WsRequest,
+        protocol::{
+            frame::coding::CloseCode as TungsteniteCloseCode, CloseFrame as TungsteniteCloseFrame,
+            Message as WsMessage,
+        },
+    },
+};
 use tower_http::trace::TraceLayer;
+
+type BackendClient = Client<HttpConnector, Full<HyperBytes>>;
 
 #[derive(Clone)]
 struct AppState {
     port: u16,
-    backend_port: Option<u16>,
+    backend_port: u16,
+    client: Arc<BackendClient>,
+    shutdown: broadcast::Sender<()>,
 }
 
 #[derive(Serialize)]
 struct HealthResponse {
     ok: bool,
     gateway: &'static str,
+    backend: String,
     port: u16,
-    backend_port: Option<u16>,
 }
 
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     Json(HealthResponse {
         ok: true,
         gateway: "rust",
+        backend: format!("bun:{}", state.backend_port),
         port: state.port,
-        backend_port: state.backend_port,
     })
 }
 
@@ -52,11 +77,11 @@ async fn log_request(request: Request<Body>, next: Next) -> Response {
 }
 
 fn usage() -> ! {
-    eprintln!("usage: maw-gateway serve [--port PORT]");
+    eprintln!("usage: maw-gateway serve [--port PORT] [--backend PORT]");
     process::exit(2);
 }
 
-fn parse_ports(args: &[String]) -> (u16, Option<u16>) {
+fn parse_ports(args: &[String]) -> (u16, u16) {
     if args.first().map(String::as_str) != Some("serve") {
         usage();
     }
@@ -64,12 +89,13 @@ fn parse_ports(args: &[String]) -> (u16, Option<u16>) {
     let mut port: Option<u16> = None;
     let mut backend_port: Option<u16> = None;
     let mut index = 1;
+
     while index < args.len() {
         match args[index].as_str() {
             "--port" => {
                 index += 1;
                 let Some(value) = args.get(index) else {
-                    usage()
+                    usage();
                 };
                 port = value.parse::<u16>().ok();
             }
@@ -79,7 +105,7 @@ fn parse_ports(args: &[String]) -> (u16, Option<u16>) {
             "--backend" => {
                 index += 1;
                 let Some(value) = args.get(index) else {
-                    usage()
+                    usage();
                 };
                 backend_port = value.parse::<u16>().ok();
             }
@@ -91,7 +117,242 @@ fn parse_ports(args: &[String]) -> (u16, Option<u16>) {
         index += 1;
     }
 
-    (port.unwrap_or(3456), backend_port)
+    (port.unwrap_or(3456), backend_port.unwrap_or(3457))
+}
+
+fn build_backend_http_uri(state: &AppState, uri: &Uri) -> HyperUri {
+    let path_and_query = uri
+        .path_and_query()
+        .map(|path| path.as_str())
+        .unwrap_or("/");
+    let target = format!("http://127.0.0.1:{}{}", state.backend_port, path_and_query);
+    target.parse::<HyperUri>().expect("backend URI")
+}
+
+fn build_backend_ws_uri(state: &AppState, uri: &Uri) -> String {
+    let path_and_query = uri
+        .path_and_query()
+        .map(|path| path.as_str())
+        .unwrap_or("/");
+    format!("ws://127.0.0.1:{}{}", state.backend_port, path_and_query)
+}
+
+fn axum_to_tungstenite(message: AxumMessage) -> Option<WsMessage> {
+    match message {
+        AxumMessage::Text(text) => Some(WsMessage::Text(text.to_string().into())),
+        AxumMessage::Binary(binary) => Some(WsMessage::Binary(binary)),
+        AxumMessage::Ping(payload) => Some(WsMessage::Ping(payload)),
+        AxumMessage::Pong(payload) => Some(WsMessage::Pong(payload)),
+        AxumMessage::Close(frame) => Some(match frame {
+            Some(frame) => WsMessage::Close(Some(TungsteniteCloseFrame {
+                code: TungsteniteCloseCode::from(frame.code),
+                reason: frame.reason.to_string().into(),
+            })),
+            None => WsMessage::Close(None),
+        }),
+    }
+}
+
+fn tungstenite_to_axum(message: WsMessage) -> Option<AxumMessage> {
+    match message {
+        WsMessage::Text(text) => Some(AxumMessage::Text(text.to_string().into())),
+        WsMessage::Binary(payload) => Some(AxumMessage::Binary(payload)),
+        WsMessage::Ping(payload) => Some(AxumMessage::Ping(payload)),
+        WsMessage::Pong(payload) => Some(AxumMessage::Pong(payload)),
+        WsMessage::Close(frame) => Some(AxumMessage::Close(Some(CloseFrame {
+            code: match frame.as_ref() {
+                Some(frame) => frame.code.into(),
+                None => 1000,
+            },
+            reason: frame
+                .map(|frame| frame.reason.to_string())
+                .unwrap_or_default()
+                .into(),
+        }))),
+        WsMessage::Frame(_) => None,
+    }
+}
+
+async fn build_http_request(
+    request: Request<Body>,
+    target: HyperUri,
+) -> Result<HyperRequest<Full<Bytes>>, StatusCode> {
+    let (parts, body) = request.into_parts();
+    let payload = body
+        .collect()
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?
+        .to_bytes();
+
+    let mut builder = HyperRequest::builder()
+        .method(parts.method)
+        .uri(target)
+        .version(parts.version);
+
+    for (name, value) in &parts.headers {
+        builder = builder.header(name, value);
+    }
+
+    builder
+        .body(Full::new(payload))
+        .map_err(|_| StatusCode::BAD_REQUEST)
+}
+
+async fn proxy_http(State(state): State<AppState>, req: Request<Body>) -> Response {
+    let target = build_backend_http_uri(&state, req.uri());
+
+    let request = match build_http_request(req, target).await {
+        Ok(request) => request,
+        Err(status) => return status.into_response(),
+    };
+
+    let mut upstream = match state.client.request(request).await {
+        Ok(response) => response,
+        Err(error) => {
+            eprintln!("backend request failed: {error}");
+            return StatusCode::BAD_GATEWAY.into_response();
+        }
+    };
+
+    let status = upstream.status();
+    let headers = std::mem::take(upstream.headers_mut());
+    let body = match upstream
+        .into_body()
+        .collect()
+        .await
+        .map(|collected| collected.to_bytes())
+    {
+        Ok(body) => body,
+        Err(error) => {
+            eprintln!("backend body read failed: {error}");
+            return StatusCode::BAD_GATEWAY.into_response();
+        }
+    };
+
+    let mut response = Response::new(Body::from(body));
+    *response.status_mut() = status;
+    *response.headers_mut() = headers;
+    response
+}
+
+async fn proxy_ws_inner(state: AppState, request: Request<Body>, ws: WebSocketUpgrade) -> Response {
+    let target = build_backend_ws_uri(&state, request.uri());
+    let mut ws_request = match WsRequest::builder().uri(target).body(()) {
+        Ok(request) => request,
+        Err(error) => {
+            eprintln!("failed to build websocket request: {error}");
+            return StatusCode::BAD_REQUEST.into_response();
+        }
+    };
+
+    for (name, value) in request.headers() {
+        ws_request.headers_mut().insert(name, value.clone());
+    }
+
+    let backend_socket = match connect_async(ws_request).await {
+        Ok((backend_socket, _)) => backend_socket,
+        Err(error) => {
+            eprintln!("failed to connect websocket backend: {error}");
+            return StatusCode::BAD_GATEWAY.into_response();
+        }
+    };
+
+    let mut shutdown_to_client = state.shutdown.subscribe();
+    let mut shutdown_to_backend = state.shutdown.subscribe();
+
+    ws.on_upgrade(move |client_socket| async move {
+        let (mut client_tx, mut client_rx) = client_socket.split();
+        let (mut backend_tx, mut backend_rx) = backend_socket.split();
+
+        let to_backend = async {
+            loop {
+                tokio::select! {
+                    message = client_rx.next() => {
+                        match message {
+                            Some(Ok(message)) => {
+                                if let Some(forwarded) = axum_to_tungstenite(message) {
+                                    if backend_tx.send(forwarded).await.is_err() {
+                                        break;
+                                    }
+                                }
+                            }
+                            Some(Err(error)) => {
+                                eprintln!("websocket from client errored: {error}");
+                                break;
+                            }
+                            None => break,
+                        }
+                    }
+                    _ = shutdown_to_client.recv() => {
+                        let _ = backend_tx.send(WsMessage::Close(Some(TungsteniteCloseFrame {
+                            code: TungsteniteCloseCode::from(1001u16),
+                            reason: "gateway shutdown".into(),
+                        }))).await;
+                        break;
+                    }
+                }
+            }
+        };
+
+        let to_client = async {
+            loop {
+                tokio::select! {
+                    message = backend_rx.next() => {
+                        match message {
+                            Some(Ok(message)) => {
+                                if let Some(forwarded) = tungstenite_to_axum(message) {
+                                    if client_tx.send(forwarded).await.is_err() {
+                                        break;
+                                    }
+                                }
+                            }
+                            None | Some(Err(_)) => break,
+                        }
+                    }
+                    _ = shutdown_to_backend.recv() => {
+                        let _ = client_tx.send(AxumMessage::Close(Some(CloseFrame {
+                            code: CloseCode::from(1001u16),
+                            reason: "gateway shutdown".into(),
+                        }))).await;
+                        break;
+                    }
+                }
+            }
+        };
+
+        tokio::join!(to_backend, to_client);
+
+        let _ = client_tx
+            .send(AxumMessage::Close(Some(CloseFrame {
+                code: CloseCode::from(1000u16),
+                reason: "bye".into(),
+            })))
+            .await;
+        let _ = backend_tx
+            .send(WsMessage::Close(Some(TungsteniteCloseFrame {
+                code: TungsteniteCloseCode::from(1000u16),
+                reason: "bye".into(),
+            })))
+            .await;
+    })
+    .into_response()
+}
+
+async fn proxy_ws(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    request: Request<Body>,
+) -> Response {
+    proxy_ws_inner(state, request, ws).await
+}
+
+async fn proxy_ws_path(
+    Path(_): Path<String>,
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+    request: Request<Body>,
+) -> Response {
+    proxy_ws_inner(state, request, ws).await
 }
 
 #[cfg(test)]
@@ -103,69 +364,102 @@ mod tests {
     }
 
     #[test]
-    fn parse_ports_defaults_to_3456_without_backend() {
-        assert_eq!(parse_ports(&args(&["serve"])), (3456, None));
+    fn parse_ports_defaults_to_gateway_and_backend() {
+        assert_eq!(parse_ports(&args(&["serve"])), (3456, 3457));
     }
 
     #[test]
     fn parse_ports_accepts_space_and_equals_forms() {
         assert_eq!(
             parse_ports(&args(&["serve", "--port", "8080"])),
-            (8080, None)
+            (8080, 3457)
         );
-        assert_eq!(parse_ports(&args(&["serve", "--port=9090"])), (9090, None));
+        assert_eq!(parse_ports(&args(&["serve", "--port=9090"])), (9090, 3457));
         assert_eq!(
             parse_ports(&args(&["serve", "--port", "8080", "--backend", "8081"])),
-            (8080, Some(8081))
+            (8080, 8081)
         );
         assert_eq!(
             parse_ports(&args(&["serve", "--port=9090", "--backend=9091"])),
-            (9090, Some(9091))
+            (9090, 9091)
+        );
+        assert_eq!(
+            parse_ports(&args(&["serve", "--backend", "4000"])),
+            (3456, 4000)
+        );
+        assert_eq!(
+            parse_ports(&args(&["serve", "--backend=5000"])),
+            (3456, 5000)
         );
     }
 }
 
 #[cfg(unix)]
-async fn shutdown_signal() {
+async fn install_shutdown_signal(sender: broadcast::Sender<()>) {
     use tokio::signal::unix::{signal, SignalKind};
 
     let mut terminate = signal(SignalKind::terminate()).expect("install SIGTERM handler");
     tokio::select! {
-        _ = tokio::signal::ctrl_c() => {},
-        _ = terminate.recv() => {},
+        _ = tokio::signal::ctrl_c() => {
+            let _ = sender.send(());
+        }
+        _ = terminate.recv() => {
+            let _ = sender.send(());
+        }
     }
 }
 
 #[cfg(not(unix))]
-async fn shutdown_signal() {
+async fn install_shutdown_signal(sender: broadcast::Sender<()>) {
     let _ = tokio::signal::ctrl_c().await;
+    let _ = sender.send(());
 }
 
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
     let (port, backend_port) = parse_ports(&args);
-    let state = AppState { port, backend_port };
+
+    let client = Client::builder(TokioExecutor::new()).build(HttpConnector::new());
+    let (shutdown_sender, _) = broadcast::channel(16);
+    let state = AppState {
+        port,
+        backend_port,
+        client: Arc::new(client),
+        shutdown: shutdown_sender,
+    };
+
     let app = Router::new()
         .route("/api/health", get(health))
+        .route("/ws", get(proxy_ws))
+        .route("/ws/{*path}", get(proxy_ws_path))
+        .fallback(proxy_http)
         .layer(middleware::from_fn(log_request))
         .layer(TraceLayer::new_for_http())
-        .with_state(state);
+        .with_state(state.clone());
+
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(listener) => listener,
         Err(error) => {
-            eprintln!("failed to bind :{}: {}", port, error);
+            eprintln!("failed to bind :{port}: {error}");
             process::exit(1);
         }
     };
 
-    println!("listening on :{}", port);
-    if let Err(error) = axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
+    println!("listening on :{port}");
+
+    let mut shutdown = state.shutdown.subscribe();
+    tokio::spawn(install_shutdown_signal(state.shutdown.clone()));
+
+    let server = axum::serve(listener, app);
+    if let Err(error) = server
+        .with_graceful_shutdown(async move {
+            let _ = shutdown.recv().await;
+        })
         .await
     {
-        eprintln!("server error: {}", error);
+        eprintln!("server error: {error}");
         process::exit(1);
     }
 }

--- a/packages/maw-gateway/src/main.rs
+++ b/packages/maw-gateway/src/main.rs
@@ -37,9 +37,17 @@ type BackendClient = Client<HttpConnector, Full<HyperBytes>>;
 #[derive(Clone)]
 struct AppState {
     port: u16,
-    backend_port: u16,
+    backend_port: Option<u16>,
+    verbosity: u8,
     client: Arc<BackendClient>,
     shutdown: broadcast::Sender<()>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct GatewayArgs {
+    port: u16,
+    backend_port: Option<u16>,
+    verbosity: u8,
 }
 
 #[derive(Serialize)]
@@ -50,11 +58,50 @@ struct HealthResponse {
     port: u16,
 }
 
+#[derive(Serialize)]
+struct StatusResponse {
+    ok: bool,
+    gateway: &'static str,
+    backend: Option<String>,
+    backend_status: &'static str,
+    port: u16,
+    status: &'static str,
+}
+
+fn clamp_verbosity(value: u8) -> u8 {
+    value.clamp(0, 4)
+}
+
+fn backend_label(state: &AppState) -> Option<String> {
+    state.backend_port.map(|port| format!("bun:{port}"))
+}
+
+fn backend_label_or_standalone(state: &AppState) -> String {
+    backend_label(state).unwrap_or_else(|| "standalone".to_string())
+}
+
+fn status_payload(state: &AppState, backend_reachable: bool) -> StatusResponse {
+    let (ok, backend_status, status) = match state.backend_port {
+        Some(_) if backend_reachable => (true, "connected", "ok"),
+        Some(_) => (false, "unavailable", "degraded"),
+        None => (true, "unconfigured", "standalone"),
+    };
+
+    StatusResponse {
+        ok,
+        gateway: "rust",
+        backend: backend_label(state),
+        backend_status,
+        port: state.port,
+        status,
+    }
+}
+
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     Json(HealthResponse {
         ok: true,
         gateway: "rust",
-        backend: format!("bun:{}", state.backend_port),
+        backend: backend_label_or_standalone(&state),
         port: state.port,
     })
 }
@@ -77,17 +124,20 @@ async fn log_request(request: Request<Body>, next: Next) -> Response {
 }
 
 fn usage() -> ! {
-    eprintln!("usage: maw-gateway serve [--port PORT] [--backend PORT]");
+    eprintln!(
+        "usage: maw-gateway serve [--port PORT] [--backend PORT] [--verbose N|-v|-vv|-vvv|-vvvv]"
+    );
     process::exit(2);
 }
 
-fn parse_ports(args: &[String]) -> (u16, u16) {
+fn parse_args(args: &[String]) -> GatewayArgs {
     if args.first().map(String::as_str) != Some("serve") {
         usage();
     }
 
     let mut port: Option<u16> = None;
     let mut backend_port: Option<u16> = None;
+    let mut verbosity = 1u8;
     let mut index = 1;
 
     while index < args.len() {
@@ -112,29 +162,59 @@ fn parse_ports(args: &[String]) -> (u16, u16) {
             value if value.starts_with("--backend=") => {
                 backend_port = value["--backend=".len()..].parse::<u16>().ok();
             }
+            "--verbose" => {
+                let next = args.get(index + 1).map(String::as_str);
+                match next {
+                    Some(value) if !value.starts_with('-') => {
+                        verbosity = value
+                            .parse::<u8>()
+                            .map(clamp_verbosity)
+                            .unwrap_or_else(|_| usage());
+                        index += 1;
+                    }
+                    _ => {
+                        verbosity = verbosity.max(2);
+                    }
+                }
+            }
+            value if value.starts_with("--verbose=") => {
+                verbosity = value["--verbose=".len()..]
+                    .parse::<u8>()
+                    .map(clamp_verbosity)
+                    .unwrap_or_else(|_| usage());
+            }
+            value if value.starts_with("-v") && value.chars().all(|ch| ch == '-' || ch == 'v') => {
+                verbosity = clamp_verbosity(verbosity.saturating_add((value.len() - 1) as u8));
+            }
             _ => usage(),
         }
         index += 1;
     }
 
-    (port.unwrap_or(3456), backend_port.unwrap_or(3457))
+    GatewayArgs {
+        port: port.unwrap_or(3456),
+        backend_port,
+        verbosity,
+    }
 }
 
-fn build_backend_http_uri(state: &AppState, uri: &Uri) -> HyperUri {
+fn build_backend_http_uri(state: &AppState, uri: &Uri) -> Option<HyperUri> {
+    let backend_port = state.backend_port?;
     let path_and_query = uri
         .path_and_query()
         .map(|path| path.as_str())
         .unwrap_or("/");
-    let target = format!("http://127.0.0.1:{}{}", state.backend_port, path_and_query);
-    target.parse::<HyperUri>().expect("backend URI")
+    let target = format!("http://127.0.0.1:{backend_port}{path_and_query}");
+    Some(target.parse::<HyperUri>().expect("backend URI"))
 }
 
-fn build_backend_ws_uri(state: &AppState, uri: &Uri) -> String {
+fn build_backend_ws_uri(state: &AppState, uri: &Uri) -> Option<String> {
+    let backend_port = state.backend_port?;
     let path_and_query = uri
         .path_and_query()
         .map(|path| path.as_str())
         .unwrap_or("/");
-    format!("ws://127.0.0.1:{}{}", state.backend_port, path_and_query)
+    Some(format!("ws://127.0.0.1:{backend_port}{path_and_query}"))
 }
 
 fn axum_to_tungstenite(message: AxumMessage) -> Option<WsMessage> {
@@ -199,7 +279,14 @@ async fn build_http_request(
 }
 
 async fn proxy_http(State(state): State<AppState>, req: Request<Body>) -> Response {
-    let target = build_backend_http_uri(&state, req.uri());
+    let is_root = req.uri().path() == "/";
+    let Some(target) = build_backend_http_uri(&state, req.uri()) else {
+        return if is_root {
+            Json(status_payload(&state, false)).into_response()
+        } else {
+            StatusCode::SERVICE_UNAVAILABLE.into_response()
+        };
+    };
 
     let request = match build_http_request(req, target).await {
         Ok(request) => request,
@@ -210,7 +297,11 @@ async fn proxy_http(State(state): State<AppState>, req: Request<Body>) -> Respon
         Ok(response) => response,
         Err(error) => {
             eprintln!("backend request failed: {error}");
-            return StatusCode::BAD_GATEWAY.into_response();
+            return if is_root {
+                Json(status_payload(&state, false)).into_response()
+            } else {
+                StatusCode::BAD_GATEWAY.into_response()
+            };
         }
     };
 
@@ -225,7 +316,11 @@ async fn proxy_http(State(state): State<AppState>, req: Request<Body>) -> Respon
         Ok(body) => body,
         Err(error) => {
             eprintln!("backend body read failed: {error}");
-            return StatusCode::BAD_GATEWAY.into_response();
+            return if is_root {
+                Json(status_payload(&state, false)).into_response()
+            } else {
+                StatusCode::BAD_GATEWAY.into_response()
+            };
         }
     };
 
@@ -236,7 +331,9 @@ async fn proxy_http(State(state): State<AppState>, req: Request<Body>) -> Respon
 }
 
 async fn proxy_ws_inner(state: AppState, request: Request<Body>, ws: WebSocketUpgrade) -> Response {
-    let target = build_backend_ws_uri(&state, request.uri());
+    let Some(target) = build_backend_ws_uri(&state, request.uri()) else {
+        return StatusCode::SERVICE_UNAVAILABLE.into_response();
+    };
     let mut ws_request = match WsRequest::builder().uri(target).body(()) {
         Ok(request) => request,
         Err(error) => {
@@ -355,42 +452,196 @@ async fn proxy_ws_path(
     proxy_ws_inner(state, request, ws).await
 }
 
+fn app(state: AppState) -> Router {
+    Router::new()
+        .route("/api/health", get(health))
+        .route("/ws", get(proxy_ws))
+        .route("/ws/{*path}", get(proxy_ws_path))
+        .fallback(proxy_http)
+        .layer(middleware::from_fn(log_request))
+        .layer(TraceLayer::new_for_http())
+        .with_state(state)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::parse_ports;
+    use super::{app, parse_args, AppState, GatewayArgs};
+    use axum::{routing::get, Router};
+    use http_body_util::{BodyExt, Full};
+    use hyper::{body::Bytes as HyperBytes, Request as HyperRequest, StatusCode, Uri as HyperUri};
+    use hyper_util::client::legacy::{connect::HttpConnector, Client};
+    use hyper_util::rt::TokioExecutor;
+    use tokio::{net::TcpListener, sync::broadcast, task::JoinHandle};
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
     }
 
-    #[test]
-    fn parse_ports_defaults_to_gateway_and_backend() {
-        assert_eq!(parse_ports(&args(&["serve"])), (3456, 3457));
+    fn test_client() -> Client<HttpConnector, Full<HyperBytes>> {
+        Client::builder(TokioExecutor::new()).build(HttpConnector::new())
+    }
+
+    async fn get_root(port: u16) -> (StatusCode, String) {
+        let client = test_client();
+        let uri = format!("http://127.0.0.1:{port}/")
+            .parse::<HyperUri>()
+            .expect("root uri");
+        let request = HyperRequest::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Full::new(HyperBytes::new()))
+            .expect("root request");
+        let response = client.request(request).await.expect("root response");
+        let status = response.status();
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("root body")
+            .to_bytes();
+        (status, String::from_utf8(body.to_vec()).expect("utf8 body"))
+    }
+
+    async fn spawn_gateway(
+        backend_port: Option<u16>,
+    ) -> (u16, broadcast::Sender<()>, JoinHandle<()>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind gateway");
+        let port = listener.local_addr().expect("gateway addr").port();
+        let (shutdown, _) = broadcast::channel(16);
+        let state = AppState {
+            port,
+            backend_port,
+            verbosity: 1,
+            client: std::sync::Arc::new(test_client()),
+            shutdown: shutdown.clone(),
+        };
+
+        let mut shutdown_rx = shutdown.subscribe();
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app(state))
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.recv().await;
+                })
+                .await;
+        });
+
+        (port, shutdown, handle)
     }
 
     #[test]
-    fn parse_ports_accepts_space_and_equals_forms() {
+    fn parse_args_defaults_to_standalone_gateway() {
         assert_eq!(
-            parse_ports(&args(&["serve", "--port", "8080"])),
-            (8080, 3457)
+            parse_args(&args(&["serve"])),
+            GatewayArgs {
+                port: 3456,
+                backend_port: None,
+                verbosity: 1,
+            }
         );
-        assert_eq!(parse_ports(&args(&["serve", "--port=9090"])), (9090, 3457));
+    }
+
+    #[test]
+    fn parse_args_accepts_space_and_equals_forms() {
         assert_eq!(
-            parse_ports(&args(&["serve", "--port", "8080", "--backend", "8081"])),
-            (8080, 8081)
+            parse_args(&args(&["serve", "--port", "8080"])),
+            GatewayArgs {
+                port: 8080,
+                backend_port: None,
+                verbosity: 1,
+            }
         );
         assert_eq!(
-            parse_ports(&args(&["serve", "--port=9090", "--backend=9091"])),
-            (9090, 9091)
+            parse_args(&args(&["serve", "--port=9090"])),
+            GatewayArgs {
+                port: 9090,
+                backend_port: None,
+                verbosity: 1,
+            }
         );
         assert_eq!(
-            parse_ports(&args(&["serve", "--backend", "4000"])),
-            (3456, 4000)
+            parse_args(&args(&["serve", "--port", "8080", "--backend", "8081"])),
+            GatewayArgs {
+                port: 8080,
+                backend_port: Some(8081),
+                verbosity: 1,
+            }
         );
         assert_eq!(
-            parse_ports(&args(&["serve", "--backend=5000"])),
-            (3456, 5000)
+            parse_args(&args(&["serve", "--port=9090", "--backend=9091"])),
+            GatewayArgs {
+                port: 9090,
+                backend_port: Some(9091),
+                verbosity: 1,
+            }
         );
+        assert_eq!(
+            parse_args(&args(&["serve", "--backend", "4000"])),
+            GatewayArgs {
+                port: 3456,
+                backend_port: Some(4000),
+                verbosity: 1,
+            }
+        );
+        assert_eq!(
+            parse_args(&args(&["serve", "--backend=5000"])),
+            GatewayArgs {
+                port: 3456,
+                backend_port: Some(5000),
+                verbosity: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_args_tracks_verbosity_forms() {
+        assert_eq!(parse_args(&args(&["serve", "--verbose"])).verbosity, 2);
+        assert_eq!(parse_args(&args(&["serve", "--verbose", "4"])).verbosity, 4);
+        assert_eq!(parse_args(&args(&["serve", "--verbose=3"])).verbosity, 3);
+        assert_eq!(parse_args(&args(&["serve", "-v"])).verbosity, 2);
+        assert_eq!(parse_args(&args(&["serve", "-vv"])).verbosity, 3);
+        assert_eq!(parse_args(&args(&["serve", "-vvv"])).verbosity, 4);
+        assert_eq!(parse_args(&args(&["serve", "-v", "-v"])).verbosity, 3);
+        assert_eq!(parse_args(&args(&["serve", "-vvvv"])).verbosity, 4);
+    }
+
+    #[tokio::test]
+    async fn root_returns_json_status_when_gateway_is_standalone() {
+        let (port, shutdown, handle) = spawn_gateway(None).await;
+
+        let (status, body) = get_root(port).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.contains("\"gateway\":\"rust\""), "body was {body}");
+        assert!(
+            body.contains("\"status\":\"standalone\""),
+            "body was {body}"
+        );
+        assert!(body.contains("\"backend\":null"), "body was {body}");
+
+        let _ = shutdown.send(());
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn root_proxies_to_backend_when_available() {
+        let backend_listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind backend");
+        let backend_port = backend_listener.local_addr().expect("backend addr").port();
+        let backend = tokio::spawn(async move {
+            let app = Router::new().route("/", get(|| async { "arra office" }));
+            let _ = axum::serve(backend_listener, app).await;
+        });
+
+        let (port, shutdown, handle) = spawn_gateway(Some(backend_port)).await;
+        let (status, body) = get_root(port).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "arra office");
+
+        let _ = shutdown.send(());
+        let _ = handle.await;
+        backend.abort();
     }
 }
 
@@ -418,41 +669,40 @@ async fn install_shutdown_signal(sender: broadcast::Sender<()>) {
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
-    let (port, backend_port) = parse_ports(&args);
+    let gateway_args = parse_args(&args);
 
     let client = Client::builder(TokioExecutor::new()).build(HttpConnector::new());
     let (shutdown_sender, _) = broadcast::channel(16);
     let state = AppState {
-        port,
-        backend_port,
+        port: gateway_args.port,
+        backend_port: gateway_args.backend_port,
+        verbosity: gateway_args.verbosity,
         client: Arc::new(client),
         shutdown: shutdown_sender,
     };
 
-    let app = Router::new()
-        .route("/api/health", get(health))
-        .route("/ws", get(proxy_ws))
-        .route("/ws/{*path}", get(proxy_ws_path))
-        .fallback(proxy_http)
-        .layer(middleware::from_fn(log_request))
-        .layer(TraceLayer::new_for_http())
-        .with_state(state.clone());
-
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = SocketAddr::from(([127, 0, 0, 1], state.port));
     let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(listener) => listener,
         Err(error) => {
-            eprintln!("failed to bind :{port}: {error}");
+            eprintln!("failed to bind :{}: {}", state.port, error);
             process::exit(1);
         }
     };
 
-    println!("listening on :{port}");
+    println!("listening on :{}", state.port);
+    if state.verbosity >= 2 {
+        eprintln!(
+            "[gateway:rust] verbosity={} backend={}",
+            state.verbosity,
+            backend_label_or_standalone(&state)
+        );
+    }
 
     let mut shutdown = state.shutdown.subscribe();
     tokio::spawn(install_shutdown_signal(state.shutdown.clone()));
 
-    let server = axum::serve(listener, app);
+    let server = axum::serve(listener, app(state));
     if let Err(error) = server
         .with_graceful_shutdown(async move {
             let _ = shutdown.recv().await;

--- a/src/core/gateway.ts
+++ b/src/core/gateway.ts
@@ -139,8 +139,10 @@ class RustGateway implements Gateway {
     await cleanupGatewayPort(port);
     await cleanupGatewayPort(backendPort);
     const backend = await new BunGateway().start(backendPort, { ...options, gateway: "bun" });
+    const childArgs = ["serve", "--port", String(port), "--backend", String(backendPort)];
+    if (typeof options.verbosity === "number") childArgs.push("--verbose", String(Math.max(0, Math.min(4, options.verbosity))));
 
-    const child = spawn(this.binary, ["serve", "--port", String(port), "--backend", String(backendPort)], {
+    const child = spawn(this.binary, childArgs, {
       stdio: ["ignore", "pipe", "pipe"],
       env: rustGatewayEnv(process.env, port, backendPort),
     });

--- a/test/isolated/gateway-rust-port-cleanup.test.ts
+++ b/test/isolated/gateway-rust-port-cleanup.test.ts
@@ -62,14 +62,14 @@ describe("RustGateway port cleanup", () => {
     chmodSync(binary, 0o755);
     process.env.MAW_GATEWAY_BIN = binary;
     try {
-      const child = await selectGateway({ cliGateway: "rust" }).start(4788) as FakeChild;
+      const child = await selectGateway({ cliGateway: "rust" }).start(4788, { verbosity: 4 }) as FakeChild;
 
       expect(calls[0]).toContain("exec:lsof -ti :4788 | xargs kill");
       expect(calls[0]).toContain('{"stdio":"ignore"}');
       expect(calls[1]).toContain("exec:lsof -ti :4789 | xargs kill");
-      expect(calls).toContain('bun:4789:{"gateway":"bun"}');
+      expect(calls).toContain('bun:4789:{"verbosity":4,"gateway":"bun"}');
       const spawnCall = calls.find(call => call.startsWith(`spawn:${binary}:`));
-      expect(spawnCall).toContain('["serve","--port","4788","--backend","4789"]');
+      expect(spawnCall).toContain('["serve","--port","4788","--backend","4789","--verbose","4"]');
       expect(spawnCall).toContain('"PORT":"4788"');
       expect(spawnCall).toContain('"MAW_BACKEND_PORT":"4789"');
       expect(spawnCall).not.toContain("ANTHROPIC_API_KEY");

--- a/test/isolated/gateway-selector.test.ts
+++ b/test/isolated/gateway-selector.test.ts
@@ -99,6 +99,13 @@ describe("gateway selector (#2566)", () => {
     expect(calls).toContainEqual({ type: "start", port: 4568, options: { verbosity: 1, gateway: "bun", forceTakeover: false } });
   });
 
+  test("maw serve preserves frame verbosity when forwarding rust gateway startup options", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    await expect(routeToolsWithDeps("serve", ["serve", "--gateway", "rust", "-vvvv", "4569"], routeDeps(calls))).resolves.toBe(true);
+
+    expect(calls).toContainEqual({ type: "start", port: 4569, options: { verbosity: 4, gateway: "rust", forceTakeover: false } });
+  });
+
   test("RustGateway.start throws UserError when maw-gateway is not found", async () => {
     const previous = process.env.MAW_GATEWAY_BIN;
     try {


### PR DESCRIPTION
## Summary
- Add `--backend PORT` support to `maw-gateway` (default `3457`).
- Proxy all non-health HTTP routes to `http://127.0.0.1:{backend}` and preserve request headers.
- Add WebSocket proxying for `/ws` and `/ws/*` routes with transparent upgrade and bi-directional forwarding.
- Update `/api/health` payload to include backend details.
- Make `GET /` proxy to Bun when the backend is available, and return a JSON status page when the gateway is standalone or the backend is unavailable.
- Forward Rust gateway verbosity from `maw serve --gateway rust -v...` to the binary.
- Preserve request logging for proxied routes and wire graceful-shutdown signaling into WS proxy paths.
- Update Rust gateway dependencies: `hyper`, `hyper-util`, `tokio-tungstenite`.

Closes #2642
Closes #2645
