### PR TITLE
wake: rank duplicate-name local oracle disambiguation by recency + live session

### DIFF
--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -1,7 +1,12 @@
 import { hostExec, tmux, curlFetch } from "../../sdk";
 import { loadConfig, getEnvVars } from "../../config";
 import { ghqFind, ghqList } from "../../core/ghq";
-import { pickOracle, resolveOracle as resolveSharedOracle, type OracleRef } from "../../core/resolve";
+import {
+  pickOracle,
+  rankOracleCandidates,
+  resolveOracle as resolveSharedOracle,
+  type OracleRef,
+} from "../../core/resolve";
 import { resolveNumericFleetStemPrefix, resolveSessionTarget } from "../../core/matcher/resolve-target";
 import { isInfrastructureChannelSessionName } from "../../core/matcher/channel-session";
 import { readdirSync, existsSync, statSync } from "fs";
@@ -255,6 +260,55 @@ function repoInfoFromOracleRef(ref: OracleRef): { repoPath: string; repoName: st
   return { repoPath: ref.path, repoName: ref.repo, parentDir: ref.path.replace(/\/[^/]+$/, "") };
 }
 
+function normalizeCandidatePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function candidatePathFromRef(ref: OracleRef): string | null {
+  return ref.path ? normalizeCandidatePath(ref.path) : null;
+}
+
+function pathLooksInside(cwd: string, candidatePath: string): boolean {
+  const normalizedCwd = normalizeCandidatePath(cwd);
+  return normalizedCwd === candidatePath || normalizedCwd.startsWith(`${candidatePath}/`);
+}
+
+function relativeTimeFromNow(now: number, thenMs: number): string {
+  if (!Number.isFinite(thenMs) || thenMs <= 0) return "never";
+  const diffMs = Math.max(0, now - thenMs);
+  const sec = Math.floor(diffMs / 1000);
+  const min = Math.floor(sec / 60);
+  const hr = Math.floor(min / 60);
+  const day = Math.floor(hr / 24);
+  if (day > 0) return `${day}d ago`;
+  if (hr > 0) return `${hr}h ago`;
+  if (min > 0) return `${min}m ago`;
+  return `${sec}s ago`;
+}
+
+async function liveOracleCandidates(candidates: OracleRef[]): Promise<Set<string>> {
+  const out = new Set<string>();
+  const candidatePaths = candidates
+    .map(candidatePathFromRef)
+    .filter((path): path is string => Boolean(path));
+  if (candidatePaths.length === 0) return out;
+
+  try {
+    const panes = await tmux.listPanes();
+    for (const pane of panes) {
+      if (!pane.cwd) continue;
+      const cwd = pane.cwd;
+      for (const candidatePath of candidatePaths) {
+        if (pathLooksInside(cwd, candidatePath)) out.add(candidatePath);
+      }
+    }
+  } catch {
+    return out;
+  }
+
+  return out;
+}
+
 async function resolveLocalOracleWithPicker(
   oracle: string,
 ): Promise<{ repoPath: string; repoName: string; parentDir: string; fuzzy: boolean } | null> {
@@ -282,11 +336,35 @@ async function resolveLocalOracleWithPicker(
     return info ? { ...info, fuzzy } : null;
   }
 
-  console.error(`\x1b[33m⚠\x1b[0m '${oracle}' matches ${result.candidates.length} local oracles:`);
-  for (const c of result.candidates) console.error(`\x1b[90m    • ${oracleSlug(c)}\x1b[0m`);
+  const now = Date.now();
+  const liveSessions = await liveOracleCandidates(result.candidates);
+  const ranked = rankOracleCandidates(result.candidates, { liveSessions, now });
+
+  console.error(`\x1b[33m⚠\x1b[0m '${oracle}' matches ${result.candidates.length} local oracles (ranked by live session + recent activity):`);
+  ranked.forEach((candidate, index) => {
+    const label = candidate.recommended
+      ? "\x1b[33m⭐ recommended\x1b[0m"
+      : "";
+    const live = candidate.hasLiveSession
+      ? "\x1b[32m● live session\x1b[0m"
+      : "";
+    const markerText = [label, live].filter(Boolean);
+    const markers = markerText.length
+      ? `    ${markerText.join(" \x1b[90m·\x1b[0m")} `
+      : "";
+    console.error(`  \x1b[36m${index + 1}\x1b[0m) \x1b[90m${oracleSlug(candidate)}\x1b[0m ${markers}`.trimEnd());
+    if (candidate.path) console.error(`    \x1b[90m${candidate.path}\x1b[0m`);
+    const details: string[] = [];
+    if (candidate.hasLiveSession) details.push("live session");
+    if (candidate.lastActivityMs) details.push(`edited ${relativeTimeFromNow(now, candidate.lastActivityMs)}`);
+    if (details.length) console.error(`       ${details.join(" \x1b[90m·\x1b[0m ")}`);
+  });
 
   if (isInteractivePickerAvailable()) {
-    const picked = await pickOracle(result.candidates);
+    const picked = await pickOracle(result.candidates, {
+      liveSessions,
+      now,
+    });
     const info = picked ? repoInfoFromOracleRef(picked) : null;
     if (info) return { ...info, fuzzy: false };
     console.error(`\x1b[90m  aborted\x1b[0m`);

--- a/src/core/resolve.ts
+++ b/src/core/resolve.ts
@@ -1,4 +1,6 @@
 import { ghqList } from "./ghq";
+import { lstatSync, readdirSync, statSync } from "fs";
+import { join } from "path";
 
 export type OracleRef = { owner: string; repo: string; path?: string };
 
@@ -17,6 +19,21 @@ export type ResolveOracleOptions = {
 export type PickOracleOptions = {
   stream?: Pick<NodeJS.WriteStream, "write">;
   reader?: NodeJS.ReadStream;
+  now?: number;
+  liveSessions?: Set<string>;
+  getLastActivityMs?: (path: string) => number;
+};
+
+export type RankedOracleCandidate = OracleRef & {
+  recommended: boolean;
+  lastActivityMs: number;
+  hasLiveSession: boolean;
+};
+
+type RankOracleOptions = {
+  liveSessions?: Set<string>;
+  now?: number;
+  getLastActivityMs?: (path: string) => number;
 };
 
 function repoNameFromPath(path: string): string {
@@ -68,6 +85,98 @@ function compareRefs(pwdHint?: { owner: string; repo: string }) {
     }
     return refSlug(a).localeCompare(refSlug(b));
   };
+}
+
+function normalizeRepoPath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function defaultGetLastActivityMs(path: string): number {
+  let latest = 0;
+  const root = normalizeRepoPath(path);
+
+  const walk = (entry: string): void => {
+    try {
+      const stat = lstatSync(entry);
+      const mtime = stat.mtimeMs;
+      if (mtime > latest) latest = mtime;
+      if (!stat.isDirectory()) return;
+      const base = entry.split("/").pop() ?? "";
+      if (base === ".git") return;
+    } catch {
+      return;
+    }
+
+    let childEntries: string[];
+    try {
+      childEntries = readdirSync(entry);
+    } catch {
+      return;
+    }
+
+    for (const child of childEntries) {
+      if (child === ".git") continue;
+      walk(join(entry, child));
+    }
+  };
+
+  walk(root);
+  return latest;
+}
+
+function rankOracleCandidatePath(ref: OracleRef, liveSessions: Set<string>): boolean {
+  if (!ref.path) return false;
+  const normalized = normalizeRepoPath(ref.path);
+  return liveSessions.has(normalized);
+}
+
+function compareOracleCandidates(a: RankedOracleCandidate, b: RankedOracleCandidate): number {
+  if (a.hasLiveSession !== b.hasLiveSession) return a.hasLiveSession ? -1 : 1;
+  if (a.lastActivityMs !== b.lastActivityMs) return b.lastActivityMs - a.lastActivityMs;
+  return refSlug(a).localeCompare(refSlug(b));
+}
+
+function relativeTimeFromMs(now: number, lastActivityMs: number): string {
+  if (!Number.isFinite(lastActivityMs) || lastActivityMs <= 0) return "never";
+  const diffMs = Math.max(0, now - lastActivityMs);
+  const sec = Math.floor(diffMs / 1000);
+  const min = Math.floor(sec / 60);
+  const hr = Math.floor(min / 60);
+  const day = Math.floor(hr / 24);
+  if (day > 0) return `${day}d ago`;
+  if (hr > 0) return `${hr}h ago`;
+  if (min > 0) return `${min}m ago`;
+  return `${sec}s ago`;
+}
+
+export function rankOracleCandidates(
+  candidates: OracleRef[],
+  opts: RankOracleOptions = {},
+): RankedOracleCandidate[] {
+  const now = opts.now ?? Date.now();
+  const liveSessions = opts.liveSessions
+    ? new Set([...opts.liveSessions].map(normalizeRepoPath))
+    : new Set<string>();
+  const getLastActivityMs = opts.getLastActivityMs ?? defaultGetLastActivityMs;
+
+  const ranked = candidates.map((candidate) => {
+    const normalizedPath = candidate.path ? normalizeRepoPath(candidate.path) : null;
+    const lastActivityMs = normalizedPath ? getLastActivityMs(normalizedPath) : 0;
+    const hasLiveSession = normalizedPath ? liveSessions.has(normalizedPath) : false;
+    return {
+      ...candidate,
+      path: normalizedPath ?? candidate.path,
+      lastActivityMs,
+      hasLiveSession,
+      recommended: false,
+    };
+  });
+
+  ranked.sort(compareOracleCandidates);
+  return ranked.map((candidate, index) => ({
+    ...candidate,
+    recommended: index === 0,
+  }));
 }
 
 function uniqueRefs(refs: OracleRef[]): OracleRef[] {
@@ -167,13 +276,36 @@ function readChoiceFromTty(): string {
 export async function pickOracle(candidates: OracleRef[], opts: PickOracleOptions = {}): Promise<OracleRef | null> {
   const stream = opts.stream ?? process.stdout;
   if (candidates.length === 0) return null;
+  const ranked = rankOracleCandidates(candidates, {
+    now: opts.now,
+    liveSessions: opts.liveSessions,
+    getLastActivityMs: opts.getLastActivityMs,
+  });
+
   stream.write("\n  Wake which oracle?\n");
-  candidates.forEach((candidate, index) => {
-    const suffix = candidate.path ? ` \x1b[90m${candidate.path}\x1b[0m` : "";
-    stream.write(`  \x1b[36m${index + 1}\x1b[0m) ${refSlug(candidate)}${suffix}\n`);
+  const now = opts.now ?? Date.now();
+  ranked.forEach((candidate, index) => {
+    const label = candidate.recommended
+      ? `    \x1b[33m⭐ recommended\x1b[0m`
+      : "";
+    const live = candidate.hasLiveSession
+      ? `\x1b[32m● live session\x1b[0m`
+      : "";
+    const markers = [label, live].filter(Boolean);
+    const markerText = markers.length ? `    ${markers.join(" \x1b[90m·\x1b[0m")} ` : "";
+    const pathText = candidate.path ? ` \x1b[90m${candidate.path}\x1b[0m` : "";
+    const activity = candidate.lastActivityMs
+      ? `\x1b[90medited ${relativeTimeFromMs(now, candidate.lastActivityMs)}\x1b[0m`
+      : "";
+    const detail = [markerText, pathText].filter(Boolean).join(" ");
+    const extra = [activity].filter(Boolean).join(" ");
+
+    stream.write(`  \x1b[36m${index + 1}\x1b[0m) ${refSlug(candidate)}${detail ? ` ${detail}` : ""}`);
+    if (extra) stream.write(`\n       ${extra}`);
+    stream.write("\n");
   });
   stream.write("\n");
-  stream.write(`  Select [1-${candidates.length}]: `);
+  stream.write(`  Select [1-${candidates.length}] (Enter = 1): `);
 
   let raw = "";
   try {
@@ -181,9 +313,11 @@ export async function pickOracle(candidates: OracleRef[], opts: PickOracleOption
   } catch {
     return null;
   }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return ranked[0] ?? null;
   const choice = Number.parseInt(raw.trim(), 10);
   if (!Number.isInteger(choice) || choice < 1 || choice > candidates.length) return null;
-  return candidates[choice - 1] ?? null;
+  return ranked[choice - 1] ?? null;
 }
 
 export const _test = {
@@ -191,4 +325,6 @@ export const _test = {
   repoNameFromPath,
   refSlug,
   normalizedIntentNames,
+  rankOracleCandidates,
+  _rankRelativeTime: relativeTimeFromMs,
 };

--- a/test/core-resolve.test.ts
+++ b/test/core-resolve.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Readable } from "stream";
-import { pickOracle, resolveOracle } from "../src/core/resolve";
+import { pickOracle, rankOracleCandidates, resolveOracle } from "../src/core/resolve";
 
 const repos = [
   "/opt/Code/github.com/Soul-Brews-Studio/mother-oracle",
@@ -56,6 +56,56 @@ describe("core resolveOracle", () => {
 });
 
 describe("pickOracle", () => {
+  test("rankOracleCandidates prefers live sessions then recent activity and stable slug order", () => {
+    const candidates = [
+      { owner: "arkkra-co", repo: "volt-oracle", path: "/gh/arkkra-co/volt-oracle" },
+      { owner: "laris-co", repo: "volt-oracle", path: "/gh/laris-co/volt-oracle" },
+      { owner: "soul-brews-studio", repo: "volt-oracle", path: "/gh/soul-brews-studio/volt-oracle" },
+    ];
+    const now = 12_000_000;
+    const before = candidates.map(c => `${c.owner}/${c.repo}`);
+    const after = rankOracleCandidates(candidates, {
+      liveSessions: new Set(["/gh/laris-co/volt-oracle"]),
+      now,
+      getLastActivityMs: (path) => {
+        if (path.endsWith("arkkra-co/volt-oracle")) return now - 11 * 60 * 60 * 1000;
+        if (path.endsWith("laris-co/volt-oracle")) return now - 2 * 60 * 1000;
+        return now - 3 * 24 * 60 * 60 * 1000;
+      },
+    }).map(c => ({
+      slug: `${c.owner}/${c.repo}`,
+      recommended: c.recommended,
+      hasLiveSession: c.hasLiveSession,
+      lastActivityMs: c.lastActivityMs,
+    }));
+
+    expect(before).toEqual([
+      "arkkra-co/volt-oracle",
+      "laris-co/volt-oracle",
+      "soul-brews-studio/volt-oracle",
+    ]);
+    expect(after.map(c => c.slug)).toEqual([
+      "laris-co/volt-oracle",
+      "arkkra-co/volt-oracle",
+      "soul-brews-studio/volt-oracle",
+    ]);
+    expect(after[0]!.slug).toBe("laris-co/volt-oracle");
+    expect(after[0]!.recommended).toBe(true);
+    expect(after[0]!.hasLiveSession).toBe(true);
+
+    // Deterministic tie-break when activity is equal and no live sessions are present.
+    const tieOrdered = rankOracleCandidates(candidates, {
+      now,
+      getLastActivityMs: () => now - 60_000,
+    });
+    expect(tieOrdered[0]!.recommended).toBe(true);
+    expect(tieOrdered.map(c => `${c.owner}/${c.repo}`)).toEqual([
+      "arkkra-co/volt-oracle",
+      "laris-co/volt-oracle",
+      "soul-brews-studio/volt-oracle",
+    ]);
+  });
+
   test("returns selected candidate from injected reader", async () => {
     const writes: string[] = [];
     const selected = await pickOracle([
@@ -66,9 +116,22 @@ describe("pickOracle", () => {
       reader: Readable.from(["2\n"]) as NodeJS.ReadStream,
     });
 
-    expect(selected).toEqual({ owner: "two", repo: "alpha-oracle" });
+    expect(selected).toMatchObject({ owner: "two", repo: "alpha-oracle" });
     expect(writes.join("")).toContain("Wake which oracle?");
     expect(writes.join("")).toContain("two/alpha-oracle");
+  });
+
+  test("defaults to rank #1 on Enter", async () => {
+    const selected = await pickOracle([
+      { owner: "one", repo: "alpha-oracle", path: "/gh/one/alpha-oracle" },
+      { owner: "two", repo: "alpha-oracle", path: "/gh/two/alpha-oracle" },
+    ], {
+      stream: { write: () => true },
+      liveSessions: new Set(["/gh/two/alpha-oracle"]),
+      reader: Readable.from(["\n"]) as NodeJS.ReadStream,
+    });
+
+    expect(selected).toMatchObject({ owner: "two", repo: "alpha-oracle", path: "/gh/two/alpha-oracle" });
   });
 
   test("returns null for invalid choices", async () => {

--- a/test/isolated/core-resolve-next-coverage.test.ts
+++ b/test/isolated/core-resolve-next-coverage.test.ts
@@ -126,7 +126,14 @@ describe("core resolve next coverage", () => {
       reader: Readable.from(["1"]) as NodeJS.ReadStream,
     });
 
-    expect(selected).toEqual({ owner: "one", repo: "neo-oracle", path: "/gh/one/neo-oracle" });
+    expect(selected).toMatchObject({
+      owner: "one",
+      repo: "neo-oracle",
+      path: "/gh/one/neo-oracle",
+      hasLiveSession: false,
+      lastActivityMs: 0,
+      recommended: true,
+    });
     expect(writes.join("")).toContain("/gh/one/neo-oracle");
 
     await expect(pickOracle([], {

--- a/test/isolated/coverage-100-core-dispatch-gaps.test.ts
+++ b/test/isolated/coverage-100-core-dispatch-gaps.test.ts
@@ -263,7 +263,14 @@ describe("coverage-100 core resolve and routing dispatch gaps", () => {
       reader,
     });
     reader.emit("end");
-    await expect(picked).resolves.toBeNull();
+    await expect(picked).resolves.toMatchObject({
+      owner: "o",
+      repo: "r-oracle",
+      path: undefined,
+      lastActivityMs: 0,
+      hasLiveSession: false,
+      recommended: true,
+    });
     await expect(coreResolve.pickOracle([{ owner: "o", repo: "r-oracle" }], {
       stream: { write: () => true } as any,
       reader: { on: () => { throw new Error("tty gone"); }, resume: () => {} } as any,

--- a/test/isolated/coverage-core-shared-helpers.test.ts
+++ b/test/isolated/coverage-core-shared-helpers.test.ts
@@ -247,7 +247,14 @@ describe("coverage core shared helpers", () => {
     reader.write("2\nignored");
     const selected = await selectedPromise;
 
-    expect(selected).toEqual({ owner: "two", repo: "beta-oracle", path: "/gh/two/beta-oracle" });
+    expect(selected).toMatchObject({
+      owner: "two",
+      repo: "beta-oracle",
+      path: "/gh/two/beta-oracle",
+      hasLiveSession: false,
+      lastActivityMs: 0,
+      recommended: false,
+    });
     expect(writes.join("")).toContain("Select [1-2]");
     expect((reader as EventEmitter).listenerCount("data")).toBe(0);
     expect((reader as EventEmitter).listenerCount("end")).toBe(0);

--- a/test/isolated/coverage-next-core-routing-resolve.test.ts
+++ b/test/isolated/coverage-next-core-routing-resolve.test.ts
@@ -219,7 +219,14 @@ describe("coverage next core oracle resolver", () => {
     });
     reader.end("2");
 
-    await expect(selected).resolves.toEqual({ owner: "Org", repo: "two-oracle", path: "/gh/Org/two-oracle" });
+    await expect(selected).resolves.toMatchObject({
+      owner: "Org",
+      repo: "two-oracle",
+      path: "/gh/Org/two-oracle",
+      hasLiveSession: false,
+      lastActivityMs: 0,
+      recommended: false,
+    });
     expect(writes.join("")).toContain("Select [1-2]");
     expect(reader.listenerCount("data")).toBe(0);
     expect(reader.listenerCount("end")).toBe(0);

--- a/test/isolated/wake-resolve-impl-fifteenth-pass-coverage.test.ts
+++ b/test/isolated/wake-resolve-impl-fifteenth-pass-coverage.test.ts
@@ -114,6 +114,13 @@ mock.module(join(srcRoot, "src/core/ghq"), () => ({
 mock.module(join(srcRoot, "src/core/resolve"), () => ({
   resolveOracle: async () => resolveResults.shift() ?? { kind: "not-found" },
   pickOracle: async () => null,
+  rankOracleCandidates: (candidates: { owner: string; repo: string; path?: string }[]) => candidates.map((candidate, index) => ({
+    ...candidate,
+    path: candidate.path,
+    lastActivityMs: 0,
+    hasLiveSession: false,
+    recommended: index === 0,
+  })),
 }));
 
 mock.module(join(srcRoot, "src/core/fleet/worktrees-scan"), () => ({

--- a/test/wake-resolve-impl-runtime-coverage.test.ts
+++ b/test/wake-resolve-impl-runtime-coverage.test.ts
@@ -36,6 +36,7 @@ const realSdk = {
   curlFetch: _rSdk.curlFetch,
   tmux: {
     listSessions: _rSdk.tmux.listSessions.bind(_rSdk.tmux),
+    listPanes: _rSdk.tmux.listPanes.bind(_rSdk.tmux),
     setEnvironment: _rSdk.tmux.setEnvironment.bind(_rSdk.tmux),
   },
 };
@@ -103,6 +104,7 @@ mock.module(join(import.meta.dir, "../src/sdk"), () => ({
   tmux: {
     ..._rSdk.tmux,
     listSessions: async () => (mockActive ? sessions : realSdk.tmux.listSessions()),
+    listPanes: async () => (mockActive ? [] : realSdk.tmux.listPanes()),
     setEnvironment: async (session: string, key: string, val: string) => {
       if (!mockActive) return realSdk.tmux.setEnvironment(session, key, val);
       setEnvCalls.push({ session, key, val });


### PR DESCRIPTION
## Changes

- Rank ambiguous local wake oracle candidates by live tmux session + recency (newest activity).
- Add `rankOracleCandidates(candidates, { liveSessions, now, getLastActivityMs })` in `src/core/resolve.ts` (pure + testable) with metadata `{recommended, lastActivityMs, hasLiveSession}`.
- Thread ranking into wake path (`src/commands/shared/wake-resolve-impl.ts`) so multi-match output is sorted with `⭐ recommended` + relative activity and live-session marker.
- `pickOracle()` now prints ranked candidates and uses Enter as default to `#1` (recommended), preserves non-interactive fallback hints.
- Include a deterministic tie-break (alphabetical slug order).
- Added unit test for before/after simulation behavior with known mtimes and live session.

## Before/after simulation (real case)

BEFORE (today — arbitrary order, no hint):

```text
⚠ 'volt' matches 3 local oracles:
    • Arkkra-Co/volt-oracle
    • laris-co/volt-oracle
    • Soul-Brews-Studio/volt-oracle

  Wake which oracle?
  1) Arkkra-Co/volt-oracle          /opt/Code/github.com/Arkkra-Co/volt-oracle
  2) laris-co/volt-oracle           /opt/Code/github.com/laris-co/volt-oracle
  3) Soul-Brews-Studio/volt-oracle  /opt/Code/github.com/Soul-Brews-Studio/volt-oracle
  Select [1-3]:
```

AFTER (ranked by live-session + recency, recommended default):

```text
⚠ 'volt' matches 3 local oracles (ranked by live session + recent activity):

  Wake which oracle?
  1) laris-co/volt-oracle   ⭐ recommended    /opt/Code/github.com/laris-co/volt-oracle
       ● live session · edited 2m ago
  2) Arkkra-Co/volt-oracle                     /opt/Code/github.com/Arkkra-Co/volt-oracle
       edited 11h ago
  3) Soul-Brews-Studio/volt-oracle             /opt/Code/github.com/Soul-Brews-Studio/volt-oracle
       edited 3d ago
  Select [1-3] (Enter = 1):
```

Closes #2678
