### PR TITLE
Suggest maw work when wake misses inside a repo

### DIFF
--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -14,6 +14,27 @@ import type { Session } from "../../core/runtime/find-window";
 
 const DEFAULT_WAKE_FLEET_GHQ_GET_TIMEOUT_MS = 10_000;
 
+export function cwdWorkHint(cwd: string, gitToplevel: string | null | undefined): string | null {
+  if (!cwd.trim()) return null;
+  const top = gitToplevel?.trim();
+  if (!top) return null;
+  const repoName = top.replace(/[\\/]+$/, "").split(/[\\/]/).pop() ?? "";
+  if (!repoName) return null;
+  return `  or:  maw work   — wake the current directory (${repoName}) in work mode`;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+async function resolveGitToplevel(cwd: string): Promise<string | null> {
+  try {
+    return (await hostExec(`git -C ${shellQuote(cwd)} rev-parse --show-toplevel 2>/dev/null`)).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 function wakeFleetGhqGetTimeoutMs(): number {
   const raw = process.env.MAW_WAKE_GHQ_GET_TIMEOUT_MS;
   if (raw === undefined) return DEFAULT_WAKE_FLEET_GHQ_GET_TIMEOUT_MS;
@@ -429,7 +450,12 @@ export async function resolveOracle(
     if (scanned) return scanned;
   } catch { /* scan suggest failed — fall through to original error */ }
 
-  console.error(`oracle repo not found: ${oracle} (tried ghq, fleet configs, worktree scan, GitHub clone, and ${(loadConfig().peers || []).length} peers — try: maw bud ${oracle}  OR  ghq get <url>)`);
+  const peerCount = (loadConfig().peers || []).length;
+  const workHint = cwdWorkHint(process.cwd(), await resolveGitToplevel(process.cwd()));
+  console.error([
+    `oracle repo not found: ${oracle} (tried ghq, fleet configs, worktree scan, GitHub clone, and ${peerCount} peers — try: maw bud ${oracle}  OR  ghq get <url>)`,
+    workHint,
+  ].filter(Boolean).join("\n"));
   process.exit(1);
 }
 

--- a/test/wake-resolve-impl-default.test.ts
+++ b/test/wake-resolve-impl-default.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  cwdWorkHint,
   resolveFromWorktrees,
   resolveLocalOracleRepoName,
   sanitizeBranchName,
@@ -9,6 +10,18 @@ import type { WorktreeInfo } from "../src/core/fleet/worktrees-scan";
 // Default coverage command only collects test/*.test.ts. Keep these tests free
 // of Bun module mocks: the colocated resolver suite mocks sdk/config globally,
 // which can pollute unrelated default-run suites when CI test ordering changes.
+
+describe("cwdWorkHint (#2679) — pure hint helper", () => {
+  it("suggests maw work with the cwd repo basename when inside a git repo", () => {
+    expect(cwdWorkHint("/tmp/ignored/subdir", "/opt/Code/github.com/Soul-Brews-Studio/maw-js")).toContain("maw work");
+    expect(cwdWorkHint("/tmp/ignored/subdir", "/opt/Code/github.com/Soul-Brews-Studio/maw-js")).toContain("maw-js");
+  });
+
+  it("returns null when cwd is not inside a git repo", () => {
+    expect(cwdWorkHint("/tmp/not-a-repo", null)).toBeNull();
+    expect(cwdWorkHint("/tmp/not-a-repo", "")).toBeNull();
+  });
+});
 
 describe("sanitizeBranchName (#823 Bug A) — default coverage", () => {
   it("strips all leading and trailing dash/dot runs", () => {

--- a/test/wake-resolve-impl-runtime-coverage.test.ts
+++ b/test/wake-resolve-impl-runtime-coverage.test.ts
@@ -435,6 +435,22 @@ describe("resolveOracle runtime paths", () => {
 
     expect(errors.some((line) => line.includes("oracle repo not found: missing"))).toBe(true);
     expect(errors.some((line) => line.includes("2 peers"))).toBe(true);
+    expect(errors.some((line) => line.includes("maw work"))).toBe(false);
+    expect(exitCalls).toContain(1);
+  });
+
+  test("adds a maw work hint on not-found when cwd is inside a git repo", async () => {
+    hostExecImpl = async (cmd) => {
+      if (cmd.includes("rev-parse --show-toplevel")) return "/opt/Code/github.com/Soul-Brews-Studio/maw-js\n";
+      throw new Error("not found");
+    };
+
+    await expect(resolveOracle("typoed-name")).resolves.toBeUndefined();
+
+    const errorText = errors.join("\n");
+    expect(errorText).toContain("oracle repo not found: typoed-name");
+    expect(errorText).toContain("maw work");
+    expect(errorText).toContain("maw-js");
     expect(exitCalls).toContain(1);
   });
 });


### PR DESCRIPTION
Closes #2679

## Summary
- add pure cwdWorkHint helper for hint-only current-repo guidance
- append the maw work hint only when wake misses from inside a git repo
- keep not-found wake failing with exit(1), with no cwd auto-fallback

## Tests
- bun test test/wake-resolve-impl-default.test.ts test/wake-resolve-impl-runtime-coverage.test.ts
- bun run test
- bun run build