### PR TITLE
Fix null command tombstones

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+pathIgnorePatterns = ["**/agents/**", "agents/**"]
+testPathIgnorePatterns = ["**/agents/**", "agents/**"]

--- a/scripts/test-default-safe.sh
+++ b/scripts/test-default-safe.sh
@@ -140,7 +140,7 @@ if [ "${#REQUESTED_FILES[@]}" -gt 0 ]; then
   for f in "${REQUESTED_FILES[@]}"; do
     [[ "$f" == test/helpers/* ]] && continue
     [[ "$f" == test/isolated/* ]] && continue
-    [[ "$f" == *"/agents/"* ]] && continue
+    [[ "$f" == agents/* || "$f" == *"/agents/"* ]] && continue
     [[ "$f" == test/zz-mock-tmux-smoke.test.ts ]] && continue
     [[ "$f" == test/zz-mock-transport-smoke.test.ts ]] && continue
     ALL_TEST_FILES+=("$f")
@@ -150,11 +150,11 @@ else
   while IFS= read -r f; do
     [[ -n "$f" ]] && ALL_TEST_FILES+=("$f")
   done < <(
-    git ls-files -- 'test/*.ts' 'test/**/*.ts' |
+    git ls-files -- ':(top)test/*.ts' ':(top)test/**/*.ts' |
       while IFS= read -r f; do
         [[ "$f" == test/helpers/* ]] && continue
         [[ "$f" == test/isolated/* ]] && continue
-        [[ "$f" == *"/agents/"* ]] && continue
+        [[ "$f" == agents/* || "$f" == *"/agents/"* ]] && continue
         [[ "$f" == test/zz-mock-tmux-smoke.test.ts ]] && continue
         [[ "$f" == test/zz-mock-transport-smoke.test.ts ]] && continue
         printf '%s\n' "$f"

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -62,15 +62,20 @@ export function validateBasicFields(
     }
   }
 
-  // commands: Record<string, string>. `commands.default` is optional: the
-  // no-engine fallback is selected by defaultEngine/defaultEngineNameForConfig.
+  // commands: Record<string, string | null> per layer. `null` is a tombstone
+  // that must survive validation so deepMerge can delete inherited commands.
+  // Final merged config.commands remains string-only after tombstones apply.
   if ("commands" in raw) {
     if (raw.commands && typeof raw.commands === "object" && !Array.isArray(raw.commands)) {
       const cmds = raw.commands as Record<string, unknown>;
-      const validCommands: Record<string, string> = {};
+      const validCommands: Record<string, string | null> = {};
       for (const [name, value] of Object.entries(cmds)) {
+        if (value === null) {
+          validCommands[name] = null;
+          continue;
+        }
         if (typeof value !== "string") {
-          warn(`commands.${name}`, "must be a string");
+          warn(`commands.${name}`, "must be a string or null");
           continue;
         }
         validCommands[name] = value;
@@ -214,10 +219,10 @@ export function validateConfigShape(config: unknown): string[] {
 
   if (c.commands !== undefined) {
     if (!c.commands || typeof c.commands !== "object" || Array.isArray(c.commands)) {
-      errors.push("commands must be a Record<string, string>");
+      errors.push("commands must be a Record<string, string | null>");
     } else {
       for (const [k, v] of Object.entries(c.commands as Record<string, unknown>)) {
-        if (typeof v !== "string") errors.push(`commands.${k} must be a string`);
+        if (v !== null && typeof v !== "string") errors.push(`commands.${k} must be a string or null`);
       }
     }
   }

--- a/test/config-command-tombstone.test.ts
+++ b/test/config-command-tombstone.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runBunChild } from "./isolated/helpers/run-bun-child";
+
+function run(script: string, cwd: string, env: Record<string, string>) {
+  return runBunChild({
+    cwd,
+    script,
+    env: { ...process.env, MAW_TEST_MODE: "1", MAW_QUIET: "1", ...env },
+  });
+}
+
+function resultJson(stdout: string) {
+  const line = stdout.split("\n").find((entry) => entry.startsWith("RESULT:"));
+  expect(line).toBeTruthy();
+  return JSON.parse(line!.slice("RESULT:".length));
+}
+
+describe("command null tombstones (#2674)", () => {
+  test("project commands.foo:null deletes a user-layer commands.foo value", () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "maw-command-tombstone-"));
+    try {
+      const mawHome = join(sandbox, "home");
+      const repo = join(sandbox, "repo");
+      mkdirSync(join(mawHome, "config"), { recursive: true });
+      mkdirSync(join(repo, ".maw"), { recursive: true });
+      writeFileSync(join(mawHome, "config", "maw.config.50.json"), JSON.stringify({
+        commands: { default: "claude", foo: "bar" },
+      }));
+      writeFileSync(join(repo, ".maw", "maw.config.80.json"), JSON.stringify({
+        commands: { foo: null },
+      }));
+
+      const result = run(`
+        const { loadConfigWithProvenance } = await import(${JSON.stringify(`${process.cwd()}/src/config.ts`)});
+        const loaded = loadConfigWithProvenance({ cwd: ${JSON.stringify(repo)} });
+        console.log("RESULT:" + JSON.stringify({
+          commands: loaded.config.commands,
+          fooProvenance: loaded.provenance["commands.foo"],
+        }));
+      `, repo, { MAW_HOME: mawHome });
+
+      expect(result.code).toBe(0);
+      const payload = resultJson(result.stdout);
+      expect(payload.commands).toEqual({ default: "claude" });
+      expect(payload.fooProvenance.at(-1).action).toBe("delete");
+      expect(payload.fooProvenance.at(-1).value).toBeNull();
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  test("null command values emit no string-type warning", () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "maw-command-null-warning-"));
+    try {
+      const mawHome = join(sandbox, "home");
+      const repo = join(sandbox, "repo");
+      mkdirSync(join(mawHome, "config"), { recursive: true });
+      mkdirSync(join(repo, ".maw"), { recursive: true });
+      writeFileSync(join(mawHome, "config", "maw.config.50.json"), JSON.stringify({
+        commands: { default: "claude", foo: "bar" },
+      }));
+      writeFileSync(join(repo, ".maw", "maw.config.80.json"), JSON.stringify({
+        commands: { foo: null },
+      }));
+
+      const result = run(`
+        const { loadConfig } = await import(${JSON.stringify(`${process.cwd()}/src/config.ts`)});
+        loadConfig({ cwd: ${JSON.stringify(repo)} });
+        console.log("RESULT:" + JSON.stringify({ ok: true }));
+      `, repo, { MAW_HOME: mawHome });
+
+      expect(result.code).toBe(0);
+      expect(result.stderr).not.toContain("commands.foo must be a string");
+      expect(result.stderr).not.toContain("commands.foo must be a string or null");
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  test("non-string non-null command values still warn and are stripped", () => {
+    const mawHome = mkdtempSync(join(tmpdir(), "maw-command-invalid-"));
+    try {
+      const result = run(`
+        const { validateConfig } = await import(${JSON.stringify(`${process.cwd()}/src/config/validate-ext.ts`)});
+        const validated = validateConfig({
+          commands: { default: "run", num: 1, obj: {}, arr: [] },
+        });
+        console.log("RESULT:" + JSON.stringify({ commands: validated.commands }));
+      `, process.cwd(), { MAW_HOME: mawHome });
+
+      expect(result.code).toBe(0);
+      expect(resultJson(result.stdout).commands).toEqual({ default: "run" });
+      expect(result.stderr).toContain("commands.num must be a string or null");
+      expect(result.stderr).toContain("commands.obj must be a string or null");
+      expect(result.stderr).toContain("commands.arr must be a string or null");
+    } finally {
+      rmSync(mawHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/config-validate.test.ts
+++ b/test/config-validate.test.ts
@@ -73,7 +73,7 @@ describe("validateBasicFields", () => {
     const cases = [
       [{ env: [] }, "env: must be an object"],
       [{ commands: [] }, "commands: must be an object"],
-      [{ commands: { default: 123 } }, "commands.default: must be a string"],
+      [{ commands: { default: 123 } }, "commands.default: must be a string or null"],
       [{ engines: [] }, "engines: must be an object"],
       [{ engines: { codex: false } }, "engines.codex: must be an object"],
       [{ engines: { codex: { cmd: "" } } }, "engines.codex.cmd: must be a non-empty string"],
@@ -186,14 +186,14 @@ describe("validateConfigShape", () => {
   test("reports invalid object maps and nested values", () => {
     expect(validateConfigShape({
       env: { GOOD: "ok", BAD: 1 },
-      commands: { default: "claude", bad: false },
+      commands: { default: "claude", tombstone: null, bad: false },
       engines: { nope: false, broken: { cmd: "" }, badName: { name: 7, cmd: "tool" } },
       sessions: { ok: "54-mawjs", bad: 2 },
       errorForward: { target: 8 },
     })).toEqual([
       "errorForward.target must be a string",
       "env.BAD must be a string",
-      "commands.bad must be a string",
+      "commands.bad must be a string or null",
       "engines.nope must be an object",
       "engines.broken.cmd must be a non-empty string",
       "engines.badName.name must be a string",
@@ -202,7 +202,7 @@ describe("validateConfigShape", () => {
 
     expect(validateConfigShape({ env: [], commands: null, sessions: [] })).toEqual([
       "env must be a Record<string, string>",
-      "commands must be a Record<string, string>",
+      "commands must be a Record<string, string | null>",
       "sessions must be a Record<string, string>",
     ]);
   });

--- a/test/repo-discovery.test.ts
+++ b/test/repo-discovery.test.ts
@@ -177,20 +177,15 @@ describe("findBySuffix — contract", () => {
     expect(withDollar).toBe(without);
   });
 
-  test("GhqDiscovery itself literalizes $ (the real, not mocked, impl)", () => {
-    // Exercise the *real* adapter's literalize guard without spawning ghq:
-    // findBySuffixSync delegates to listSync() which returns [] when ghq
-    // is absent — but the code path that strips $ still runs. A suffix
-    // that won't match anything regardless lets us assert "returns null,
-    // doesn't throw" on both forms.
-    expect(() => GhqDiscovery.findBySuffixSync("/xxx-no-such-repo$")).not.toThrow();
-    expect(() => GhqDiscovery.findBySuffixSync("/xxx-no-such-repo")).not.toThrow();
-    // Both produce the same sentinel (either null or a real path), never
-    // diverge — if literalize regressed, "$" form would always be null
-    // while bare form might be a string. Same-value equality catches it.
-    expect(GhqDiscovery.findBySuffixSync("/xxx-no-such-repo$")).toBe(
-      GhqDiscovery.findBySuffixSync("/xxx-no-such-repo"),
-    );
+  test("GhqDiscovery itself literalizes $ without hitting the real ghq backend", () => {
+    const originalListSync = GhqDiscovery.listSync;
+    try {
+      GhqDiscovery.listSync = () => ["/home/user/Code/github.com/org/foo"];
+      expect(GhqDiscovery.findBySuffixSync("/foo$")).toBe("/home/user/Code/github.com/org/foo");
+      expect(GhqDiscovery.findBySuffixSync("/foo")).toBe("/home/user/Code/github.com/org/foo");
+    } finally {
+      GhqDiscovery.listSync = originalListSync;
+    }
   });
 
   test("no match returns null (not undefined, not empty string)", async () => {


### PR DESCRIPTION
Closes #2674

## Summary
- Preserve per-layer `commands.*: null` values through config validation so `deepMerge` can delete inherited command keys.
- Keep invalid non-string/non-null command values warning and stripped.
- Add regression coverage for tombstone deletion, no warning on null, and invalid-value warnings.
- Ignore `agents/**` worktree copies in Bun test discovery and make the ghq literalize test deterministic.

## Verification
- `bun test test/config-command-tombstone.test.ts test/config-validate.test.ts test/repo-discovery.test.ts --path-ignore-patterns '**/agents/**'`\n- `bun run test`\n- `bun run build`