### PR TITLE
Fix maw done installed-binary team plugin exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,8 @@
     "./commands/shared/wake-resolve": "./src/commands/shared/wake-resolve.ts",
     "./commands/shared/wake-target": "./src/commands/shared/wake-target.ts",
     "./commands/plugins/tmux/impl": "./src/commands/plugins/tmux/impl.ts",
+    "./vendor/mpr-plugins/team/team-charter": "./src/vendor/mpr-plugins/team/team-charter.ts",
+    "./vendor/mpr-plugins/team/team-liveness": "./src/vendor/mpr-plugins/team/team-liveness.ts",
     "./commands/shared/workspace": "./src/commands/shared/workspace.ts",
     "./core/transport/transport": "./src/core/transport/transport.ts",
     "./commands/shared/discovered-peers-client": "./src/commands/shared/discovered-peers-client.ts"


### PR DESCRIPTION
## Summary
- Add explicit package exports for `maw-js/vendor/mpr-plugins/team/team-charter` and `team-liveness`.
- Keeps runtime-loaded `maw done` plugin imports resolvable from the installed package binary.

Closes #2672

## Verification
- `bun link`
- Installed binary smoke: `/Users/nat/.local/bin/maw done maw-done-2672-smoke-82779 --force` against a throwaway tmux window (no `Cannot find module` crash)
- `MAW_TEST_MODE=1 bun test test/done-command.test.ts --coverage --coverage-reporter=lcov --coverage-dir=coverage/2672-done`
- `bun run build`
- `bun -e "await import('maw-js/vendor/mpr-plugins/team/team-charter'); await import('maw-js/vendor/mpr-plugins/team/team-liveness'); console.log('exports resolve')"`

## Notes
- Full no-arg `bun test` / default coverage sweep currently traverses tracked `agents/*` test copies and hits unrelated baseline failures; changed-surface tests and installed-binary smoke are green.