### PR TITLE
Guard local ghq scan against host-like fleet segments

### DIFF
--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -102,6 +102,20 @@ function repoNameFromPath(path: string): string {
   return path.split("/").pop() ?? "";
 }
 
+function isLikelyHostName(segment: string): boolean {
+  if (segment === "github.com") return true;
+  return /^[a-z0-9.-]+\.[a-z]{2,}$/i.test(segment);
+}
+
+function sanitizeFleetRepoForClone(slug: string): string | null {
+  const parts = slug.split("/").filter(Boolean);
+  if (parts.length !== 2) return null;
+  const [owner, repo] = parts;
+  if (!owner || !repo) return null;
+  if (isLikelyHostName(owner)) return null;
+  return `${owner}/${repo}`;
+}
+
 function repoSlugFromPath(path: string): string {
   const parts = path.split("/").filter(Boolean);
   return parts.length >= 2 ? parts.slice(-2).join("/") : repoNameFromPath(path);
@@ -285,13 +299,18 @@ export async function resolveOracle(
     for (const config of loadFleet()) {
       const win = (config.windows || []).find((w: FleetWindow) => w.name === `${oracle}-oracle` || w.name === oracle);
       if (win?.repo) {
-        const fullPath = await ghqFind(`/${win.repo.replace(/^[^/]+\//, "")}`);
+        const sanitizedFleetPin = sanitizeFleetRepoForClone(win.repo);
+        if (!sanitizedFleetPin) {
+          console.error(`\x1b[33m⚠\x1b[0m malformed fleet repo '${win.repo}' for ${win.name}; expected 'owner/repo'.`);
+          continue;
+        }
+        const fullPath = await ghqFind(`/${sanitizedFleetPin.replace(/^[^/]+\//, "")}`);
         if (fullPath) {
           const repoPath = fullPath;
           return { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
         }
         // Fleet knows the slug but it's not cloned yet — remember for step 3
-        fleetRepo = win.repo;
+        fleetRepo = sanitizedFleetPin;
       }
     }
   } catch { /* fleet dir may not exist */ }

--- a/src/core/fleet/registry-oracle-scan-local.ts
+++ b/src/core/fleet/registry-oracle-scan-local.ts
@@ -82,6 +82,20 @@ interface ScanLocalDeps {
   fleetLineage?: Map<string, FleetLineage>;
 }
 
+function isLikelyHostName(segment: string): boolean {
+  if (segment === "github.com") return true;
+  return /^[a-z0-9.-]+\.[a-z]{2,}$/i.test(segment);
+}
+
+function parseFleetRepoSlug(key: string): { org: string; repo: string } | null {
+  const parts = key.split("/").filter(Boolean);
+  if (parts.length !== 2) return null;
+  const [org, repo] = parts;
+  if (!org || !repo) return null;
+  if (isLikelyHostName(org)) return null;
+  return { org, repo };
+}
+
 /**
  * Scan local ghq for oracles. Verbose-by-default per user direction
  * (alpha.74, 2026-04-16) — pass verbose=false for the terse summary.
@@ -105,6 +119,10 @@ export function scanLocal(verbose = true, deps: ScanLocalDeps = {}): OracleEntry
   // Walk reposRoot: <reposRoot>/<org>/<repo>/
   try {
     for (const org of readdirSync(reposRoot)) {
+      if (isLikelyHostName(org)) {
+        if (verbose) console.log(`  \x1b[90m  ⏭ skipping host-like org segment: ${org}\x1b[0m`);
+        continue;
+      }
       const orgPath = join(reposRoot, org);
       try {
         if (!statSync(orgPath).isDirectory()) continue;
@@ -188,8 +206,9 @@ export function scanLocal(verbose = true, deps: ScanLocalDeps = {}): OracleEntry
   let fleetOnly = 0;
   for (const [key, lineage] of fleetLineage) {
     if (!seen.has(key)) {
-      const [org, repo] = key.split("/");
-      if (org && repo) {
+      const parsed = parseFleetRepoSlug(key);
+      if (parsed) {
+        const { org, repo } = parsed;
         fleetOnly++;
         if (verbose) {
           console.log(`  \x1b[90m  + ${key}\x1b[0m [\x1b[36mfleet-only\x1b[0m] (not cloned)`);

--- a/test/registry-oracle-scan-local.test.ts
+++ b/test/registry-oracle-scan-local.test.ts
@@ -140,6 +140,41 @@ describe("registry-oracle-scan-local", () => {
     });
   });
 
+  test("scanLocal ignores host-like org segments at ghq root", () => {
+    const root = tmpRoot("host-org");
+    const ghqRoot = join(root, "ghq");
+    const fleetDir = join(root, "fleet");
+    mkdirp(fleetDir);
+    mkdirp(join(ghqRoot, "github.com", "Soul-Brews-Studio"));
+
+    makeRepo(ghqRoot, "Soul-Brews-Studio", "valid-oracle", { psi: true });
+    makeRepo(ghqRoot, "github.com", "laris-co", { psi: true });
+
+    writeJson(join(fleetDir, "fleet.json"), {
+      project_repos: [],
+      windows: [],
+    });
+
+    const entries = scanLocal(false, { ghqRoot, fleetDir });
+
+    expect(entries.map((entry) => `${entry.org}/${entry.repo}`)).toEqual(["Soul-Brews-Studio/valid-oracle"]);
+  });
+
+  test("scanLocal treats malformed fleet lineage key github.com/owner as non-oracle", () => {
+    const root = tmpRoot("malformed-lineage");
+    const ghqRoot = join(root, "ghq");
+    const fleetDir = join(root, "fleet");
+    mkdirp(fleetDir);
+
+    writeJson(join(fleetDir, "fleet.json"), {
+      project_repos: ["github.com/laris-co"],
+    });
+
+    const entries = scanLocal(false, { ghqRoot, fleetDir });
+
+    expect(entries).toHaveLength(0);
+  });
+
   test("scanLocal verbose mode reports scan sources, fleet-only refs, enrichment, and walk failures", () => {
     const root = tmpRoot("verbose");
     const ghqRoot = join(root, "ghq");

--- a/test/wake-resolve-impl-runtime-coverage.test.ts
+++ b/test/wake-resolve-impl-runtime-coverage.test.ts
@@ -321,6 +321,29 @@ describe("resolveOracle runtime paths", () => {
     expect(logs.some((line) => line.includes("found at /repos/Org/special-oracle"))).toBe(true);
   });
 
+  test("skips malformed fleet slug (owner-only) and still resolves via fallback org scan", async () => {
+    writeFleet("12-special", [{ name: "special-oracle", repo: "github.com/laris-co" }]);
+    config.githubOrgs = ["Soul-Brews-Studio"];
+    hostExecImpl = async (cmd) => {
+      if (cmd.includes("gh repo view 'Soul-Brews-Studio/special-oracle'")) return '{"name":"special-oracle"}';
+      if (cmd.includes("ghq get -u 'github.com/Soul-Brews-Studio/special-oracle'")) {
+        ghqFindMap["/special-oracle"] = "/repos/Soul-Brews-Studio/special-oracle";
+      }
+      return "";
+    };
+
+    await expect(resolveOracle("special")).resolves.toEqual({
+      repoPath: "/repos/Soul-Brews-Studio/special-oracle",
+      repoName: "special-oracle",
+      parentDir: "/repos/Soul-Brews-Studio",
+    });
+
+    expect(hostExecCalls.some((cmd) => cmd.includes("ghq get 'github.com/github.com/laris-co'"))).toBe(false);
+    expect(hostExecCalls.some((cmd) => cmd.includes("ghq get 'github.com/laris-co'"))).toBe(false);
+    expect(errors.some((line) => line.includes("malformed fleet repo 'github.com/laris-co'"))).toBe(true);
+    expect(hostExecCalls.some((cmd) => cmd.includes("ghq get -u 'github.com/Soul-Brews-Studio/special-oracle'"))).toBe(true);
+  });
+
   test("re-checks fleet-pinned repos before cloning and reports failed fleet clones", async () => {
     writeFleet("12-special", [{ name: "special-oracle", repo: "Org/special-oracle" }]);
     let findCount = 0;


### PR DESCRIPTION
Guard local scanner/wake path against host-like fleet lineage and owner-only slugs.

Closes #2675