### PR TITLE
fix(wake): return after bootstrap by default

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -171,7 +171,7 @@ function printBringUsage(write: (line: string) => void = console.log): void {
 }
 
 function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => void = console.log): void {
-  write(`usage: maw ${verb} <oracle> [--work|--oracle] [--session <tmux-session>] [--task <s>] [--wt <s>] [--layout nested|legacy] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh|--new] [--pick] [--name <s>] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--no-fleet] [--split] [--parent-session-id <id>] [--session-id <id>] [--all-local] [-e|--engine <name>]`);
+  write(`usage: maw ${verb} <oracle> [--work|--oracle] [--session <tmux-session>] [--task <s>] [--wt <s>] [--layout nested|legacy] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh|--new] [--pick] [--name <s>] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--no-fleet] [--split] [--wait] [--parent-session-id <id>] [--session-id <id>] [--all-local] [-e|--engine <name>]`);
   if (verb === "awake") {
     write("  Launch/start an oracle process with the selected engine. Does not send /awaken.");
     write("  Use `maw awaken` for the awakening ritual; use `maw new` for a plain workspace session.");
@@ -179,6 +179,7 @@ function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => vo
     write("  Wake or reuse an oracle session, fuzzy-resolving repos and worktrees as needed.");
   }
   write("  --work/--oracle overrides suffix-based mode detection; work mode uses repo identity and keeps ψ/ local.");
+  write("  --wait waits for the engine process after bootstrap; default wake returns immediately after sending it.");
   write("  --session targets an existing foreign workspace session instead of the oracle's own session.");
   write("  --fresh/--new forces a new numbered worktree slot; default prefers a stable reusable slot.");
   write("  --layout selects new worktree filesystem layout: nested (default repo/agents/N-X) or legacy (.wt-N-X).");
@@ -445,6 +446,8 @@ export async function invokeDirectHandler(
       "--oracle": Boolean,
       "--parent-session-id": String,
       "--session-id": String,
+      "--wait": Boolean,
+      "--wait-engine": "--wait",
     }, 0);
 
     const positional = flags._;
@@ -481,6 +484,7 @@ export async function invokeDirectHandler(
       snapshotId?: string;
       layout?: "nested" | "legacy";
       sessionMode?: "oracle" | "work";
+      wait?: boolean;
     } = {};
     if (flags["--work"] && flags["--oracle"]) throw new UserError("wake: choose only one of --work or --oracle");
     if (flags["--work"]) opts.sessionMode = "work";
@@ -519,6 +523,7 @@ export async function invokeDirectHandler(
       opts.parentSessionId = (flags["--parent-session-id"] as string | undefined) || (flags["--parent"] as string | undefined);
     }
     if (flags["--session-id"]) opts.sessionId = flags["--session-id"] as string;
+    if (flags["--wait"]) opts.wait = true;
 
     // Shorthand: --codex, --gemini etc. → engine from config.engines/legacy commands.
     // Unknown flags land in flags._ (permissive mode), so scan for --<engine>

--- a/src/commands/shared/wake-cmd-helpers.ts
+++ b/src/commands/shared/wake-cmd-helpers.ts
@@ -95,8 +95,8 @@ export function shouldOfferExistingSessionAttach(
   );
 }
 
-const FRESH_SESSION_READY_ATTEMPTS = 120;
-const FRESH_SESSION_READY_DELAY_MS = 250;
+const FRESH_SESSION_READY_ATTEMPTS = 10;
+const FRESH_SESSION_READY_DELAY_MS = 50;
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -433,6 +433,8 @@ export interface WakeOptions {
   layout?: WorktreeLayout;
   /** Force Discord channel launch for Claude-like engines (#1999). */
   channels?: boolean;
+  /** Wait until the engine process is detected after sending bootstrap commands. Default wake returns immediately (#2661). */
+  wait?: boolean;
   /** Explicit wake session mode override. Auto mode infers from the resolved repo suffix. */
   sessionMode?: WakeSessionMode;
 }
@@ -458,6 +460,7 @@ function isAttachOnlyWake(opts: WakeOptions): boolean {
     && !opts.signalOnBirth
     && !opts.engine
     && !opts.channels
+    && !opts.wait
     && !opts.fromSnapshot
     && !opts.snapshotId;
 }
