### PR TITLE
Bound fleet ghq clone during wake

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -882,6 +882,37 @@ async function loadWakeFleetSessions(): Promise<FleetSession[]> {
   }
 }
 
+const DEFAULT_WAKE_FLEET_GHQ_GET_TIMEOUT_MS = 10_000;
+
+function wakeFleetGhqGetTimeoutMs(): number {
+  const raw = process.env.MAW_WAKE_GHQ_GET_TIMEOUT_MS;
+  if (raw === undefined) return DEFAULT_WAKE_FLEET_GHQ_GET_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_WAKE_FLEET_GHQ_GET_TIMEOUT_MS;
+}
+
+function isWakeFleetCloneTimeout(error: unknown): boolean {
+  return error instanceof Error && /timed out after \d+ms/.test(error.message);
+}
+
+async function hostExecWakeFleetGhqGet(command: string, timeoutMs: number): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    await Promise.race([
+      hostExec(command, undefined, { timeoutMs }),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function wakeFleetManualCloneHint(cloneSlug: string, oracle: string): string {
+  return `ghq get github.com/${cloneSlug} && maw wake ${oracle}`;
+}
+
 async function resolveWakeFleetSessionRepo(meta: WakeFleetSessionMetadata): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
   const repoStem = fleetRepoStem(meta.repo);
   const existing = await ghqFind(`/${meta.repo}`) || await ghqFind(`/${repoStem}`);
@@ -890,19 +921,25 @@ async function resolveWakeFleetSessionRepo(meta: WakeFleetSessionMetadata): Prom
   }
 
   const cloneSlug = meta.repo.replace(/^github\.com\//i, "");
-  console.log(`\x1b[36m🌱\x1b[0m ${meta.session} pinned in fleet → github.com/${cloneSlug} — cloning to ghq...`);
+  const timeoutMs = wakeFleetGhqGetTimeoutMs();
+  const hint = wakeFleetManualCloneHint(cloneSlug, meta.oracle);
+  console.log(`\x1b[36m🌱\x1b[0m ${meta.session} pinned in fleet → github.com/${cloneSlug} — checking ghq clone (bounded ${Math.ceil(timeoutMs / 1000)}s)...`);
   try {
-    await hostExec(`ghq get -u 'github.com/${cloneSlug}'`);
+    await hostExecWakeFleetGhqGet(`ghq get 'github.com/${cloneSlug}'`, timeoutMs);
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
-    console.error(`\x1b[33m⚠\x1b[0m fleet-pinned ${cloneSlug} clone/update failed: ${msg.split("\n")[0]}`);
+    const reason = isWakeFleetCloneTimeout(e) ? `timed out after ${timeoutMs}ms` : msg.split("\n")[0];
+    console.error(`\x1b[33m⚠\x1b[0m fleet-pinned ${cloneSlug} clone failed: ${reason}`);
+    console.error(`\x1b[90m  run manually: ${hint}\x1b[0m`);
   }
   const cloned = await ghqFind(`/${meta.repo}`) || await ghqFind(`/${repoStem}`);
   if (cloned) {
     console.log(`\x1b[32m✓\x1b[0m found at ${cloned}`);
     return { repoPath: cloned, repoName: cloned.split("/").pop()!, parentDir: cloned.replace(/\/[^/]+$/, "") };
   }
-  throw new Error(`fleet-pinned ${meta.repo} for session ${meta.session} — clone failed and not found locally`);
+  console.error(`\x1b[31merror\x1b[0m: fleet-pinned ${meta.repo} for session ${meta.session} is not cloned locally`);
+  console.error(`\x1b[90m  run manually: ${hint}\x1b[0m`);
+  throw new Error(`fleet-pinned ${meta.repo} for session ${meta.session} not found locally; run ${hint}`);
 }
 
 export async function chooseWakeSessionName(oracle: string, urlRepoName?: string): Promise<string> {

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -12,6 +12,37 @@ import { scanSuggestOracle } from "./wake-resolve-scan-suggest";
 import { loadFleet, resolveFleetSession, type FleetWindow } from "./fleet-load";
 import type { Session } from "../../core/runtime/find-window";
 
+const DEFAULT_WAKE_FLEET_GHQ_GET_TIMEOUT_MS = 10_000;
+
+function wakeFleetGhqGetTimeoutMs(): number {
+  const raw = process.env.MAW_WAKE_GHQ_GET_TIMEOUT_MS;
+  if (raw === undefined) return DEFAULT_WAKE_FLEET_GHQ_GET_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_WAKE_FLEET_GHQ_GET_TIMEOUT_MS;
+}
+
+function isWakeFleetCloneTimeout(error: unknown): boolean {
+  return error instanceof Error && /timed out after \d+ms/.test(error.message);
+}
+
+async function hostExecWakeFleetGhqGet(command: string, timeoutMs: number): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    await Promise.race([
+      hostExec(command, undefined, { timeoutMs }),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function wakeFleetManualCloneHint(repo: string, oracle: string): string {
+  return `ghq get github.com/${repo} && maw wake ${oracle}`;
+}
+
 /**
  * Worktree fallback for resolveOracle: if maw ls can see a worktree whose
  * main repo matches `${oracle}-oracle`, the main repo must be on disk even
@@ -301,20 +332,24 @@ export async function resolveOracle(
         parentDir: existing.replace(/\/[^/]+$/, ""),
       };
     }
-    console.log(`\x1b[36m🌱\x1b[0m ${oracle} pinned in fleet → github.com/${fleetRepo} — cloning to ghq...`);
+    const timeoutMs = wakeFleetGhqGetTimeoutMs();
+    const hint = wakeFleetManualCloneHint(fleetRepo, oracle);
+    console.log(`\x1b[36m🌱\x1b[0m ${oracle} pinned in fleet → github.com/${fleetRepo} — checking ghq clone (bounded ${Math.ceil(timeoutMs / 1000)}s)...`);
     try {
-      await hostExec(`ghq get -u 'github.com/${fleetRepo}'`);
+      await hostExecWakeFleetGhqGet(`ghq get 'github.com/${fleetRepo}'`, timeoutMs);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      console.error(`\x1b[33m⚠\x1b[0m fleet-pinned ${fleetRepo} clone/update failed: ${msg.split("\n")[0]}`);
+      const reason = isWakeFleetCloneTimeout(e) ? `timed out after ${timeoutMs}ms` : msg.split("\n")[0];
+      console.error(`\x1b[33m⚠\x1b[0m fleet-pinned ${fleetRepo} clone failed: ${reason}`);
+      console.error(`\x1b[90m  run manually: ${hint}\x1b[0m`);
     }
     const cloned = await ghqFind(`/${fleetRepoStem}`);
     if (cloned) {
       console.log(`\x1b[32m✓\x1b[0m found at ${cloned}`);
       return { repoPath: cloned, repoName: cloned.split("/").pop()!, parentDir: cloned.replace(/\/[^/]+$/, "") };
     }
-    console.error(`\x1b[31merror\x1b[0m: fleet-pinned ${fleetRepo} — clone failed and not found locally`);
-    console.error(`\x1b[90m  manually: ghq get -u 'github.com/${fleetRepo}' && maw wake ${oracle}\x1b[0m`);
+    console.error(`\x1b[31merror\x1b[0m: fleet-pinned ${fleetRepo} is not cloned locally`);
+    console.error(`\x1b[90m  run manually: ${hint}\x1b[0m`);
     process.exit(1);
   }
 

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -51,8 +51,12 @@ export interface SshDeps {
   requireConfig: () => { loadConfig: typeof loadConfig };
 }
 
+export interface HostExecOptions {
+  timeoutMs?: number;
+}
+
 export interface SshTransport {
-  hostExec: (cmd: string, host?: string) => Promise<string>;
+  hostExec: (cmd: string, host?: string, options?: HostExecOptions) => Promise<string>;
   ssh: (cmd: string, host?: string) => Promise<string>;
   listSessions: (host?: string) => Promise<Session[]>;
   capture: (target: string, lines?: number, host?: string) => Promise<string>;
@@ -99,7 +103,7 @@ export function createSshTransport(overrides: Partial<SshDeps> = {}): SshTranspo
   }
 
   /** Transport — run on oracle host. local → bash -c | remote → ssh */
-  async function hostExec(cmd: string, host = defaultHost): Promise<string> {
+  async function hostExec(cmd: string, host = defaultHost, options: HostExecOptions = {}): Promise<string> {
     // #713: with bind/host split, host is never a bind address (0.0.0.0 etc.)
     const local = host === "local" || host === "localhost" || isLocal;
     const transport: HostExecTransport = local ? "local" : "ssh";
@@ -111,16 +115,35 @@ export function createSshTransport(overrides: Partial<SshDeps> = {}): SshTranspo
       windowsHide: true,
       env: local ? { ...process.env, ...env, PATH: pathWithCommonLocalBins(env) } : undefined,
     });
-    const [text, err, code] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ]);
-    if (code !== 0) {
-      const underlying = new Error(err.trim() || `exit ${code}`);
-      throw new HostExecError(host, transport, underlying, code);
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const exited = options.timeoutMs && options.timeoutMs > 0
+      ? Promise.race([
+          proc.exited,
+          new Promise<number>((_, reject) => {
+            timeout = setTimeout(() => {
+              try { proc.kill("SIGTERM"); } catch { /* best effort */ }
+              setTimeout(() => {
+                try { proc.kill("SIGKILL"); } catch { /* best effort */ }
+              }, 250).unref?.();
+              reject(new HostExecError(host, transport, new Error(`timed out after ${options.timeoutMs}ms`)));
+            }, options.timeoutMs);
+          }),
+        ])
+      : proc.exited;
+    try {
+      const [text, err, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        exited,
+      ]);
+      if (code !== 0) {
+        const underlying = new Error(err.trim() || `exit ${code}`);
+        throw new HostExecError(host, transport, underlying, code);
+      }
+      return text.trim();
+    } finally {
+      if (timeout) clearTimeout(timeout);
     }
-    return text.trim();
   }
 
   const ssh = hostExec;

--- a/test/isolated/wake-resolve-impl-fifteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-resolve-impl-fifteenth-pass-coverage.test.ts
@@ -298,8 +298,8 @@ describe("resolveOracle fallback branches", () => {
     ghqFindMap = {};
     hostExecHandler = async () => { throw new Error("network down\nmore"); };
     await expect(resolveOracle("broken")).resolves.toBeUndefined();
-    expect(errors.join("\n")).toContain("fleet-pinned Org/broken-oracle clone/update failed: network down");
-    expect(errors.join("\n")).toContain("clone failed and not found locally");
+    expect(errors.join("\n")).toContain("fleet-pinned Org/broken-oracle clone failed: network down");
+    expect(errors.join("\n")).toContain("is not cloned locally");
     expect(exitCodes).toContain(1);
   });
 

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -29,6 +29,7 @@ const _rShouldAutoWake =
   await import("../src/commands/shared/should-auto-wake");
 const _rTeamEnsure = await import("../src/commands/plugins/team/ensure-config");
 const _rFleetEnsure = await import("../src/commands/shared/fleet-ensure");
+const _rFleetLoad = await import("../src/commands/shared/fleet-load");
 
 const realSdk = {
   hostExec: _rSdk.hostExec,
@@ -95,6 +96,7 @@ const realClaudeSessions = {
 const realShouldAutoWake = { shouldAutoWake: _rShouldAutoWake.shouldAutoWake };
 const realTeamEnsure = { ensureTeamConfig: _rTeamEnsure.ensureTeamConfig };
 const realFleetEnsure = { ensureFleetSessionEntry: _rFleetEnsure.ensureFleetSessionEntry };
+const realFleetLoad = { loadFleet: _rFleetLoad.loadFleet };
 
 type TmuxWindow = {
   index: number;
@@ -115,6 +117,7 @@ let worktrees: Array<{ name: string; path: string }>;
 let sessions: Array<{ name: string }>;
 let sessionMap: Record<string, string>;
 let fleetSession: string | null;
+let fleetSessions: Array<{ name: string; windows: Array<{ name: string; repo?: string }> }>;
 let detectSessionReturn: string | null;
 let detectSessionByOracle: Record<string, string | null>;
 let shouldWakeDecision: { wake: boolean; reason: string };
@@ -153,6 +156,7 @@ let throwCurrentSessionProbe: boolean;
 
 let logs: string[];
 let hostExecCalls: string[];
+let hostExecImpl: ((cmd: string) => Promise<string>) | null;
 let detectSessionCalls: Array<{ oracle: string; urlRepoName?: string }>;
 let findWorktreesCalls: Array<{ parentDir: string; repoName: string; taskSlug?: string; scopeStem?: string }>;
 let setSessionEnvCalls: string[];
@@ -251,6 +255,7 @@ mock.module(join(import.meta.dir, "../src/sdk"), () => ({
     }
     if (cmd.includes("list-panes")) return liveTileRoles.join("\n");
     if (cmd.includes("branch --show-current")) return `${branchName}\n`;
+    if (hostExecImpl) return hostExecImpl(cmd);
     return "";
   },
   restoreTabOrder: async (session: string) => {
@@ -590,6 +595,12 @@ mock.module(join(import.meta.dir, "../src/commands/shared/fleet-ensure"), () => 
   },
 }));
 
+mock.module(join(import.meta.dir, "../src/commands/shared/fleet-load"), () => ({
+  ..._rFleetLoad,
+  loadFleet: (...args: Parameters<typeof _rFleetLoad.loadFleet>) =>
+    mockActive ? fleetSessions as ReturnType<typeof _rFleetLoad.loadFleet> : realFleetLoad.loadFleet(...args),
+}));
+
 const { cmdWake, _wtPicker, promptAmbiguousBringPick, WakeSession, parseRehydrationSelection } = await import("../src/commands/shared/wake-cmd");
 const originalWtPickerIsStdoutTTY = _wtPicker.isStdoutTTY;
 const originalWtPickerReadChoice = _wtPicker.readChoice;
@@ -612,6 +623,7 @@ beforeEach(() => {
   sessions = [{ name: "54-mawjs" }];
   sessionMap = {};
   fleetSession = null;
+  fleetSessions = [];
   detectSessionReturn = "54-mawjs";
   detectSessionByOracle = {};
   shouldWakeDecision = { wake: false, reason: "already-live" };
@@ -638,6 +650,7 @@ beforeEach(() => {
 
   logs = [];
   hostExecCalls = [];
+  hostExecImpl = null;
   detectSessionCalls = [];
   findWorktreesCalls = [];
   setSessionEnvCalls = [];
@@ -808,6 +821,45 @@ describe("cmdWake main-suite coverage", () => {
     expect(logs.join("\n")).not.toContain("drained");
     expect(detectSessionCalls).toHaveLength(0);
     expect(sendTextCalls).toHaveLength(0);
+  });
+
+  test("fleet-pinned numeric wake skips ghq get when the repo already exists", async () => {
+    fleetSessions = [{ name: "12-special", windows: [{ name: "special-oracle", repo: "Org/special-oracle" }] }];
+    ghqFindReturn = "/repos/Org/special-oracle";
+    sessions = [];
+
+    const { result } = await captureLogs(() => cmdWake("12-special", { dryRun: true }));
+
+    expect(result).toBe("54-mawjs:special-oracle");
+    expect(hostExecCalls.filter((cmd) => cmd.startsWith("ghq get"))).toEqual([]);
+  });
+
+  test("fleet-pinned numeric wake bounds missing ghq clone and prints manual hint", async () => {
+    const previousTimeout = process.env.MAW_WAKE_GHQ_GET_TIMEOUT_MS;
+    const errors: string[] = [];
+    const originalError = console.error;
+    process.env.MAW_WAKE_GHQ_GET_TIMEOUT_MS = "20";
+    fleetSessions = [{ name: "12-special", windows: [{ name: "special-oracle", repo: "Org/special-oracle" }] }];
+    ghqFindReturn = null;
+    sessions = [];
+    hostExecImpl = async (cmd) => {
+      if (cmd.startsWith("ghq get")) return await new Promise<string>(() => {});
+      return "";
+    };
+    console.error = (...parts: unknown[]) => { errors.push(parts.map(String).join(" ")); };
+    const started = Date.now();
+    try {
+      await expect(cmdWake("12-special", { dryRun: true })).rejects.toThrow("run ghq get github.com/Org/special-oracle && maw wake special");
+    } finally {
+      console.error = originalError;
+      if (previousTimeout === undefined) delete process.env.MAW_WAKE_GHQ_GET_TIMEOUT_MS;
+      else process.env.MAW_WAKE_GHQ_GET_TIMEOUT_MS = previousTimeout;
+    }
+
+    expect(Date.now() - started).toBeLessThan(1_000);
+    expect(hostExecCalls.filter((cmd) => cmd.startsWith("ghq get"))).toEqual(["ghq get 'github.com/Org/special-oracle'"]);
+    expect(errors.join("\n")).toContain("timed out after 20ms");
+    expect(errors.join("\n")).toContain("run manually: ghq get github.com/Org/special-oracle && maw wake special");
   });
 
   test("lists worktrees without detecting or mutating tmux", async () => {

--- a/test/wake-resolve-impl-runtime-coverage.test.ts
+++ b/test/wake-resolve-impl-runtime-coverage.test.ts
@@ -306,7 +306,7 @@ describe("resolveOracle runtime paths", () => {
     writeFleet("12-special", [{ name: "special-oracle", repo: "Org/special-oracle" }]);
     ghqFindImpl = async (query) => ghqFindMap[query] ?? null;
     hostExecImpl = async (cmd) => {
-      if (cmd.includes("ghq get -u 'github.com/Org/special-oracle'")) {
+      if (cmd.includes("ghq get 'github.com/Org/special-oracle'")) {
         ghqFindMap["/special-oracle"] = "/repos/Org/special-oracle";
       }
       return "";
@@ -342,9 +342,9 @@ describe("resolveOracle runtime paths", () => {
 
     await expect(resolveOracle("broken")).resolves.toEqual(scanSuggestResult);
 
-    expect(errors.some((line) => line.includes("fleet-pinned Org/broken-oracle clone/update failed: network down"))).toBe(true);
-    expect(errors.some((line) => line.includes("fleet-pinned Org/broken-oracle — clone failed"))).toBe(true);
-    expect(errors.some((line) => line.includes("ghq get -u 'github.com/Org/broken-oracle'"))).toBe(true);
+    expect(errors.some((line) => line.includes("fleet-pinned Org/broken-oracle clone failed: network down"))).toBe(true);
+    expect(errors.some((line) => line.includes("fleet-pinned Org/broken-oracle is not cloned locally"))).toBe(true);
+    expect(errors.some((line) => line.includes("ghq get github.com/Org/broken-oracle && maw wake broken"))).toBe(true);
     expect(exitCalls).toContain(1);
   });
 


### PR DESCRIPTION
Closes #2660

## Summary
- keep the fleet-pinned existing-repo fast path ahead of any ghq network work
- change automatic missing-repo clone to bounded `ghq get` without `-u` and add a visible manual recovery hint
- add timeout support to hostExec and regression coverage for existing-skip and missing-bounded wake paths

## Validation
- bun run build
- bun test test/wake-cmd-cmdwake-coverage.test.ts --timeout 20000
- bun test test/wake-resolve-impl-runtime-coverage.test.ts test/isolated/wake-resolve-impl-fifteenth-pass-coverage.test.ts --timeout 20000
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun run test:default:safe
- clean HOME/XDG_CONFIG_HOME bun run test:isolated