### PR TITLE
Fix wake inbox notice newline

### DIFF
--- a/src/commands/shared/wake-inbox-drain.ts
+++ b/src/commands/shared/wake-inbox-drain.ts
@@ -69,7 +69,7 @@ function markFrontmatterRead(raw: string, timestamp: string): string {
 export function formatWakeInboxPrompt(messages: WakeInboxMessage[], omittedCount = 0): string {
   const unreadCount = messages.length + omittedCount;
   if (unreadCount <= 0) return "";
-  return `You have ${unreadCount} unread messages in inbox. Run maw inbox --unread to review.`;
+  return `You have ${unreadCount} unread messages in inbox. Run maw inbox --unread to review.\n`;
 }
 
 export function mergeWakeInboxPrompt(existingPrompt: string | undefined, inboxPrompt: string): string | undefined {

--- a/test/isolated/wake-inbox-drain-2013.test.ts
+++ b/test/isolated/wake-inbox-drain-2013.test.ts
@@ -27,7 +27,7 @@ describe("wake inbox drain (#2390)", () => {
     const result = drainWakeInbox(repo);
 
     expect(result.count).toBe(1);
-    expect(result.prompt).toBe("You have 1 unread messages in inbox. Run maw inbox --unread to review.");
+    expect(result.prompt).toBe("You have 1 unread messages in inbox. Run maw inbox --unread to review.\n");
     expect(result.prompt).not.toContain("please review #2013");
     expect(result.prompt).not.toContain("old");
     const updated = readFileSync(unread, "utf-8");
@@ -63,8 +63,15 @@ describe("wake inbox drain (#2390)", () => {
   });
 
   test("merges drained inbox after an explicit wake prompt", () => {
-    expect(mergeWakeInboxPrompt("continue task", "You have 1 unread messages in inbox. Run maw inbox --unread to review."))
-      .toBe("continue task\n\nYou have 1 unread messages in inbox. Run maw inbox --unread to review.");
+    expect(mergeWakeInboxPrompt("continue task", "You have 1 unread messages in inbox. Run maw inbox --unread to review.\n"))
+      .toBe("continue task\n\nYou have 1 unread messages in inbox. Run maw inbox --unread to review.\n");
+  });
+
+  test("terminates unread notice before a following launch command", () => {
+    const notice = mergeWakeInboxPrompt(undefined, "You have 1 unread messages in inbox. Run maw inbox --unread to review.\n");
+
+    expect(`${notice}DISCORD_STATE_DIR=/tmp claude --continue`)
+      .toContain("review.\nDISCORD_STATE_DIR=/tmp");
   });
 
   test("skips draining inbox for non-Claude engines", () => {
@@ -108,7 +115,7 @@ test("counts all unread messages without body-size omissions", () => {
   expect(Buffer.byteLength(result.prompt, "utf-8")).toBeLessThanOrEqual(400);
   expect(result.count).toBe(2);
   expect(result.omittedCount).toBe(0);
-  expect(result.prompt).toBe("You have 2 unread messages in inbox. Run maw inbox --unread to review.");
+  expect(result.prompt).toBe("You have 2 unread messages in inbox. Run maw inbox --unread to review.\n");
   expect(result.prompt).not.toContain("small body");
   expect(result.prompt).not.toContain("xxx");
   expect(readFileSync(small, "utf-8")).toContain("read: false");


### PR DESCRIPTION
Closes #2668

## Summary
- terminate the wake inbox unread notice with a newline
- add a regression that proves a following launch command starts on the next line
- update existing wake-inbox prompt expectations for the newline contract

## Tests
- MAW_TEST_MODE=1 bun test test/isolated/wake-inbox-drain-2013.test.ts --path-ignore-patterns "**/agents/**"
- git diff --check

## Notes
- Started bun run test:default:safe, but stopped it after it recursed into nested agents/* worktrees and duplicated unrelated suites; all observed tests before stop were passing.