@@ -616,7 +619,6 @@ async function restoreSnapshotWindows(
   }
   for (const win of planned) {
     await tmux.newWindow(session, win.windowName, { cwd: win.cwd });
-    await new Promise(r => setTimeout(r, 300));
     await tmux.sendText(`${session}:${win.windowName}`, buildWakeCommand(win.windowName, win.cwd, { engine }));
     existingWindows.add(win.windowName);
     const label = win.source === "worktree" ? "worktree" : "repo";
@@ -1342,14 +1344,13 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     await retryFreshSessionTmuxStep(session, "set session environment", () => setSessionEnv(session), {
       hasSession: tmux.hasSession,
     });
-    await new Promise(r => setTimeout(r, 300));
     await retryFreshSessionTmuxStep(session, "launch main window", () => {
       const command = buildWakeCommand(mainWindowName, repoPath, opts);
       return sendWakeCommandAndPrompt(`${session}:${mainWindowName}`, opts.prompt, command, opts.engine);
     }, {
       hasSession: tmux.hasSession,
     });
-    await wakeSession.waitForEngine(`${session}:${mainWindowName}`, getPaneInfos, isAgentCommand);
+    if (opts.wait) await wakeSession.waitForEngine(`${session}:${mainWindowName}`, getPaneInfos, isAgentCommand);
     console.log(`\x1b[32m+\x1b[0m created session '${session}' (main: ${mainWindowName})`);
 
     if (!opts.noFleet) {
@@ -1401,12 +1402,11 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       }
       for (const wt of selectedPlan) {
         await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
-        await new Promise(r => setTimeout(r, 300));
         const wtEngine = wakeSession.readWorktreeEngineFile(wt.path);
         const wtOpts = wtEngine ? { ...opts, engine: wtEngine } : opts;
         const target = `${session}:${wt.windowName}`;
         await tmux.sendText(target, await buildWakeCommandForPane(wt.windowName, wt.path, wtOpts, target));
-        await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
+        if (opts.wait) await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
         existingWindows.add(wt.windowName);
         console.log(`\x1b[32m+\x1b[0m window: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
       }
@@ -1456,7 +1456,6 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
             console.log(`\x1b[36m↻\x1b[0m rehydrating from agents/ folder:`);
             for (const wt of selectedPlan) {
               await tmux.newWindow(session, wt.windowName, { cwd: wt.path });
-              await new Promise(r => setTimeout(r, 300));
               const wtEngine = wakeSession.readWorktreeEngineFile(wt.path);
               const wtOpts = wtEngine ? { ...opts, engine: wtEngine } : opts;
               const target = `${session}:${wt.windowName}`;
@@ -1629,7 +1628,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       if (!agentAlive) {
         console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' in ${session} — agent dead, re-launching fresh...`);
         await tmux.sendText(target, buildWakeCommand(existingWindow, targetPath, { ...opts, freshLaunch: true }));
-        await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
+        if (opts.wait) await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
         if (opts.attach) {
           await tmux.selectWindow(target);
           await wakeSession.attachToSession(session);
@@ -1689,7 +1688,6 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   registerWorktreeWindow();
-  await new Promise(r => setTimeout(r, 300));
   const cmd = buildWakeCommand(windowName, targetPath, opts);
   if (opts.prompt) {
     await sendWakeCommandAndPrompt(`${session}:${windowName}`, opts.prompt, cmd, opts.engine);

--- a/test/top-aliases-default.test.ts
+++ b/test/top-aliases-default.test.ts
@@ -313,6 +313,7 @@ describe("direct handler invocation", () => {
       "--split",
       "--parent-session-id", "parent-1",
       "--session-id", "child-1",
+      "--wait",
       "--all-local",
       "--codex",
     ], deps);
@@ -341,6 +342,7 @@ describe("direct handler invocation", () => {
       split: true,
       parentSessionId: "parent-1",
       sessionId: "child-1",
+      wait: true,
       allLocal: true,
       engine: "codex",
     }]]);

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -69,6 +69,7 @@ const realWakeResolve = {
 const realWakeSession = {
   attachToSession: _rWakeSession.attachToSession,
   ensureSessionRunning: _rWakeSession.ensureSessionRunning,
+  waitForEngine: _rWakeSession.waitForEngine,
   createWorktree: _rWakeSession.createWorktree,
 };
 const realWakeMaybeSplit = {
@@ -173,6 +174,7 @@ let saveConfigCalls: any[];
 let ensureTeamConfigCalls: string[];
 let attachCalls: string[];
 let ensureSessionRunningCalls: string[];
+let waitForEngineCalls: string[];
 let maybeSplitCalls: Array<{ target: string; opts: any }>;
 let maybeOpenWindowCalls: Array<{ target: string; opts: any }>;
 let writeSignalCalls: Array<{ root: string; child: string; signal: any }>;
@@ -414,6 +416,14 @@ mock.module(
       const [session] = args;
       ensureSessionRunningCalls.push(session);
       return ensureSessionRunningReturn;
+    },
+    waitForEngine: async (
+      ...args: Parameters<typeof _rWakeSession.waitForEngine>
+    ) => {
+      if (!mockActive) return realWakeSession.waitForEngine(...args);
+      const [target] = args;
+      waitForEngineCalls.push(target);
+      return true;
     },
     createWorktree: async (
       repoPathArg: string,
@@ -667,6 +677,7 @@ beforeEach(() => {
   ensureTeamConfigCalls = [];
   attachCalls = [];
   ensureSessionRunningCalls = [];
+  waitForEngineCalls = [];
   maybeSplitCalls = [];
   maybeOpenWindowCalls = [];
   writeSignalCalls = [];
@@ -708,6 +719,38 @@ describe("cmdWake main-suite coverage", () => {
     expect(sendTextCalls[0]?.target).toBe("01-maw-js:maw-js");
     expect(existsSync(join(repoPath, "ψ"))).toBe(true);
     expect(readFileSync(join(repoPath, ".gitignore"), "utf-8")).toContain("ψ/\n");
+  });
+
+  test("#2661 fresh session creation returns without waiting for engine by default", async () => {
+    sessions = [];
+    hasSessions = new Set();
+    detectSessionReturn = null;
+    shouldWakeDecision = { wake: true, reason: "missing" };
+
+    const { result } = await captureLogs(() =>
+      cmdWake("mawjs", { noRehydrate: true, noFleet: true }),
+    );
+
+    expect(result).toBe("01-mawjs:mawjs-oracle");
+    expect(newSessionCalls).toEqual([{ name: "01-mawjs", opts: { window: "mawjs-oracle", cwd: repoPath } }]);
+    expect(sendTextCalls).toHaveLength(1);
+    expect(sendTextCalls[0]?.target).toBe("01-mawjs:mawjs-oracle");
+    expect(waitForEngineCalls).toEqual([]);
+  });
+
+  test("#2661 --wait preserves engine-ready blocking for fresh session creation", async () => {
+    sessions = [];
+    hasSessions = new Set();
+    detectSessionReturn = null;
+    shouldWakeDecision = { wake: true, reason: "missing" };
+
+    const { result } = await captureLogs(() =>
+      cmdWake("mawjs", { noRehydrate: true, noFleet: true, wait: true }),
+    );
+
+    expect(result).toBe("01-mawjs:mawjs-oracle");
+    expect(sendTextCalls[0]?.target).toBe("01-mawjs:mawjs-oracle");
+    expect(waitForEngineCalls).toEqual(["01-mawjs:mawjs-oracle"]);
   });
 
   test("#2598 explicit oracle override wins over non-oracle repo detection", async () => {


### PR DESCRIPTION
## Summary
- Make fresh `maw wake` return immediately after creating the tmux session and sending the bootstrap command.
- Add explicit `--wait` / `--wait-engine` opt-in for scripts that need engine-ready blocking.
- Remove fixed 300ms wake sleeps and bound fresh-session tmux retries to 10x50ms.
- Add regression coverage for default no-wait and `--wait` behavior.

## Tests
- `bun test ./test/wake-cmd-cmdwake-coverage.test.ts ./test/top-aliases-default.test.ts ./test/isolated/wake-cmd-helper-coverage.test.ts ./test/isolated/wake-session-ready.test.ts --path-ignore-patterns '**/agents/**'`\n\nCloses #2661