### PR TITLE
fix: harden ghq normalization for oracle wake verbs

### DIFF
--- a/src/core/repo-discovery/ghq-normalize.test.ts
+++ b/src/core/repo-discovery/ghq-normalize.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { canonicalRepoKey, normalizeGhqRepos } from "./ghq-normalize";
+
+describe("normalizeGhqRepos", () => {
+  test("prefers canonical repo path when doubled github.com entry appears first", () => {
+    const repos = normalizeGhqRepos([
+      "/opt/Code/github.com/github.com/Soul-Brews-Studio/mawjs-oracle",
+      "/opt/Code/github.com/Soul-Brews-Studio/mawjs-oracle",
+    ]);
+
+    expect(repos).toEqual([
+      "/opt/Code/github.com/Soul-Brews-Studio/mawjs-oracle",
+    ]);
+  });
+
+  test("deduplicates absolute and ghq-relative github.com repo paths by canonical suffix", () => {
+    expect(canonicalRepoKey("github.com/Soul-Brews-Studio/mawjs-oracle")).toBe("soul-brews-studio/mawjs-oracle");
+
+    const repos = normalizeGhqRepos([
+      "github.com/Soul-Brews-Studio/mawjs-oracle",
+      "/opt/Code/github.com/Soul-Brews-Studio/mawjs-oracle",
+    ]);
+
+    expect(repos).toEqual([
+      "github.com/Soul-Brews-Studio/mawjs-oracle",
+    ]);
+  });
+
+  test("filters nested archive ghosts before deduplicating canonical repos", () => {
+    const repos = normalizeGhqRepos([
+      "/opt/Code/_archive/oracle-world/github.com/Soul-Brews-Studio/mawjs-oracle",
+      "/opt/Code/github.com/Soul-Brews-Studio/mawjs-oracle",
+    ]);
+
+    expect(repos).toEqual([
+      "/opt/Code/github.com/Soul-Brews-Studio/mawjs-oracle",
+    ]);
+  });
+});

--- a/src/core/repo-discovery/ghq-normalize.ts
+++ b/src/core/repo-discovery/ghq-normalize.ts
@@ -20,8 +20,7 @@ const ARCHIVE_SEGMENTS = new Set<string>([
   "snapshots",
 ]);
 
-const GITHUB_HOST_MARKER = "/github.com/";
-const DOUBLED_GITHUB_MARKER = `${GITHUB_HOST_MARKER}${GITHUB_HOST_MARKER}`;
+const GITHUB_HOST_SEGMENT = "github.com";
 
 function normalizeRepoPath(path: string): string {
   return path.replace(/\\/g, "/").replace(/\/+$/, "");
@@ -32,7 +31,10 @@ function pathSegments(path: string): string[] {
 }
 
 function isDoubledGithubPath(path: string): boolean {
-  return path.toLowerCase().includes(DOUBLED_GITHUB_MARKER);
+  const segments = pathSegments(path).map((segment) => segment.toLowerCase());
+  return segments.some((segment, index) => (
+    segment === GITHUB_HOST_SEGMENT && segments[index + 1] === GITHUB_HOST_SEGMENT
+  ));
 }
 
 export function isArchiveLikePath(repoPath: string): boolean {
@@ -41,9 +43,10 @@ export function isArchiveLikePath(repoPath: string): boolean {
 
 export function canonicalRepoKey(repoPath: string): string {
   const normalized = normalizeRepoPath(repoPath).toLowerCase();
-  const markerIndex = normalized.lastIndexOf(GITHUB_HOST_MARKER);
-  if (markerIndex >= 0) {
-    return normalized.slice(markerIndex + GITHUB_HOST_MARKER.length);
+  const segments = normalized.split("/").filter(Boolean);
+  const hostIndex = segments.lastIndexOf(GITHUB_HOST_SEGMENT);
+  if (hostIndex >= 0 && hostIndex < segments.length - 1) {
+    return segments.slice(hostIndex + 1).join("/");
   }
   return normalized;
 }


### PR DESCRIPTION
HARDENING oracle/wake verbs follow-up.

Found/fixed: `normalizeGhqRepos` did not recognize real doubled ghq paths shaped `github.com/github.com/<org>/<repo>` because the detector searched for `/github.com//github.com/`. If the doubled ghost appeared before the canonical repo, the resolver kept the ghost path.

Changes:
- Detect doubled github path by path segments.
- Canonical repo keys now handle both absolute ghq paths and ghq-relative `github.com/<org>/<repo>` paths.
- Added targeted tests for doubled-first preference, relative/absolute key dedupe, and nested archive filtering.

Tests:
- `bun test src/core/repo-discovery/ghq-normalize.test.ts src/commands/shared/wake-resolve-impl.test.ts`
- `bun run build`