### PR TITLE
feat: maw share — read-only web view of tmux session (Phase 1, #2685)

### DIFF
--- a/src/core/serve-ws-registry.ts
+++ b/src/core/serve-ws-registry.ts
@@ -1,7 +1,7 @@
 import type { ServerWebSocket } from "bun";
 import type { WSData } from "./types";
 
-export type ServeWsData = WSData & { __serveWsRoute?: string };
+export type ServeWsData = WSData & { __serveWsRoute?: string; params?: Record<string, string> };
 export type ServeWsSocket = ServerWebSocket<ServeWsData>;
 
 export type ServeWsDataFactory = (request: Request) => WSData;
@@ -32,9 +32,14 @@ type RegisteredServeWsRoute = {
   data: ServeWsDataFactory;
   handlers: ServeWsRouteHandlers;
 };
+type RouteMatch = {
+  params: Record<string, string>;
+  route: RegisteredServeWsRoute;
+};
 
 export class ServeWsRegistry implements ServeWsRouteRegistrar {
   private readonly routes = new Map<string, RegisteredServeWsRoute>();
+  private readonly paramRoutes: RegisteredServeWsRoute[] = [];
 
   readonly handlers = {
     open: (ws: ServeWsSocket) => this.dispatch("open", ws),
@@ -45,15 +50,45 @@ export class ServeWsRegistry implements ServeWsRouteRegistrar {
   route(path: string, data: ServeWsDataFactory, handlers: ServeWsRouteHandlers): void {
     assertAbsolutePath(path);
     if (this.routes.has(path)) throw new Error(`serve ws route already registered: ${path}`);
-    this.routes.set(path, { path, data, handlers });
+    const entry = { path, data, handlers };
+    this.routes.set(path, entry);
+    if (path.includes(":")) this.paramRoutes.push(entry);
+  }
+
+  private match(pathname: string): RouteMatch | null {
+    const exact = this.routes.get(pathname);
+    if (exact && !exact.path.includes(":")) {
+      return { route: exact, params: {} };
+    }
+
+    for (const entry of this.paramRoutes) {
+      const template = entry.path.split("/").filter(Boolean);
+      const actual = pathname.split("/").filter(Boolean);
+      if (template.length !== actual.length) continue;
+      const params: Record<string, string> = {};
+      let ok = true;
+      for (let i = 0; i < template.length; i += 1) {
+        const token = template[i];
+        if (token.startsWith(":")) {
+          params[token.slice(1)] = decodeURIComponent(actual[i] ?? "");
+        } else if (token !== actual[i]) {
+          ok = false;
+          break;
+        }
+      }
+      if (ok) return { route: entry, params };
+    }
+
+    return null;
   }
 
   handleUpgrade(req: Request, server: { upgrade: (request: Request, options: { data: ServeWsData }) => boolean }): ServeWsUpgradeResult {
     const url = new URL(req.url);
-    const route = this.routes.get(url.pathname);
+    const match = this.match(url.pathname);
+    const route = match?.route;
     if (!route) return { matched: false };
 
-    const data = { ...route.data(req), __serveWsRoute: route.path } as ServeWsData;
+    const data = { ...route.data(req), __serveWsRoute: route.path, ...(Object.keys(match?.params ?? {}).length ? { params: match?.params } : {}) } as ServeWsData;
     if (server.upgrade(req, { data })) return { matched: true };
     return { matched: true, response: new Response("WebSocket upgrade failed", { status: 400 }) };
   }

--- a/src/vendor/mpr-plugins/share/impl.ts
+++ b/src/vendor/mpr-plugins/share/impl.ts
@@ -1,0 +1,229 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "crypto";
+
+type ShareAuthKind = "token" | "federation" | "none";
+
+export interface Share {
+  target: string;
+  panes: string[];
+  readOnly: boolean;
+  tokenHash: string;
+  expiresAt: number;
+  auth: ShareAuthKind;
+}
+
+export interface CreateShareOptions {
+  target: string;
+  panes?: string[];
+  readOnly?: boolean;
+  ttl?: number;
+  auth?: ShareAuthKind;
+}
+
+export interface CreateShareResult {
+  slug: string;
+  token: string;
+  url: string;
+}
+
+export interface ShareAuth {
+  mint(share: Omit<Share, "tokenHash" | "expiresAt" | "auth">, slug: string): Promise<string> | string;
+  verify(slug: string, presented: string): Promise<boolean> | boolean;
+  kind: ShareAuthKind;
+}
+
+const DEFAULT_TTL_MS = 3_600_000;
+const SWEEP_INTERVAL_MS = 10_000;
+
+const shareRegistry = new Map<string, Share>();
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function hashesMatch(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
+function makeSlug(): string {
+  while (true) {
+    const raw = randomUUID().replace(/-/g, "");
+    const slug = BigInt(`0x${raw}`).toString(36).toLowerCase();
+    if (slug.length >= 10) return slug;
+    const padded = slug.padStart(10, "0");
+    if (padded.length >= 10) return padded;
+  }
+}
+
+function ensureTTL(ttl?: number): number {
+  if (!Number.isFinite(ttl) || ttl === undefined) return DEFAULT_TTL_MS;
+  return Math.max(0, ttl) * 1000;
+}
+
+function tokenAuthProvider(): ShareAuth {
+  return {
+    kind: "token",
+    mint: () => randomBytes(24).toString("base64url"),
+    verify: (slug, presented) => {
+      const share = shareRegistry.get(slug);
+      if (!share) return false;
+      return hashesMatch(share.tokenHash, hashToken(presented));
+    },
+  };
+}
+
+function noneAuthProvider(): ShareAuth {
+  const NONE_TOKEN = "";
+  return {
+    kind: "none",
+    mint: () => NONE_TOKEN,
+    verify: (slug, presented) => {
+      return (presented === NONE_TOKEN) && shareRegistry.has(slug);
+    },
+  };
+}
+
+let federationAuth: (() => Promise<typeof import("../../../lib/federation-auth")>) | null = null;
+
+function resolveFederationAuthModule(): Promise<typeof import("../../../lib/federation-auth")> {
+  if (!federationAuth) {
+    federationAuth = async () => await import("../../../lib/federation-auth");
+  }
+  return federationAuth();
+}
+
+let federationConfigModule: (() => Promise<typeof import("../../../config")>) | null = null;
+
+function resolveConfigModule(): Promise<typeof import("../../../config")> {
+  if (!federationConfigModule) {
+    federationConfigModule = async () => await import("../../../config");
+  }
+  return federationConfigModule();
+}
+
+function federationAuthProvider(): Promise<ShareAuth> {
+  return Promise.all([resolveFederationAuthModule(), resolveConfigModule()]).then(([federation, configModule]) => {
+    const token = configModule.loadConfig()?.federationToken;
+    if (!token) {
+      throw new Error("federation auth requires federationToken");
+    }
+    return {
+      kind: "federation",
+      mint: (_share, slug) => {
+        const ts = Math.floor(Date.now() / 1000);
+        const signature = federation.sign(token, "GET", `/share/${slug}`, ts);
+        return `${ts}.${signature}`;
+      },
+      verify: (slug, presented) => {
+        const share = shareRegistry.get(slug);
+        if (!share) return false;
+        const parts = presented.split(".", 2);
+        if (parts.length !== 2) return false;
+        const ts = Number(parts[0]);
+        const signature = parts[1];
+        if (!Number.isFinite(ts)) return false;
+        return federation.verify(token, "GET", `/share/${slug}`, ts, signature);
+      },
+    };
+  });
+}
+
+async function resolveAuth(kind: ShareAuthKind): Promise<ShareAuth> {
+  if (kind === "token") return tokenAuthProvider();
+  if (kind === "none") return noneAuthProvider();
+  return federationAuthProvider();
+}
+
+function purgeExpired(): number {
+  const now = Date.now();
+  let removed = 0;
+  for (const [slug, share] of shareRegistry.entries()) {
+    if (share.expiresAt <= now) {
+      shareRegistry.delete(slug);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+function ensureSweepTimer(): void {
+  if (sweepTimer) return;
+  sweepTimer = setInterval(() => {
+    purgeExpired();
+  }, SWEEP_INTERVAL_MS);
+}
+
+export function stopShareSweepTimer(): void {
+  if (!sweepTimer) return;
+  clearInterval(sweepTimer);
+  sweepTimer = null;
+}
+
+export async function createShare(opts: CreateShareOptions): Promise<CreateShareResult> {
+  if (!opts.target?.trim()) throw new Error("share target is required");
+
+  const target = opts.target;
+  const panes = Array.isArray(opts.panes) ? opts.panes.slice() : [];
+  const readOnly = opts.readOnly !== false;
+  const auth: ShareAuthKind = opts.auth ?? "token";
+  const expiresAt = Date.now() + ensureTTL(opts.ttl);
+
+  const authHandler = await resolveAuth(auth);
+  const slug = makeSlug();
+  const share: Share = {
+    target,
+    panes,
+    readOnly,
+    tokenHash: "",
+    expiresAt,
+    auth,
+  };
+  const token = await authHandler.mint(share, slug);
+  share.tokenHash = hashToken(token);
+
+  shareRegistry.set(slug, share);
+  ensureSweepTimer();
+
+  return {
+    slug,
+    token,
+    url: `/share/${slug}#${token}`,
+  };
+}
+
+export function getShare(slug: string): Share | undefined {
+  const share = shareRegistry.get(slug);
+  if (!share) return undefined;
+  if (share.expiresAt <= Date.now()) {
+    shareRegistry.delete(slug);
+    return undefined;
+  }
+  return share;
+}
+
+export async function verifyShare(slug: string, presented: string): Promise<boolean> {
+  const share = getShare(slug);
+  if (!share) return false;
+  const provider = await resolveAuth(share.auth);
+  const ok = await provider.verify(slug, presented);
+  if (!ok) return false;
+  const expectedHash = share.tokenHash;
+  if (expectedHash.length === 0) return false;
+  return hashesMatch(expectedHash, hashToken(presented));
+}
+
+export function revoke(slug: string): boolean {
+  return shareRegistry.delete(slug);
+}
+
+export function sweepExpiredShares(): number {
+  return purgeExpired();
+}
+
+export function clearShareRegistry(): void {
+  shareRegistry.clear();
+  stopShareSweepTimer();
+}

--- a/src/vendor/mpr-plugins/share/index.ts
+++ b/src/vendor/mpr-plugins/share/index.ts
@@ -1,0 +1,40 @@
+import { parseFlags, type InvokeContext, type InvokeResult } from "maw-js/sdk";
+
+const DEFAULT_TTL_SECONDS = 3600;
+const DEFAULT_READ_ONLY = true;
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  try {
+    if (ctx.source !== "cli") {
+      return { ok: false, error: "maw share currently supports CLI usage only" };
+    }
+
+    const flags = parseFlags(ctx.args as string[], {
+      "--read-only": Boolean,
+      "--ttl": Number,
+      "--port": Number,
+    }, 0);
+
+    const target = flags._[0] ?? "";
+    const readOnly = flags["--read-only"] ?? DEFAULT_READ_ONLY;
+    const ttl = typeof flags["--ttl"] === "number" && Number.isFinite(flags["--ttl"]) ? flags["--ttl"] : DEFAULT_TTL_SECONDS;
+    const port = typeof flags["--port"] === "number" && Number.isFinite(flags["--port"]) ? flags["--port"] : undefined;
+
+    if (!target) {
+      return { ok: false, error: "usage: maw share <session-or-pane> [--read-only] [--ttl <seconds>] [--port <number>]" };
+    }
+
+    console.log(`share ${target} readOnly=${readOnly} ttl=${ttl}s port=${port === undefined ? "auto" : port}`);
+
+    // TODO(#2685): call share impl (target resolve + auth + stream + registry).
+
+    return { ok: true, output: `share ${target}` };
+  } catch (error: any) {
+    return { ok: false, error: error?.message ?? String(error) };
+  }
+}
+
+
+export async function serve(_ctx: { http?: unknown }): Promise<{ ok: true } | { ok: false; error: string }> {
+  return { ok: true };
+}

--- a/src/vendor/mpr-plugins/share/index.ts
+++ b/src/vendor/mpr-plugins/share/index.ts
@@ -1,40 +1,277 @@
-import { parseFlags, type InvokeContext, type InvokeResult } from "maw-js/sdk";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { loadConfig } from "maw-js/config";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags } from "maw-js/cli/parse-args";
+import { resolveTmuxTarget } from "../../../commands/plugins/tmux/impl";
+import type { ServeHookContext } from "../../../core/serve-route-registry";
+import type { ServeWsData, ServeWsSocket } from "../../../core/serve-ws-registry";
+import { createShare, getShare, verifyShare, type Share } from "./impl";
+import { attach, type ShareStreamHandle } from "./stream";
 
+export const command = {
+  name: "share",
+  description: "Share a live read-only tmux session/pane in a browser via a temporary link.",
+};
+
+const SHARE_USAGE = "usage: maw share <session-or-pane> [--read-only] [--ttl <seconds>] [--port <number>] [--auth token|federation|none]";
 const DEFAULT_TTL_SECONDS = 3600;
 const DEFAULT_READ_ONLY = true;
+
+type ShareAuth = "token" | "federation" | "none";
+
+type ShareWsData = ServeWsData & {
+  shareSlug?: string;
+  shareToken?: string;
+  shareError?: string;
+};
+
+type ShareOpenState = {
+  slug: string;
+  handle: ShareStreamHandle;
+};
+
+type ShareMetadata = {
+  target: string;
+  panes: string[];
+  readOnly: boolean;
+  expiresAt: number;
+  auth: string;
+};
+
+const viewerHtml = (() => {
+  const p = join(import.meta.dir, "viewer.html");
+  return existsSync(p) ? readFileSync(p, "utf-8") : "";
+})();
+
+function parseRoutePart(pathname: string, pattern: string): Record<string, string> | null {
+  const pathParts = pathname.split("/").filter(Boolean);
+  const patternParts = pattern.split("/").filter(Boolean);
+  if (pathParts.length !== patternParts.length) return null;
+
+  const params: Record<string, string> = {};
+  for (let i = 0; i < patternParts.length; i += 1) {
+    const part = patternParts[i];
+    const actual = pathParts[i];
+    if (actual === undefined) return null;
+    if (part.startsWith(":")) {
+      params[part.slice(1)] = decodeURIComponent(actual);
+      continue;
+    }
+    if (part !== actual) return null;
+  }
+
+  return params;
+}
+
+function parseShareToken(req: Request): string {
+  const url = new URL(req.url);
+  return url.searchParams.get("token") || url.searchParams.get("t") || "";
+}
+
+function getShareSlugFromWsData(data: ShareWsData): string | null {
+  return data.params?.slug || data.shareSlug || null;
+}
+
+function isPingMessage(message: unknown): boolean {
+  if (typeof message === "string") return message.trim().toLowerCase() === "ping";
+  if (ArrayBuffer.isView(message)) {
+    const text = new TextDecoder().decode(new Uint8Array(message.buffer, message.byteOffset, message.byteLength));
+    return text.trim().toLowerCase() === "ping";
+  }
+  if (message instanceof ArrayBuffer) {
+    const text = new TextDecoder().decode(new Uint8Array(message));
+    return text.trim().toLowerCase() === "ping";
+  }
+  return false;
+}
+
+async function openShareWebSocket(
+  ws: ServeWsSocket,
+  states: Map<ServeWsSocket, ShareOpenState>,
+): Promise<void> {
+  const data = ws.data as ShareWsData;
+  const slug = getShareSlugFromWsData(data);
+  const token = data.shareToken ?? "";
+
+  if (!slug) {
+    ws.close(1008, "invalid share route");
+    return;
+  }
+
+  const share = getShare(slug);
+  if (!share || !(await verifyShare(slug, token))) {
+    ws.close(1008, "invalid or expired share token");
+    return;
+  }
+
+  try {
+    const handle = await attach(share, ws);
+    states.set(ws, { slug, handle });
+  } catch (error: unknown) {
+    ws.close(1011, error instanceof Error ? error.message : "share stream failed");
+  }
+}
+
+function routeShareHtml(req: Request): Response {
+  const params = parseRoutePart(new URL(req.url).pathname, "/share/:slug");
+  const slug = params?.slug;
+  if (!slug) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const share = getShare(slug);
+  if (!share) {
+    return new Response("Share not found", { status: 404 });
+  }
+
+  return new Response(viewerHtml, {
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}
+
+async function routeShareMetadata(req: Request): Promise<Response> {
+  const params = parseRoutePart(new URL(req.url).pathname, "/api/share/:slug");
+  const slug = params?.slug;
+  if (!slug) {
+    return new Response(JSON.stringify({ error: "not_found" }), {
+      status: 404,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    });
+  }
+
+  const token = parseShareToken(req);
+  const share = getShare(slug);
+  if (!share || !(await verifyShare(slug, token))) {
+    return new Response(JSON.stringify({ error: "invalid_share" }), {
+      status: 401,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    });
+  }
+
+  const payload: ShareMetadata = {
+    target: share.target,
+    panes: share.panes,
+    readOnly: share.readOnly,
+    expiresAt: share.expiresAt,
+    auth: share.auth,
+  };
+
+  return new Response(JSON.stringify(payload), {
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+function shareWsRouteData(req: Request): ShareWsData {
+  const params = parseRoutePart(new URL(req.url).pathname, "/ws/share/:slug");
+  return {
+    target: null,
+    previewTargets: new Set(),
+    shareSlug: params?.slug,
+    shareToken: parseShareToken(req),
+    shareError: params?.slug ? undefined : "missing slug",
+  };
+}
+
+export async function serve(ctx: ServeHookContext): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!ctx.http) return { ok: false, error: "share serve requires ctx.http" };
+
+  const registerJson = async () => {
+    ctx.http.route("GET", "/share/:slug", routeShareHtml);
+    ctx.http.route("GET", "/api/share/:slug", routeShareMetadata);
+  };
+
+  await registerJson();
+
+  if (!ctx.ws) return { ok: true };
+
+  const openStreams = new Map<ServeWsSocket, ShareOpenState>();
+  ctx.ws.route("/ws/share/:slug", shareWsRouteData, {
+    open: (ws) => {
+      const data = ws.data as ShareWsData;
+      if (data.shareError) {
+        ws.close(1008, data.shareError);
+        return;
+      }
+      void openShareWebSocket(ws, openStreams);
+    },
+    message: (ws, message) => {
+      const state = openStreams.get(ws);
+      if (state?.handle && isPingMessage(message)) {
+        ws.send("pong");
+        return;
+      }
+      if (!state) return;
+      state.handle.onMessage(message);
+    },
+    close: (ws) => {
+      const state = openStreams.get(ws);
+      if (!state) return;
+      void state.handle.close();
+      openStreams.delete(ws);
+    },
+  });
+
+  return { ok: true };
+}
+
+function daemonPortFromFlags(flags: Record<string, unknown>): number {
+  const fromFlag = typeof flags["--port"] === "number" && Number.isFinite(flags["--port"])
+    ? Number(flags["--port"])
+    : undefined;
+  return fromFlag || loadConfig().port || 3456;
+}
+
+function resolveAuthFlag(raw: unknown): ShareAuth {
+  if (typeof raw !== "string") return "token";
+  const maybe = raw.toLowerCase();
+  if (maybe === "token" || maybe === "federation" || maybe === "none") return maybe;
+  throw new Error(`invalid --auth '${raw}', expected one of token|federation|none`);
+}
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   try {
     if (ctx.source !== "cli") {
-      return { ok: false, error: "maw share currently supports CLI usage only" };
+      return { ok: false, error: "share currently supports CLI usage only" };
     }
 
     const flags = parseFlags(ctx.args as string[], {
       "--read-only": Boolean,
       "--ttl": Number,
       "--port": Number,
+      "--auth": String,
     }, 0);
 
-    const target = flags._[0] ?? "";
-    const readOnly = flags["--read-only"] ?? DEFAULT_READ_ONLY;
-    const ttl = typeof flags["--ttl"] === "number" && Number.isFinite(flags["--ttl"]) ? flags["--ttl"] : DEFAULT_TTL_SECONDS;
-    const port = typeof flags["--port"] === "number" && Number.isFinite(flags["--port"]) ? flags["--port"] : undefined;
-
-    if (!target) {
-      return { ok: false, error: "usage: maw share <session-or-pane> [--read-only] [--ttl <seconds>] [--port <number>]" };
+    const target = flags._[0];
+    if (!target || target === "--help" || target === "-h") {
+      return { ok: false, error: `${SHARE_USAGE}` };
+    }
+    if (target.startsWith("-")) {
+      return { ok: false, error: `${SHARE_USAGE}\n  target looks like a flag` };
     }
 
-    console.log(`share ${target} readOnly=${readOnly} ttl=${ttl}s port=${port === undefined ? "auto" : port}`);
+    const hit = resolveTmuxTarget(target);
+    if (!hit) {
+      return { ok: false, error: `cannot resolve tmux target: ${target}` };
+    }
 
-    // TODO(#2685): call share impl (target resolve + auth + stream + registry).
+    const readOnly = flags["--read-only"] === undefined ? DEFAULT_READ_ONLY : Boolean(flags["--read-only"]);
+    const ttl = typeof flags["--ttl"] === "number" && Number.isFinite(flags["--ttl"]) ? flags["--ttl"] : DEFAULT_TTL_SECONDS;
+    const auth = resolveAuthFlag(flags["--auth"]);
 
-    return { ok: true, output: `share ${target}` };
+    const { slug, token } = await createShare({
+      target: hit.resolved,
+      readOnly,
+      ttl,
+      auth,
+    });
+
+    const host = loadConfig().host || "localhost";
+    const port = daemonPortFromFlags(flags);
+    const url = `http://${host}:${port}/share/${slug}#t=${token}`;
+    console.log(`🔗 ${url}`);
+    return { ok: true, output: url };
   } catch (error: any) {
-    return { ok: false, error: error?.message ?? String(error) };
+    return { ok: false, error: error?.message || String(error) };
   }
-}
-
-
-export async function serve(_ctx: { http?: unknown }): Promise<{ ok: true } | { ok: false; error: string }> {
-  return { ok: true };
 }

--- a/src/vendor/mpr-plugins/share/plugin.json
+++ b/src/vendor/mpr-plugins/share/plugin.json
@@ -10,7 +10,8 @@
     "flags": {
       "--read-only": "boolean",
       "--ttl": "number",
-      "--port": "number"
+      "--port": "number",
+      "--auth": "string"
     }
   },
   "weight": 10,

--- a/src/vendor/mpr-plugins/share/plugin.json
+++ b/src/vendor/mpr-plugins/share/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "share",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Share a tmux session/pane as a read-only web stream.",
+  "cli": {
+    "command": "share",
+    "help": "maw share <session-or-pane> [--read-only] [--ttl <seconds>] [--port <number>]",
+    "flags": {
+      "--read-only": "boolean",
+      "--ttl": "number",
+      "--port": "number"
+    }
+  },
+  "weight": 10,
+  "license": "MIT",
+  "schemaVersion": 1,
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve"
+    }
+  }
+}

--- a/src/vendor/mpr-plugins/share/stream.ts
+++ b/src/vendor/mpr-plugins/share/stream.ts
@@ -1,0 +1,203 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ServerWebSocket } from "bun";
+import { Tmux } from "maw-js/sdk";
+import type { Share } from "./impl";
+
+type ChildProcessLike = {
+  kill: (signal?: string | number) => void;
+  exited: Promise<number | void>;
+};
+
+type TmuxShape = Pick<Tmux, "capture" | "pipePane">;
+
+type StreamDeps = {
+  mkdtempSync: typeof mkdtempSync;
+  tmpdir: typeof tmpdir;
+  join: typeof join;
+  rmSync: typeof rmSync;
+  tmux: TmuxShape;
+  spawnTail: (path: string, onChunk: (chunk: Uint8Array) => void) => Promise<ChildProcessLike>;
+  setTimeout: typeof setTimeout;
+  clearTimeout: typeof clearTimeout;
+};
+
+export interface ShareStreamHandle {
+  onMessage: (message: unknown) => void;
+  close: () => Promise<void>;
+}
+
+const DEFAULT_SNAPSHOT_LINES = 120;
+const CLOSE_TIMEOUT_MS = 1_500;
+
+function defaultDeps(): StreamDeps {
+  return {
+    mkdtempSync,
+    tmpdir,
+    join,
+    rmSync,
+    tmux: new Tmux(),
+    spawnTail: async (path, onChunk) => {
+      const child = Bun.spawn({
+        cmd: ["tail", "-n", "0", "-f", path],
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      void (async () => {
+        for await (const chunk of child.stdout) {
+          if (!chunk || chunk.byteLength === 0) continue;
+          onChunk(chunk as Uint8Array);
+        }
+      })();
+      return {
+        kill: (signal) => {
+          try {
+            child.kill(signal);
+          } catch {
+            // best-effort cleanup
+          }
+        },
+        exited: child.exited.then(() => undefined),
+      };
+    },
+    setTimeout,
+    clearTimeout,
+  };
+}
+
+function shellEscapeArg(value: string): string {
+  if (value === "") return "''";
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function decodeInboundMessage(message: unknown): string | null {
+  if (typeof message === "string") return message;
+  if (message instanceof ArrayBuffer) return new TextDecoder().decode(new Uint8Array(message));
+  if (ArrayBuffer.isView(message)) {
+    return new TextDecoder().decode(new Uint8Array(message.buffer, message.byteOffset, message.byteLength));
+  }
+  return null;
+}
+
+function makeStreamConsumerPath(tmpDir: string, target: string): string {
+  return join(tmpDir, `${Date.now().toString(36)}-${target.replace(/[^a-zA-Z0-9._-]/g, "-")}`);
+}
+
+function sendSafe(ws: ServerWebSocket, data: string | Uint8Array): void {
+  try {
+    ws.send(data);
+  } catch {
+    // ws may be closed already
+  }
+}
+
+async function awaitOrKill(child: ChildProcessLike | null, deps: Pick<StreamDeps, "setTimeout" | "clearTimeout">): Promise<void> {
+  if (!child) return;
+  const timer = deps.setTimeout(() => {}, CLOSE_TIMEOUT_MS);
+  try {
+    await Promise.race([
+      child.exited,
+      new Promise<void>((resolve) => {
+        deps.setTimeout(() => {
+          resolve();
+        }, CLOSE_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    deps.clearTimeout(timer);
+  }
+
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // best effort
+  }
+
+  const hardKill = new Promise<void>((resolve) => {
+    deps.setTimeout(() => {
+      resolve();
+    }, 250);
+  });
+  try {
+    await Promise.race([child.exited, hardKill]);
+  } catch {
+    // ignore
+  }
+
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    // ignore
+  }
+}
+
+function normalizePing(message: string): string {
+  return message.trim().toLowerCase();
+}
+
+export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<StreamDeps> = {}): Promise<ShareStreamHandle> {
+  const resolved = {
+    ...defaultDeps(),
+    ...deps,
+    tmux: {
+      ...(defaultDeps().tmux),
+      ...(deps.tmux ?? {}),
+    },
+  };
+
+  const tempDir = resolved.mkdtempSync(join(resolved.tmpdir(), "maw-share-"));
+  const consumerPath = makeStreamConsumerPath(tempDir, share.target);
+
+  await Bun.write(consumerPath, "");
+
+  let closed = false;
+  let consumerChild: ChildProcessLike | null = null;
+
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+
+    try {
+      await resolved.tmux.pipePane(share.target);
+    } catch {
+      // best-effort stream teardown
+    }
+
+    await awaitOrKill(consumerChild, resolved);
+    consumerChild = null;
+
+    try {
+      resolved.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  };
+
+  const onMessage = (message: unknown): void => {
+    const text = decodeInboundMessage(message);
+    if (text !== null && normalizePing(text) === "ping") return;
+    // read-only mode intentionally ignores inbound traffic
+  };
+
+  try {
+    const snapshot = await resolved.tmux.capture(share.target, DEFAULT_SNAPSHOT_LINES);
+    if (snapshot) sendSafe(ws, snapshot);
+
+    const command = `cat >> ${shellEscapeArg(consumerPath)}`;
+    await resolved.tmux.pipePane(share.target, command);
+
+    consumerChild = await resolved.spawnTail(consumerPath, (chunk) => {
+      if (closed) return;
+      sendSafe(ws, chunk);
+    });
+  } catch (error) {
+    await close();
+    throw error;
+  }
+
+  return {
+    onMessage,
+    close,
+  };
+}

--- a/src/vendor/mpr-plugins/share/viewer.html
+++ b/src/vendor/mpr-plugins/share/viewer.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>maw share</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        background: #0d0d0d;
+        color: #d1d5db;
+        height: 100%;
+      }
+
+      #fallback {
+        font: 14px/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        padding: 12px;
+        white-space: pre-wrap;
+      }
+
+      #term {
+        width: 100%;
+        height: 100%;
+      }
+
+      xterm-host, #xterm {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+    <script src="https://unpkg.com/@xterm/xterm/lib/xterm.js"></script>
+    <script src="https://unpkg.com/@xterm/addon-fit/lib/addon-fit.js"></script>
+  </head>
+  <body>
+    <div id="fallback" style="display:none;">xterm.js failed to load; falling back to static display.</div>
+    <div id="term"></div>
+    <pre id="ansi-fallback" style="display:none; margin:0;"></pre>
+
+    <script>
+      (() => {
+        const match = location.pathname.match(/\/share\/([^/?#]+)/);
+        const slug = match?.[1] || "";
+        const params = new URLSearchParams(location.hash?.replace(/^#/, "") || "");
+        const token = params.get("t") || params.get("token") || "";
+        const wsProto = location.protocol === "https:" ? "wss" : "ws";
+        const socket = new WebSocket(`${wsProto}://${location.host}/ws/share/${encodeURIComponent(slug)}?t=${encodeURIComponent(token)}`);
+
+        const fallback = document.getElementById("fallback");
+        const termHost = document.getElementById("term");
+        const pre = document.getElementById("ansi-fallback");
+
+        const writeFallback = (chunk) => {
+          pre.textContent += chunk;
+          pre.parentElement?.appendChild(pre);
+          pre.style.display = "block";
+          termHost.style.display = "none";
+        };
+
+        const initTerminal = () => {
+          if (!window.Terminal || !window.FitAddon) {
+            fallback.textContent = "xterm.js unavailable; using fallback terminal.";
+            fallback.style.display = "block";
+            return false;
+          }
+
+          const term = new window.Terminal({
+            theme: { background: "#0d0d0d", foreground: "#d1d5db" },
+            convertEol: true,
+            disableStdin: true,
+            cursorBlink: false,
+          });
+
+          const fit = new window.FitAddon.FitAddon();
+          term.loadAddon(fit);
+          term.open(termHost);
+          const resize = () => {
+            try { fit.fit(); } catch { /* resize is advisory */ }
+          };
+          window.addEventListener("resize", resize);
+          resize();
+
+          socket.addEventListener("message", (event) => {
+            term.write(typeof event.data === "string" ? event.data : new TextDecoder().decode(event.data));
+          });
+          return true;
+        };
+
+        if (!initTerminal()) {
+          socket.addEventListener("message", (event) => {
+            if (typeof event.data === "string") {
+              writeFallback(event.data);
+            } else {
+              writeFallback(new TextDecoder().decode(event.data));
+            }
+          });
+        }
+
+        socket.addEventListener("open", () => {
+          try {
+            socket.send("ping");
+          } catch {
+            // ignore
+          }
+        });
+
+        socket.addEventListener("close", () => {
+          // read-only: nothing to do
+        });
+
+        socket.addEventListener("error", () => {
+          if (fallback.style.display === "none") {
+            fallback.textContent = "Connection error while opening share.";
+            fallback.style.display = "block";
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const realConfig = await import("../../src/config.ts");
+afterAll(() => { mock.restore(); });
+
+const root = join(import.meta.dir, "../..");
+const resolvedTargets: string[] = [];
+
+const configMock = {
+  ...realConfig,
+  loadConfig: () => ({ host: "127.0.0.1", port: 3456 }),
+};
+mock.module("maw-js/config", () => configMock);
+mock.module(import.meta.resolve("../../src/config.ts"), () => configMock);
+
+mock.module(import.meta.resolve("../../src/commands/plugins/tmux/impl"), () => ({
+  resolveTmuxTarget: (target: string) => {
+    resolvedTargets.push(target);
+    if (target === "missing") return null;
+    return { resolved: `${target}:resolved` };
+  },
+}));
+
+const sharePlugin = await import("../../src/vendor/mpr-plugins/share/index.ts?plugin-share-standalone");
+const shareImpl = await import("../../src/vendor/mpr-plugins/share/impl.ts?plugin-share-standalone");
+const shareHandler = sharePlugin.default;
+
+beforeEach(() => {
+  resolvedTargets.length = 0;
+  shareImpl.clearShareRegistry();
+});
+
+describe("share plugin standalone boundary (#2685)", () => {
+  test("manifest-backed sources expose the CLI command and serve hook", () => {
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/share/plugin.json"), "utf8"));
+    expect(manifest.name).toBe("share");
+    expect(manifest.cli.command).toBe("share");
+    expect(manifest.hooks.serve.handler).toBe("serve");
+
+    const index = readFileSync(join(root, "src/vendor/mpr-plugins/share/index.ts"), "utf8");
+    expect(index).toContain("export async function serve");
+    expect(index).toContain("export default async function handler");
+  });
+
+  test("cli share dispatch parses read-only, ttl, port, and auth flags", async () => {
+    const result = await shareHandler({
+      source: "cli",
+      args: ["neo:1", "--read-only", "--ttl", "42", "--port", "4567", "--auth", "token"],
+    } as any);
+
+    expect(result.ok).toBe(true);
+    expect(resolvedTargets).toEqual(["neo:1"]);
+    expect(result.output).toMatch(/^http:\/\/127\.0\.0\.1:4567\/share\/[a-z0-9]+#t=.+/);
+
+    const match = String(result.output).match(/\/share\/([^#]+)#t=(.+)$/);
+    expect(match).toBeTruthy();
+    const slug = match![1]!;
+    const token = match![2]!;
+    expect(slug).toMatch(/^[a-z0-9]+$/);
+    expect(token.length).toBeGreaterThan(10);
+  });
+
+  test("serve hook registers viewer, metadata, and websocket routes", async () => {
+    const httpRoutes: Array<{ method: string; path: string; handler: (req: Request) => Response | Promise<Response> }> = [];
+    const wsRoutes: Array<{ path: string; data: (req: Request) => unknown; handlers: Record<string, unknown> }> = [];
+
+    const result = await sharePlugin.serve({
+      http: {
+        route(method: string, path: string, handler: (req: Request) => Response | Promise<Response>) {
+          httpRoutes.push({ method, path, handler });
+        },
+      },
+      ws: {
+        route(path: string, data: (req: Request) => unknown, handlers: Record<string, unknown>) {
+          wsRoutes.push({ path, data, handlers });
+        },
+      },
+    } as any);
+
+    expect(result).toEqual({ ok: true });
+    expect(httpRoutes.map((route) => `${route.method} ${route.path}`)).toEqual([
+      "GET /share/:slug",
+      "GET /api/share/:slug",
+    ]);
+    expect(wsRoutes.map((route) => route.path)).toEqual(["/ws/share/:slug"]);
+    expect(typeof wsRoutes[0]!.handlers.open).toBe("function");
+    expect(typeof wsRoutes[0]!.handlers.message).toBe("function");
+    expect(typeof wsRoutes[0]!.handlers.close).toBe("function");
+
+    const created = await shareHandler({ source: "cli", args: ["neo:1", "--ttl", "60"] } as any);
+    const match = String(created.output).match(/\/share\/([^#]+)#t=(.+)$/);
+    expect(match).toBeTruthy();
+    const slug = match![1]!;
+    const token = match![2]!;
+    const metadata = httpRoutes.find((route) => route.path === "/api/share/:slug")!;
+    const response = await metadata.handler(new Request(`http://localhost/api/share/${slug}?token=${encodeURIComponent(token)}`));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      target: "neo:1:resolved",
+      readOnly: true,
+      auth: "token",
+    });
+
+    const wsData = wsRoutes[0]!.data(new Request(`http://localhost/ws/share/${slug}?t=${encodeURIComponent(token)}`)) as any;
+    expect(wsData.shareSlug).toBe(slug);
+    expect(wsData.shareToken).toBe(token);
+  });
+
+  test("token auth public API mints, verifies, rejects bad tokens, and expires", async () => {
+    const { slug, token, url } = await shareImpl.createShare({ target: "neo:1", panes: ["neo:1.0"], ttl: 1, auth: "token" });
+
+    expect(url).toBe(`/share/${slug}#${token}`);
+    expect(shareImpl.getShare(slug)).toMatchObject({ target: "neo:1", panes: ["neo:1.0"], auth: "token" });
+    await expect(shareImpl.verifyShare(slug, token)).resolves.toBe(true);
+    await expect(shareImpl.verifyShare(slug, `${token}-bad`)).resolves.toBe(false);
+
+    const expired = await shareImpl.createShare({ target: "expired", ttl: 0, auth: "token" });
+    expect(shareImpl.getShare(expired.slug)).toBeUndefined();
+    await expect(shareImpl.verifyShare(expired.slug, expired.token)).resolves.toBe(false);
+  });
+});

--- a/test/vendor-share-readonly.test.ts
+++ b/test/vendor-share-readonly.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { attach } from "../src/vendor/mpr-plugins/share/stream";
+import type { Share } from "../src/vendor/mpr-plugins/share/impl";
+
+type WsMessage = string | Uint8Array;
+type FakeWs = {
+  send: (data: WsMessage) => void;
+};
+
+function makeFakeWs(): { ws: FakeWs; sent: Array<WsMessage> } {
+  const sent: Array<WsMessage> = [];
+  return {
+    ws: {
+      send: (data: WsMessage) => sent.push(data),
+    },
+    sent,
+  };
+}
+
+function bytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+describe("share readonly stream", () => {
+  let killCalls: Array<Array<unknown>> = [];
+  let pipeCalls: Array<Array<unknown>> = [];
+  let captures: string[] = [];
+  let sendKeysCalls: number = 0;
+
+  beforeEach(() => {
+    killCalls = [];
+    pipeCalls = [];
+    captures = [];
+    sendKeysCalls = 0;
+  });
+
+  test("dropping inbound ws messages does not write pane text", async () => {
+    const share: Share = {
+      target: "session:0",
+      panes: [],
+      readOnly: true,
+      tokenHash: "hash",
+      expiresAt: Date.now() + 1_000_000,
+      auth: "token",
+    };
+
+    const { ws, sent } = makeFakeWs();
+    let childResolve: (() => void) | null = null;
+    const handle = await attach(
+      share,
+      ws as unknown as any,
+      {
+        tmux: {
+          capture: async (target: string) => {
+            captures.push(target);
+            return "SNAPSHOT\n";
+          },
+          pipePane: async (...args: unknown[]) => {
+            pipeCalls.push(args);
+          },
+          sendKeys: async () => {
+            sendKeysCalls += 1;
+          },
+        },
+        spawnTail: async (_path: string, onChunk: (chunk: Uint8Array) => void) => {
+          onChunk(bytes("LIVE\n"));
+          return {
+            kill: (signal?: string | number) => {
+              killCalls.push(["kill", signal]);
+            },
+            exited: new Promise((resolve) => {
+              childResolve = resolve;
+            }),
+          };
+        },
+      } as any,
+    );
+
+    expect(sent).toEqual(["SNAPSHOT\n", bytes("LIVE\n")] );
+    expect(captures).toEqual(["session:0"]);
+
+    handle.onMessage("ping");
+    handle.onMessage(bytes("typed-inbound"));
+    handle.onMessage("typed-string");
+    expect(sendKeysCalls).toBe(0);
+
+    await handle.close();
+    if (childResolve) childResolve();
+
+    expect(pipeCalls.some((call) => call[0] === "session:0" && call.length === 1)).toBe(true);
+    expect(killCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/test/vendor-share-registry.test.ts
+++ b/test/vendor-share-registry.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  clearShareRegistry,
+  createShare,
+  getShare,
+  revoke,
+  sweepExpiredShares,
+} from "../src/vendor/mpr-plugins/share/impl";
+
+const originalNow = Date.now;
+
+beforeEach(() => {
+  clearShareRegistry();
+});
+
+afterEach(() => {
+  Date.now = originalNow;
+});
+
+describe("share registry", () => {
+  test("create and get share entries", async () => {
+    const share = await createShare({ target: "alpha", ttl: 120, readOnly: false });
+    const loaded = getShare(share.slug);
+
+    expect(loaded).toMatchObject({
+      target: "alpha",
+      panes: [],
+      readOnly: false,
+      auth: "token",
+    });
+  });
+
+  test("sweep removes only expired entries", async () => {
+    const alive = await createShare({ target: "alive", ttl: 120 });
+    const expired = await createShare({ target: "dead", ttl: 1 });
+
+    expect(getShare(alive.slug)).toBeDefined();
+    expect(getShare(expired.slug)).toBeDefined();
+    expect(sweepExpiredShares()).toBe(0);
+
+    Date.now = () => originalNow() + 100_000;
+
+    const removed = sweepExpiredShares();
+    Date.now = originalNow;
+
+    expect(removed).toBe(1);
+    expect(getShare(expired.slug)).toBeUndefined();
+    expect(getShare(alive.slug)).toBeDefined();
+  });
+
+  test("revoke removes share immediately", async () => {
+    const share = await createShare({ target: "revoke" });
+    expect(getShare(share.slug)).toBeDefined();
+    expect(revoke(share.slug)).toBe(true);
+    expect(revoke(share.slug)).toBe(false);
+    expect(getShare(share.slug)).toBeUndefined();
+  });
+});

--- a/test/vendor-share-token.test.ts
+++ b/test/vendor-share-token.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  clearShareRegistry,
+  createShare,
+  verifyShare,
+} from "../src/vendor/mpr-plugins/share/impl";
+
+describe("share token auth", () => {
+  beforeEach(() => {
+    clearShareRegistry();
+  });
+
+  test("mint returns sluggable token and verify succeeds for matching token", async () => {
+    const share = await createShare({ target: "session:0" });
+
+    expect(share.slug).toMatch(/^[0-9a-z]{10,}$/);
+    expect(typeof share.token).toBe("string");
+    expect(share.token.length).toBeGreaterThan(0);
+    expect(share.url).toContain(share.slug);
+
+    await expect(verifyShare(share.slug, share.token)).resolves.toBe(true);
+  });
+
+  test("tampered token fails verification", async () => {
+    const share = await createShare({ target: "session:1" });
+    await expect(verifyShare(share.slug, `${share.token}-tampered`)).resolves.toBe(false);
+  });
+
+  test("expired share fails verification", async () => {
+    const share = await createShare({ target: "session:2", ttl: -1 });
+    await expect(verifyShare(share.slug, share.token)).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #2685

Phase 1 of epic #2684. Native vendor plugin: pluggable token auth (default local, federation opt-in), real-time via pipePane, read-only enforced in WS, xterm.js viewer.