### PR TITLE
fix(wake): per-worktree respawn is opt-in (default OFF) — thread #14

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -171,7 +171,7 @@ function printBringUsage(write: (line: string) => void = console.log): void {
 }
 
 function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => void = console.log): void {
-  write(`usage: maw ${verb} <oracle> [--work|--oracle] [--session <tmux-session>] [--task <s>] [--wt <s>] [--layout nested|legacy] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh|--new] [--pick] [--name <s>] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--no-fleet] [--split] [--wait] [--parent-session-id <id>] [--session-id <id>] [--all-local] [-e|--engine <name>]`);
+  write(`usage: maw ${verb} <oracle> [--work|--oracle] [--session <tmux-session>] [--task <s>] [--wt <s>] [--layout nested|legacy] [--bud] [--signal-on-birth] [-p|--prompt <s>] [--incubate <slug>] [--fresh|--new] [--pick] [--name <s>] [-a|--attach] [--list] [--dry-run] [--from-snapshot|--snapshot <id>] [--main|--solo|--no-rehydrate] [--respawn-worktrees] [--no-fleet] [--split] [--wait] [--parent-session-id <id>] [--session-id <id>] [--all-local] [-e|--engine <name>]`);
   if (verb === "awake") {
     write("  Launch/start an oracle process with the selected engine. Does not send /awaken.");
     write("  Use `maw awaken` for the awakening ritual; use `maw new` for a plain workspace session.");
@@ -185,6 +185,7 @@ function printWakeAliasUsage(verb: "wake" | "awake", write: (line: string) => vo
   write("  --layout selects new worktree filesystem layout: nested (default repo/agents/N-X) or legacy (.wt-N-X).");
   write("  --pick opens the reusable worktree picker; --name creates/reuses a stable named worktree.");
   write("  --list previews worktrees only; it does not create sessions or respawn windows.");
+  write("  --respawn-worktrees opts IN to rehydrating a window per worktree on disk (default OFF; thread #14) — plain wake touches only the role window.");
   write("  --from-snapshot restores missing windows from the latest recovery snapshot; --snapshot <id> selects one.");
   write("  --bud with --task/--wt writes ψ/.lineage.yaml in the worktree (no repo/fleet mutation).");
   write("  --signal-on-birth with --bud also drops a parent ψ/memory/signals birth signal.");
@@ -436,6 +437,7 @@ export async function invokeDirectHandler(
       "--from-snapshot": Boolean,
       "--snapshot": String,
       "--main": Boolean, "--solo": "--main", "--no-rehydrate": "--main",
+      "--respawn-worktrees": Boolean,
       "--split": Boolean,
       "--split-target": String,
       "--bring-alias": Boolean,
@@ -470,6 +472,7 @@ export async function invokeDirectHandler(
       listWt?: boolean;
       dryRun?: boolean;
       noRehydrate?: boolean;
+      respawnWorktrees?: boolean;
       noFleet?: boolean;
       split?: boolean;
       splitTarget?: string;
@@ -507,6 +510,7 @@ export async function invokeDirectHandler(
     if (flags["--attach"]) opts.attach = true;
     if (flags["--list"]) opts.listWt = true;
     if (flags["--dry-run"]) opts.dryRun = true;
+    if (flags["--respawn-worktrees"]) opts.respawnWorktrees = true;
     if (flags["--no-fleet"]) opts.noFleet = true;
     if (flags["--from-snapshot"]) opts.fromSnapshot = true;
     if (flags["--snapshot"]) {

--- a/src/commands/shared/wake-cmd-helpers.ts
+++ b/src/commands/shared/wake-cmd-helpers.ts
@@ -215,6 +215,23 @@ export async function filterMergedWorktreesForRehydrate(
   return kept;
 }
 
+/**
+ * Per-worktree rehydration is OPT-IN (default OFF) — thread #14, owner GO
+ * 2026-06-11. A plain `maw wake <role>` must touch only the resolved role
+ * window; it must NOT fan out a `<role>-<wt-suffix>` window per worktree on
+ * disk (the 17-window explosion + cross-role resume incident). Rehydration
+ * runs only when the caller explicitly opts in via `--respawn-worktrees`
+ * (`opts.respawnWorktrees`) or the fleet config key `respawnWorktrees: true`,
+ * and is still suppressed by `--no-rehydrate` / `--main` / `--solo`.
+ */
+export function shouldRehydrateWorktrees(
+  opts: { respawnWorktrees?: boolean; noRehydrate?: boolean },
+  config: { respawnWorktrees?: boolean } = {},
+): boolean {
+  if (opts.noRehydrate) return false;
+  return opts.respawnWorktrees === true || config.respawnWorktrees === true;
+}
+
 export type RehydrateWorktreePlan = {
   worktreeName: string;
   windowName: string;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -41,6 +41,7 @@ import {
   planSnapshotRestoreWindows,
   retryFreshSessionTmuxStep,
   shouldOfferExistingSessionAttach,
+  shouldRehydrateWorktrees,
   writeWakeBudBirthSignal,
   writeWakeBudLineage,
 } from "./wake-cmd-helpers";
@@ -405,6 +406,13 @@ export interface WakeOptions {
   listWt?: boolean;
   dryRun?: boolean;
   noRehydrate?: boolean;
+  /**
+   * Opt IN to per-worktree rehydration (default OFF; thread #14, owner GO
+   * 2026-06-11). Without this (and without the `respawnWorktrees` config key),
+   * a plain `maw wake <role>` touches only the role window and does NOT spawn a
+   * `<role>-<wt-suffix>` window per worktree on disk. See shouldRehydrateWorktrees.
+   */
+  respawnWorktrees?: boolean;
   noFleet?: boolean;
   split?: boolean;
   /** Hidden bring alias split anchor. Shape: "session:window" (#1816 Part 3). */
@@ -1264,6 +1272,10 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
 
   const mainWindowName = foreignSession ? oracle : mainWindowNameForWakeSession(sessionContext, oracle);
   const shouldCreateSession = !session && (wakeDecision.wake || Boolean(foreignSession));
+  // Per-worktree rehydration is OPT-IN (default OFF) — thread #14 / owner GO
+  // 2026-06-11. Plain `maw wake <role>` must touch only the role window and not
+  // fan out a `<role>-<wt-suffix>` window per worktree on disk. Gated below.
+  const doRehydrate = shouldRehydrateWorktrees(opts, config);
 
   if (opts.dryRun) {
     console.log(`\x1b[90mdry-run — no tmux sessions/windows will be changed\x1b[0m`);
@@ -1303,8 +1315,12 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       }
     }
 
-    if (opts.noRehydrate || foreignSession) {
-      const reason = foreignSession ? "foreign workspace session" : "--main/--solo/--no-rehydrate";
+    if (!doRehydrate || foreignSession) {
+      const reason = foreignSession
+        ? "foreign workspace session"
+        : opts.noRehydrate
+          ? "--main/--solo/--no-rehydrate"
+          : "opt-in only — pass --respawn-worktrees (or config respawnWorktrees:true)";
       console.log(`\x1b[90m↻ worktree rehydrate skipped (${reason})\x1b[0m`);
       return session ? `${session}:${mainWindowName}` : `${oracle}:dry-run`;
     }
@@ -1389,7 +1405,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       console.log(`\x1b[36m↻\x1b[0m snapshot restore: ${restored} window${restored === 1 ? "" : "s"}`);
     }
 
-    if (!foreignSession && !opts.task && !opts.wt && !opts.noRehydrate) {
+    if (!foreignSession && !opts.task && !opts.wt && doRehydrate) {
       const allWt = await findWorktrees(parentDir, repoName);
       const rehydratableWt = await filterMergedWorktreesForRehydrate(allWt, { hostExec, baseBranch: "alpha" });
       const plan = planRehydrateWorktreeWindows(oracle, rehydratableWt, [...existingWindows]);
@@ -1410,6 +1426,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
         existingWindows.add(wt.windowName);
         console.log(`\x1b[32m+\x1b[0m window: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
       }
+      if (selectedPlan.length > 0) console.log(`\x1b[36m↻\x1b[0m respawned ${selectedPlan.length} worktree window${selectedPlan.length === 1 ? "" : "s"}`);
     }
     knownWindows = existingWindows;
     knownWindowEntries = [...initialWindows, { name: mainWindowName, cwd: repoPath }];
@@ -1440,7 +1457,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
       console.log(`\x1b[36m↻\x1b[0m snapshot restore: ${restored} window${restored === 1 ? "" : "s"}`);
     }
 
-    if (!foreignSession && !opts.task && !opts.wt && !opts.noRehydrate) {
+    if (!foreignSession && !opts.task && !opts.wt && doRehydrate) {
       const allWt = await findWorktrees(parentDir, repoName);
       if (allWt.length > 0) {
         const existingWindows = [...preExistingWindows];
@@ -1464,6 +1481,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
               preExistingWindowEntries.push({ name: wt.windowName, cwd: wt.path });
               console.log(`\x1b[32m↻\x1b[0m respawned: ${wt.windowName}  \x1b[90m(from ${formatWorktreeSource(wt.path)})\x1b[0m`);
             }
+            console.log(`\x1b[36m↻\x1b[0m respawned ${selectedPlan.length} worktree window${selectedPlan.length === 1 ? "" : "s"}`);
           }
         }
       } else {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -186,6 +186,13 @@ export interface MawConfig {
   githubOrgs?: string[];
   /** Fixed Claude session UUIDs per agent */
   sessionIds?: Record<string, string>;
+  /**
+   * Opt IN to per-worktree rehydration on a plain `maw wake <role>` (default
+   * OFF; thread #14 / owner GO 2026-06-11). When false/unset, plain wake touches
+   * only the role window — pass `--respawn-worktrees` for a one-off. See
+   * shouldRehydrateWorktrees in commands/shared/wake-cmd-helpers.ts.
+   */
+  respawnWorktrees?: boolean;
   /** Path to ψ/ directory */
   psiPath?: string;
   /** TLS cert/key paths */

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -828,7 +828,7 @@ describe("cmdWake main-suite coverage", () => {
     _wtPicker.readChoice = () => answers.shift() ?? "";
 
     try {
-      const { result, logs } = await captureLogs(() => cmdWake("mawjs", { engine: "codex" }));
+      const { result, logs } = await captureLogs(() => cmdWake("mawjs", { engine: "codex", respawnWorktrees: true }));
 
       expect(result).toBe("01-mawjs:mawjs-oracle");
       expect(newWindowCalls).toEqual([
@@ -1008,7 +1008,7 @@ describe("cmdWake main-suite coverage", () => {
     ];
 
     const { result, logs } = await captureLogs(() =>
-      cmdWake("mawjs", { dryRun: true }),
+      cmdWake("mawjs", { dryRun: true, respawnWorktrees: true }),
     );
     const rendered = logs.join("\n");
 
@@ -1498,7 +1498,7 @@ describe("cmdWake main-suite coverage", () => {
     };
 
     const { result } = await captureLogs(() =>
-      cmdWake("https://github.com/the-oracle-keeps-the-human-human/graph-oracle", {}),
+      cmdWake("https://github.com/the-oracle-keeps-the-human-human/graph-oracle", { respawnWorktrees: true }),
     );
 
     expect(result).toBe("24-graph:graph-oracle");
@@ -1622,7 +1622,7 @@ describe("cmdWake main-suite coverage", () => {
     restoreTabOrderReturn = 1;
 
     const { result, logs } = await captureLogs(() =>
-      cmdWake("mawjs", { engine: "codex" }),
+      cmdWake("mawjs", { engine: "codex", respawnWorktrees: true }),
     );
 
     expect(result).toBe("10-mawjs:mawjs-oracle");
@@ -1727,7 +1727,7 @@ describe("cmdWake main-suite coverage", () => {
     restoreTabOrderReturn = 1;
 
     const { result, logs } = await captureLogs(() =>
-      cmdWake("mawjs", { fromSnapshot: true, snapshotId: "snap-1" }),
+      cmdWake("mawjs", { fromSnapshot: true, snapshotId: "snap-1", respawnWorktrees: true }),
     );
 
     expect(result).toBe("54-mawjs:mawjs-oracle");

--- a/test/wake-respawn-optin.test.ts
+++ b/test/wake-respawn-optin.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from "bun:test";
+import {
+  shouldRehydrateWorktrees,
+  planRehydrateWorktreeWindows,
+} from "../src/commands/shared/wake-cmd-helpers";
+import { buildCommandInDir } from "../src/config";
+
+/**
+ * thread #14 — `maw wake <role>` must NOT fan out a `<role>-<wt-suffix>` window
+ * per worktree on disk (the 17-window explosion + cross-role `--continue`
+ * resume incident, 2026-06-11). Per-worktree rehydration is now OPT-IN
+ * (default OFF); owner GO 2026-06-11.
+ */
+
+describe("F1 — per-worktree respawn is opt-in (default OFF)", () => {
+  test("plain wake (no flag, no config) → rehydration OFF → 0 respawns", () => {
+    expect(shouldRehydrateWorktrees({}, {})).toBe(false);
+    expect(shouldRehydrateWorktrees({ respawnWorktrees: false }, { respawnWorktrees: false })).toBe(false);
+  });
+
+  test("opt-in via --respawn-worktrees → ON", () => {
+    expect(shouldRehydrateWorktrees({ respawnWorktrees: true }, {})).toBe(true);
+  });
+
+  test("opt-in via fleet config respawnWorktrees:true → ON", () => {
+    expect(shouldRehydrateWorktrees({}, { respawnWorktrees: true })).toBe(true);
+  });
+
+  test("--no-rehydrate / --main / --solo overrides the opt-in → OFF", () => {
+    expect(shouldRehydrateWorktrees({ respawnWorktrees: true, noRehydrate: true }, { respawnWorktrees: true })).toBe(false);
+  });
+});
+
+describe("F1 — when opted IN, the plan still scopes (own-name + collision skip)", () => {
+  const WTS = [
+    { name: "2-adr", path: "/r.wt-2-adr" },
+    { name: "c-p2pmode", path: "/r.wt-c-p2pmode" },
+    { name: "next-pm", path: "/r.wt-next-pm" }, // the role's own-name worktree
+  ];
+
+  test("one window per worktree, the role's own-name worktree is skipped", () => {
+    const plan = planRehydrateWorktreeWindows("next-pm", WTS, []);
+    expect(plan.length).toBe(2); // next-pm own-name worktree dropped
+    expect(plan.every(p => p.windowName.startsWith("next-pm-"))).toBe(true);
+    expect(plan.some(p => p.worktreeName === "next-pm")).toBe(false);
+  });
+
+  test("a worktree whose window already exists is skipped (collision)", () => {
+    const first = planRehydrateWorktreeWindows("next-pm", WTS, []);
+    const existing = first.map(p => p.windowName);
+    const second = planRehydrateWorktreeWindows("next-pm", WTS, existing);
+    expect(second.length).toBe(0);
+  });
+});
+
+describe("F2 — a rehydrated (fresh) worktree pane never bare-`--continue`s", () => {
+  test("buildCommandInDir with fresh=true emits no `--continue`", () => {
+    const cmd = buildCommandInDir("next-pm-adr", "/tmp/maw-test-nonexistent-cwd-f2", { fresh: true });
+    expect(cmd).not.toContain("--continue");
+  });
+});


### PR DESCRIPTION
## Incident (thread #14, 2026-06-11)
One `maw wake next-pm` ballooned session `03-mb-next-payment-gateway` to 17 `next-pm-*` windows — one per `.wt-*` worktree, several `claude --continue` resuming OTHER agents' live campaign sessions (cross-role contamination). Owner asked for a structural fix.

## What this does (against alpha — the running fleet is on a stale local `feat/all-prs-rebased`, 1397 commits behind)
- **F1 — per-worktree rehydration is now OPT-IN (default OFF).** A plain `maw wake <role>` touches only the role window. Rehydration runs only with `--respawn-worktrees` (or fleet config `respawnWorktrees: true`); `--no-rehydrate`/`--main`/`--solo` still override. New pure gate `shouldRehydrateWorktrees(opts, config)` gates all three rehydration sites (dry-run preview, new-session, existing-session). Prints a `respawned N worktree windows` summary on an opt-in run.
- **F2 — already satisfied on alpha; locked.** A rehydrated worktree window is freshly created, so `buildWakeCommandForPane` sets `freshLaunch → fresh` → no bare `--continue`, no cross-role resume (unlike the stale `feat` code's `buildCommandInDir` auto-probe, which `--continue`d on a sibling role's session in a shared cwd). Added a regression test asserting `fresh` strips `--continue`.
- **F3 — tests:** the gate (plain → OFF, flag/config → ON, `--no-rehydrate` overrides), the scoped plan (own-name + collision skip), and the no-bare-`--continue` invariant. Updated the 5 coverage tests that asserted the old default-ON rehydration to opt-in.

## Verification (dry-run, against the LIVE `03` session — no mutation)
| Scenario | worktree windows |
|---|---|
| **before** plain `maw wake next-pm` (feat behaviour) | **15** (one per `.wt-*`) |
| **after** plain `maw wake next-pm` | **0** → `↻ worktree rehydrate skipped (opt-in only — pass --respawn-worktrees)` |
| **after** `maw wake next-pm --respawn-worktrees` | 15 (restored, now explicit) |

Tests: `bun test test/wake-respawn-optin.test.ts` (7/7) + `test/wake-cmd-cmdwake-coverage.test.ts` (52/0). `tsc --noEmit` clean. (14 pre-existing ssh-transport/failsoft failures in the combined sweep are test-isolation flakiness on alpha — identical with my changes stashed; not from this PR.)

## ⚠️ Flips a default wake semantic for the whole fleet
Rehydration was default-ON (opt-out via `--no-rehydrate`); this makes it opt-in. **Owner GO 2026-06-11 (thread #14).** Per the dispatch rule, **not self-merging** — owner merges. Rollout to the running fleet (`feat/all-prs-rebased` → alpha + relink `~/.bun/bin/maw`) is owner-gated and tracked separately on the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)