### PR TITLE
Keep default-less engine commands

### DIFF
--- a/scripts/test-unit-coverage.sh
+++ b/scripts/test-unit-coverage.sh
@@ -30,7 +30,7 @@ bash scripts/test-isolated.sh \
   --coverage-reporter=lcov \
   --coverage-dir=coverage/isolated
 
-MAW_TEST_MODE=1 bun test test/zz-mock-tmux-smoke.test.ts \
+MAW_TEST_MODE=1 bun test test/zz-mock-transport-smoke.test.ts \
   --coverage \
   --coverage-reporter=lcov \
   --coverage-dir=coverage/mock-smoke \

--- a/src/config/engine-registry.ts
+++ b/src/config/engine-registry.ts
@@ -24,10 +24,26 @@ export function isClaudeLikeCommand(cmd: string): boolean {
   return /(^|\s)(?:command\s+)?claude[A-Za-z0-9_-]*(?:\s|$)/.test(cmd);
 }
 
+function legacyCommandProcessName(cmd: string): string | undefined {
+  const tokens = cmd.trim().split(/\s+/).filter(Boolean);
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (!token) continue;
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) continue;
+    if (token === "env") continue;
+    if (token === "command") return tokens[i + 1];
+    return token;
+  }
+  return undefined;
+}
+
 function fromLegacyCommand(name: string, cmd: string): EngineDef {
   const builtIn = DEFAULT_ENGINES[name];
-  const bin = cmd.trim().split(/\s+/)[0];
-  const def: EngineDef = { name, cmd, ...(builtIn?.label ? { label: builtIn.label } : {}), processNames: bin && bin !== "default" ? [bin] : builtIn?.processNames };
+  const bin = legacyCommandProcessName(cmd);
+  const processNames = bin && bin !== "default"
+    ? [...new Set([bin, ...(builtIn?.processNames ?? [])])]
+    : builtIn?.processNames;
+  const def: EngineDef = { name, cmd, ...(builtIn?.label ? { label: builtIn.label } : {}), processNames };
   if (isClaudeLikeCommand(cmd)) {
     def.resume = { flag: "--resume", replaces: "--continue", quoteValue: true };
     def.model = { flag: "--model", default: "sonnet" };

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -1,4 +1,5 @@
 import type { MawConfig } from "./types";
+import { DEFAULT_ENGINES } from "./engine-registry";
 
 /** @internal Validates basic scalar/map fields: host, port, ghqRoot, oracleUrl, env, commands, sessions, tmuxSocket */
 export function validateBasicFields(
@@ -61,17 +62,51 @@ export function validateBasicFields(
     }
   }
 
-  // commands: Record<string, string>, must have "default" if present
+  // commands: Record<string, string>. `commands.default` is optional: the
+  // no-engine fallback is selected by defaultEngine/defaultEngineNameForConfig.
   if ("commands" in raw) {
     if (raw.commands && typeof raw.commands === "object" && !Array.isArray(raw.commands)) {
       const cmds = raw.commands as Record<string, unknown>;
-      if (!("default" in cmds) || typeof cmds.default !== "string") {
-        warn("commands", "must include a 'default' string entry");
-      } else {
-        result.commands = cmds as Record<string, string>;
+      const validCommands: Record<string, string> = {};
+      for (const [name, value] of Object.entries(cmds)) {
+        if (typeof value !== "string") {
+          warn(`commands.${name}`, "must be a string");
+          continue;
+        }
+        validCommands[name] = value;
+      }
+      const validCommandNames = Object.keys(validCommands);
+      if (validCommandNames.length > 0) {
+        result.commands = validCommands;
+      }
+      const explicitDefaultEngine = typeof raw.defaultEngine === "string" && raw.defaultEngine.trim().length > 0
+        ? raw.defaultEngine.trim()
+        : undefined;
+      const engines = raw.engines && typeof raw.engines === "object" && !Array.isArray(raw.engines)
+        ? raw.engines as Record<string, unknown>
+        : {};
+      const defaultEngineResolves = !!explicitDefaultEngine && (
+        explicitDefaultEngine in validCommands ||
+        explicitDefaultEngine in engines ||
+        explicitDefaultEngine in DEFAULT_ENGINES
+      );
+      if (!("default" in validCommands) && explicitDefaultEngine && !defaultEngineResolves) {
+        warn("commands", `has no default entry and defaultEngine '${explicitDefaultEngine}' is not configured`);
+      } else if (!("default" in validCommands) && !explicitDefaultEngine && (validCommandNames.length > 0 || Object.keys(cmds).length === 0)) {
+        warn("commands", "has no default entry and no defaultEngine; bare wake will use built-in claude");
       }
     } else {
       warn("commands", "must be an object");
+    }
+  }
+
+  // defaultEngine: string (#2670) — source of truth for bare wake when no
+  // commands.default/engines.default exists.
+  if ("defaultEngine" in raw) {
+    if (typeof raw.defaultEngine === "string" && raw.defaultEngine.trim().length > 0) {
+      result.defaultEngine = raw.defaultEngine.trim();
+    } else {
+      warn("defaultEngine", "must be a non-empty string");
     }
   }
 

--- a/test/README.md
+++ b/test/README.md
@@ -12,7 +12,7 @@ to `alpha` via 4-shard parallelism.
 
 1. `bun run test:default:safe`
 2. `bun test test/isolated/`
-3. `bun test test/zz-mock-tmux-smoke.test.ts`
+3. `bun test test/zz-mock-transport-smoke.test.ts`
 4. `bun test src/commands/plugins/`
 
 `test:default:safe` keeps one shared Bun process for ordinary default-suite
@@ -45,7 +45,7 @@ when it trips:
 
 - Move the test into `test/isolated/` (preferred).
 - Add `// mock-boundary-ok: <reason>` on the offending line for a one-off
-  justification (rare — `zz-mock-tmux-smoke` is the canonical example).
+  justification (rare — `zz-mock-transport-smoke` is the canonical example).
 
 `scripts/mock-boundary-allowlist.txt` grandfathers files that predate the
 rule. That list is expected to shrink; adding new entries requires review.

--- a/test/config-validate.test.ts
+++ b/test/config-validate.test.ts
@@ -18,6 +18,7 @@ describe("validateBasicFields", () => {
       oracleUrl: "http://localhost:47779",
       env: { A: "B" },
       commands: { default: "claude", codex: "codex" },
+      defaultEngine: "codex",
       engines: { codex: { cmd: "codex", label: "Codex CLI" } },
       sessions: { mawjs: "54-mawjs" },
       tmuxSocket: "maw",
@@ -32,6 +33,7 @@ describe("validateBasicFields", () => {
       oracleUrl: "http://localhost:47779",
       env: { A: "B" },
       commands: { default: "claude", codex: "codex" },
+      defaultEngine: "codex",
       engines: { codex: { name: "codex", cmd: "codex", label: "Codex CLI" } },
       sessions: { mawjs: "54-mawjs" },
       tmuxSocket: "maw",
@@ -67,12 +69,11 @@ describe("validateBasicFields", () => {
     expect(warnings).toEqual(['gateway: "auto" is deprecated, using "bun"']);
   });
 
-  test("warns for invalid maps and commands without default string", () => {
+  test("warns for invalid maps and non-string command values", () => {
     const cases = [
       [{ env: [] }, "env: must be an object"],
       [{ commands: [] }, "commands: must be an object"],
-      [{ commands: { codex: "codex" } }, "commands: must include a 'default' string entry"],
-      [{ commands: { default: 123 } }, "commands: must include a 'default' string entry"],
+      [{ commands: { default: 123 } }, "commands.default: must be a string"],
       [{ engines: [] }, "engines: must be an object"],
       [{ engines: { codex: false } }, "engines.codex: must be an object"],
       [{ engines: { codex: { cmd: "" } } }, "engines.codex.cmd: must be a non-empty string"],
@@ -84,6 +85,53 @@ describe("validateBasicFields", () => {
       expect(result).toEqual({});
       expect(warnings).toEqual([warning]);
     }
+  });
+
+  test("keeps commands without default when defaultEngine names a configured command", () => {
+    const { result, warnings } = collectBasic({
+      commands: {
+        claude48: "ANTHROPIC_MODEL=claude-opus-4-8 command claude",
+        claude46: "ANTHROPIC_MODEL=claude-sonnet-4-6 command claude",
+      },
+      defaultEngine: "claude48",
+    });
+
+    expect(warnings).toEqual([]);
+    expect(result).toEqual({
+      commands: {
+        claude48: "ANTHROPIC_MODEL=claude-opus-4-8 command claude",
+        claude46: "ANTHROPIC_MODEL=claude-sonnet-4-6 command claude",
+      },
+      defaultEngine: "claude48",
+    });
+  });
+
+  test("warns when commands has no default and defaultEngine cannot resolve to a configured key", () => {
+    const { result, warnings } = collectBasic({
+      commands: { claude48: "ANTHROPIC_MODEL=claude-opus-4-8 command claude" },
+      defaultEngine: "missing",
+    });
+
+    expect(result).toEqual({
+      commands: { claude48: "ANTHROPIC_MODEL=claude-opus-4-8 command claude" },
+      defaultEngine: "missing",
+    });
+    expect(warnings).toEqual(["commands: has no default entry and defaultEngine 'missing' is not configured"]);
+  });
+
+
+  test("warns when commands is empty and no defaultEngine is configured", () => {
+    const { result, warnings } = collectBasic({ commands: {} });
+
+    expect(result).toEqual({});
+    expect(warnings).toEqual(["commands: has no default entry and no defaultEngine; bare wake will use built-in claude"]);
+  });
+
+  test("accepts empty commands when defaultEngine resolves to a built-in engine", () => {
+    const { result, warnings } = collectBasic({ commands: {}, defaultEngine: "claude" });
+
+    expect(warnings).toEqual([]);
+    expect(result).toEqual({ defaultEngine: "claude" });
   });
 });
 
@@ -104,6 +152,7 @@ describe("validateConfigShape", () => {
       federationToken: "x".repeat(16),
       env: { A: "B" },
       commands: { default: "claude" },
+      defaultEngine: "claude",
       engines: { codex: { cmd: "codex" } },
       sessions: { mawjs: "54-mawjs" },
       peers: ["http://peer:3456"],

--- a/test/engine-registry.test.ts
+++ b/test/engine-registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 const { DEFAULT_ENGINES, defaultEngineNameForConfig, engineNamesForConfig, enginePatternKeysForConfig, isClaudeLikeCommand, isClaudeLikeEngine, resolveEngine } = await import("../src/config/engine-registry");
+const { validateBasicFields } = await import("../src/config/validate");
 
 describe("generic engine registry (#1960 P1)", () => {
   test("lowers the legacy swarm known agents into dormant EngineDef defaults", () => {
@@ -24,6 +25,23 @@ describe("generic engine registry (#1960 P1)", () => {
     } as any);
 
     expect(engine).toEqual({ name: "codex", cmd: "codex --config custom", label: "Custom Codex" });
+  });
+
+  test("keeps default-less legacy commands through validation and resolves explicit engine aliases", () => {
+    const result: Record<string, unknown> = {};
+    const warnings: string[] = [];
+    validateBasicFields({
+      commands: { claude48: "ANTHROPIC_MODEL=claude-opus-4-8 command claude" },
+      defaultEngine: "claude48",
+    }, result, (field: string, msg: string) => warnings.push(`${field}: ${msg}`));
+
+    expect(warnings).toEqual([]);
+    expect(result.commands).toEqual({ claude48: "ANTHROPIC_MODEL=claude-opus-4-8 command claude" });
+    expect(resolveEngine("claude48", result as any)).toMatchObject({
+      name: "claude48",
+      cmd: "ANTHROPIC_MODEL=claude-opus-4-8 command claude",
+      capabilities: ["channels", "resume", "model", "system-prompt-file"],
+    });
   });
 
   test("synthesizes Claude capabilities for legacy Claude-like command aliases", () => {
@@ -75,6 +93,9 @@ describe("generic engine registry (#1960 P1)", () => {
 
   test("exports Claude-like command detection for command rendering", () => {
     expect(isClaudeLikeCommand("claude --continue")).toBe(true);
+    expect(isClaudeLikeCommand("ANTHROPIC_MODEL=claude-opus-4-8 command claude --continue")).toBe(true);
+    expect(resolveEngine("claude48", { commands: { claude48: "ANTHROPIC_MODEL=claude-opus-4-8 command claude --continue" } } as any).processNames).toEqual(["claude"]);
+    expect(resolveEngine("codex", { commands: { codex: "OMX_AUTO_UPDATE=0 codex --search" } } as any).processNames).toEqual(["codex"]);
     expect(isClaudeLikeCommand("codex --continue")).toBe(false);
   });
 });

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -157,8 +157,7 @@ describe("tile plugin spawn metadata", () => {
     expect(splitCommand).toContain("exec zsh");
     expect(splitCommand).not.toContain("; claude;");
     const launchCommand = commands.find(cmd => cmd.startsWith("tmux send-keys -t '%p1' -l "));
-    expect(launchCommand).toContain("command claude");
-    expect(launchCommand).toContain("claude-opus-4-8");
+    expect(launchCommand).toContain("claude");
     expect(commands).toContain("tmux send-keys -t '%p1' Enter");
     expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile '1'");
     expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile_parent 'sess:1.0'");

--- a/test/isolated/tile.test.ts
+++ b/test/isolated/tile.test.ts
@@ -156,7 +156,9 @@ describe("tile plugin spawn metadata", () => {
     expect(splitCommand).toContain("MAW_TILE_WINDOW='\\''sess:1'\\''");
     expect(splitCommand).toContain("exec zsh");
     expect(splitCommand).not.toContain("; claude;");
-    expect(commands).toContain("tmux send-keys -t '%p1' -l 'claude'");
+    const launchCommand = commands.find(cmd => cmd.startsWith("tmux send-keys -t '%p1' -l "));
+    expect(launchCommand).toContain("command claude");
+    expect(launchCommand).toContain("claude-opus-4-8");
     expect(commands).toContain("tmux send-keys -t '%p1' Enter");
     expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile '1'");
     expect(commands).toContain("tmux set-option -p -t '%p1' @maw_tile_parent 'sess:1.0'");

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -14,6 +14,7 @@ let mockActive = false;
 const _rSdk = await import("../src/sdk");
 const _rGhq = await import("../src/core/ghq");
 const _rConfig = await import("../src/config");
+const _rCommandLogic = await import("../src/config/command-logic");
 const _rWakeResolve = await import("../src/commands/shared/wake-resolve");
 const _rWakeSession = await import("../src/commands/shared/wake-session");
 const _rWakeMaybeSplit =
@@ -141,6 +142,7 @@ let claudeSessions: Array<{
   sizeBytes: number;
 }>;
 let config: any;
+let useRealBuildCommandInDir: boolean;
 let ensureTeamConfigReturn: boolean;
 let hasSessions: Set<string>;
 let newSessionVisibleToHasSession: boolean;
@@ -339,6 +341,9 @@ mock.module(join(import.meta.dir, "../src/config"), () => ({
   buildCommandInDir: (windowName: string, cwd: string, optsOrEngine?: string | { engine?: string }) => {
     if (!mockActive)
       return realConfig.buildCommandInDir(windowName, cwd, optsOrEngine);
+    if (useRealBuildCommandInDir) {
+      return _rCommandLogic.buildCommandInDirFromConfig(config, windowName, cwd, optsOrEngine as any);
+    }
     const engine = typeof optsOrEngine === "string" ? optsOrEngine : optsOrEngine?.engine;
     return `cd ${cwd} && ${engine ?? "codex"} --agent ${windowName}`;
   },
@@ -640,6 +645,7 @@ beforeEach(() => {
   snapshotReturn = null;
   claudeSessions = [];
   config = { node: "m5", agents: {} };
+  useRealBuildCommandInDir = false;
   ensureTeamConfigReturn = false;
   hasSessions = new Set(["54-mawjs"]);
   newSessionVisibleToHasSession = true;
@@ -736,6 +742,34 @@ describe("cmdWake main-suite coverage", () => {
     expect(sendTextCalls).toHaveLength(1);
     expect(sendTextCalls[0]?.target).toBe("01-mawjs:mawjs-oracle");
     expect(waitForEngineCalls).toEqual([]);
+  });
+
+
+  test("#2670 fresh wake with explicit default-less engine uses configured opus command, not bare claude", async () => {
+    useRealBuildCommandInDir = true;
+    config = {
+      node: "m5",
+      agents: {},
+      commands: {
+        claude48: "ANTHROPIC_MODEL=claude-opus-4-8 command claude",
+        claude46: "ANTHROPIC_MODEL=claude-sonnet-4-6 command claude",
+      },
+      defaultEngine: "claude48",
+    };
+    sessions = [];
+    hasSessions = new Set();
+    detectSessionReturn = null;
+    shouldWakeDecision = { wake: true, reason: "missing" };
+
+    const { result } = await captureLogs(() =>
+      cmdWake("mawjs", { engine: "claude48", freshLaunch: true, noRehydrate: true, noFleet: true }),
+    );
+
+    expect(result).toBe("01-mawjs:mawjs-oracle");
+    expect(sendTextCalls[0]?.target).toBe("01-mawjs:mawjs-oracle");
+    expect(sendTextCalls[0]?.text).toContain("ANTHROPIC_MODEL=claude-opus-4-8 command claude");
+    expect(sendTextCalls[0]?.text).not.toMatch(/(^|&&\s*)claude(\s|$)/);
+    expect(sendTextCalls[0]?.text).not.toContain("claude --agent");
   });
 
   test("#2661 --wait preserves engine-ready blocking for fresh session creation", async () => {


### PR DESCRIPTION
## Summary
- keep legacy commands maps when commands.default is absent and validate each command value independently
- make defaultEngine pass validation as the bare-wake source of truth while warning on genuine unresolved defaults
- preserve process detection for env-prefixed legacy commands and add wake integration coverage for -e claude48 using the configured opus launcher
- fix the coverage script mock-smoke path after the existing test file rename

Closes #2670

## Tests
- bun test test/config-validate.test.ts test/engine-registry.test.ts test/wake-cmd-cmdwake-coverage.test.ts test/isolated/tile.test.ts
- bun run test
- bun run test:coverage