### PR TITLE
harden: maw share security and lifecycle failures

### DIFF
--- a/src/vendor/mpr-plugins/share/impl.ts
+++ b/src/vendor/mpr-plugins/share/impl.ts
@@ -61,6 +61,17 @@ function hashesMatch(a: string, b: string): boolean {
   return timingSafeEqual(left, right);
 }
 
+function isSha256Hex(value: string): boolean {
+  return /^[a-f0-9]{64}$/i.test(value);
+}
+
+function presentedMatchesTokenHash(share: Share, presented: string): boolean {
+  if (share.auth === "encrypted" && isSha256Hex(presented)) {
+    return hashesMatch(share.tokenHash, presented.toLowerCase());
+  }
+  return hashesMatch(share.tokenHash, hashToken(presented));
+}
+
 function makeSlug(): string {
   while (true) {
     const raw = randomUUID().replace(/-/g, "");
@@ -106,7 +117,8 @@ function encryptedAuthProvider(): ShareAuth {
     verify: (slug, presented) => {
       const share = shareRegistry.get(slug);
       if (!share?.encryptionKeyHash) return false;
-      return hashesMatch(share.encryptionKeyHash, hashShareSecret(presented));
+      const presentedHash = isSha256Hex(presented) ? presented.toLowerCase() : hashShareSecret(presented);
+      return hashesMatch(share.encryptionKeyHash, presentedHash);
     },
   };
 }
@@ -246,7 +258,7 @@ export async function verifyShare(slug: string, presented: string): Promise<bool
   if (!ok) return false;
   const expectedHash = share.tokenHash;
   if (expectedHash.length === 0) return false;
-  return hashesMatch(expectedHash, hashToken(presented));
+  return presentedMatchesTokenHash(share, presented);
 }
 
 export function revoke(slug: string): boolean {

--- a/src/vendor/mpr-plugins/share/index.ts
+++ b/src/vendor/mpr-plugins/share/index.ts
@@ -75,7 +75,7 @@ function parseRoutePart(pathname: string, pattern: string): Record<string, strin
 
 function parseShareToken(req: Request): string {
   const url = new URL(req.url);
-  return url.searchParams.get("token") || url.searchParams.get("t") || url.searchParams.get("k") || "";
+  return url.searchParams.get("token") || url.searchParams.get("t") || url.searchParams.get("h") || "";
 }
 
 function getShareSlugFromWsData(data: ShareWsData): string | null {
@@ -294,11 +294,26 @@ function daemonLoopbackOrigin(flags: Record<string, unknown>): string {
   return `http://127.0.0.1:${port}`;
 }
 
-function displayOrigin(flags: Record<string, unknown>): string {
-  const { host } = loadConfig();
+function formatDisplayHost(host: string): string {
+  if (host.includes("://")) {
+    throw new Error(`share display URL requires config.host without protocol, got '${host}'`);
+  }
+  if (host === "0.0.0.0" || host === "::" || host === "[::]") {
+    throw new Error(`share display URL requires a reachable config.host, got bind-only host '${host}'`);
+  }
+  if (host.includes(":") && !host.startsWith("[") && !host.endsWith("]")) return `[${host}]`;
+  return host;
+}
+
+export function displayOriginForHost(host: string | undefined, port: number): string {
   if (!host) throw new Error("share display URL requires config.host");
+  return `http://${formatDisplayHost(host)}:${port}`;
+}
+
+export function displayOrigin(flags: Record<string, unknown>): string {
+  const { host } = loadConfig();
   const port = daemonPortFromFlags(flags);
-  return `http://${host}:${port}`;
+  return displayOriginForHost(host, port);
 }
 
 function displayShareUrl(origin: string, share: { slug: string; token: string; encrypted?: boolean }): string {
@@ -306,12 +321,19 @@ function displayShareUrl(origin: string, share: { slug: string; token: string; e
   return `${origin}/share/${share.slug}#${param}=${share.token}`;
 }
 
-async function createShareViaDaemon(origin: string, body: CreateShareRequest): Promise<{ slug: string; token: string; encrypted?: boolean }> {
-  const res = await fetch(`${origin}/api/share`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
+export async function createShareViaDaemon(origin: string, body: CreateShareRequest): Promise<{ slug: string; token: string; encrypted?: boolean }> {
+  const endpoint = `${origin}/api/share`;
+  let res: Response;
+  try {
+    res = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`share daemon request failed at ${endpoint}: ${message}; is 'maw serve' running on this port?`);
+  }
   let payload: any = null;
   try {
     payload = await res.json();
@@ -319,7 +341,10 @@ async function createShareViaDaemon(origin: string, body: CreateShareRequest): P
     // keep null payload; status branch below reports HTTP code
   }
   if (!res.ok) {
-    throw new Error(payload?.error || `share daemon returned HTTP ${res.status}`);
+    if (res.status === 404) {
+      throw new Error(`share daemon at ${origin} does not expose /api/share (HTTP 404); ensure maw serve is running with the share plugin loaded`);
+    }
+    throw new Error(payload?.error || `share daemon at ${origin} returned HTTP ${res.status}`);
   }
   if (!payload || typeof payload.slug !== "string" || typeof payload.token !== "string") {
     throw new Error("share daemon returned an invalid response");

--- a/src/vendor/mpr-plugins/share/stream.ts
+++ b/src/vendor/mpr-plugins/share/stream.ts
@@ -151,14 +151,19 @@ function normalizePing(message: string): string {
 }
 
 export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<StreamDeps> = {}): Promise<ShareStreamHandle> {
+  const baseDeps = defaultDeps();
   const resolved = {
-    ...defaultDeps(),
+    ...baseDeps,
     ...deps,
     tmux: {
-      ...(defaultDeps().tmux),
+      ...(baseDeps.tmux),
       ...(deps.tmux ?? {}),
     },
   };
+
+  if (share.expiresAt <= Date.now()) {
+    throw new Error("share expired before stream attach");
+  }
 
   const tempDir = resolved.mkdtempSync(join(resolved.tmpdir(), "maw-share-"));
   const consumerPath = makeStreamConsumerPath(tempDir, share.target);
@@ -167,10 +172,16 @@ export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<St
 
   let closed = false;
   let consumerChild: ChildProcessLike | null = null;
+  let expiryTimer: ReturnType<typeof setTimeout> | null = null;
 
   const close = async (): Promise<void> => {
     if (closed) return;
     closed = true;
+
+    if (expiryTimer) {
+      resolved.clearTimeout(expiryTimer);
+      expiryTimer = null;
+    }
 
     try {
       await resolved.tmux.pipePane(share.target);
@@ -187,6 +198,17 @@ export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<St
       // best effort
     }
   };
+
+  expiryTimer = resolved.setTimeout(() => {
+    void (async () => {
+      await close();
+      try {
+        ws.close(1008, "share expired");
+      } catch {
+        // socket may already be closed
+      }
+    })();
+  }, Math.max(0, share.expiresAt - Date.now()));
 
   const onMessage = (message: unknown): void => {
     const text = decodeInboundMessage(message);

--- a/src/vendor/mpr-plugins/share/viewer.html
+++ b/src/vendor/mpr-plugins/share/viewer.html
@@ -38,17 +38,13 @@
     <pre id="ansi-fallback" style="display:none; margin:0;"></pre>
 
     <script>
-      (() => {
+      void (async () => {
         const match = location.pathname.match(/\/share\/([^/?#]+)/);
         const slug = match?.[1] || "";
         const params = new URLSearchParams(location.hash?.replace(/^#/, "") || "");
         const token = params.get("t") || params.get("token") || "";
         const e2eKey = params.get("k") || "";
-        const wsToken = e2eKey || token;
         const wsProto = location.protocol === "https:" ? "wss" : "ws";
-        const socket = new WebSocket(`${wsProto}://${location.host}/ws/share/${encodeURIComponent(slug)}?${e2eKey ? "k" : "t"}=${encodeURIComponent(wsToken)}`);
-        socket.binaryType = "arraybuffer";
-
 
         const b64urlToBytes = (value) => {
           const base64 = value.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((value.length + 3) % 4);
@@ -75,6 +71,15 @@
             ["decrypt"],
           );
         };
+
+        const sha256Hex = async (value) => {
+          const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+          return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+        };
+
+        const wsProof = e2eKey ? await sha256Hex(e2eKey) : token;
+        const socket = new WebSocket(`${wsProto}://${location.host}/ws/share/${encodeURIComponent(slug)}?${e2eKey ? "h" : "t"}=${encodeURIComponent(wsProof)}`);
+        socket.binaryType = "arraybuffer";
 
         const decryptFrame = async (key, data) => {
           if (!key) return typeof data === "string" ? data : new TextDecoder().decode(data);

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -44,6 +44,11 @@ function parseShareOutput(output: unknown, param = "t"): { slug: string; token: 
   return { slug: match![1]!, token: match![2]! };
 }
 
+function tamperHexDigest(hex: string): string {
+  const replacement = hex.endsWith("0") ? "1" : "0";
+  return `${hex.slice(0, -1)}${replacement}`;
+}
+
 async function makeServeHarness() {
   const httpRoutes: Array<{ method: string; path: string; handler: (req: Request) => Response | Promise<Response> }> = [];
   const wsRoutes: Array<{ path: string; data: (req: Request) => unknown; handlers: Record<string, unknown> }> = [];
@@ -202,7 +207,7 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
       expect(share.encryptionKeyHash).toBe(shareCrypto.hashShareSecret(secret));
       expect(share.encryptionKey).toBeTruthy();
       await expect(shareRuntimeImpl.verifyShare(slug, shareCrypto.hashShareSecret(secret))).resolves.toBe(true);
-      await expect(shareRuntimeImpl.verifyShare(slug, `${shareCrypto.hashShareSecret(secret).slice(0, -1)}0`)).resolves.toBe(false);
+      await expect(shareRuntimeImpl.verifyShare(slug, tamperHexDigest(shareCrypto.hashShareSecret(secret)))).resolves.toBe(false);
 
       const sent: Array<string | Uint8Array> = [];
       let childResolve: (() => void) | null = null;

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import type { Share } from "../../src/vendor/mpr-plugins/share/impl";
 
 const realConfig = await import("../../src/config.ts");
 afterAll(() => { mock.restore(); });
@@ -63,6 +65,20 @@ async function makeServeHarness() {
 }
 
 describe("share plugin standalone boundary (#2685/#2703)", () => {
+  test("share plugin import boundary stays explicit for standalone coverage gate", () => {
+    expectStandalonePluginBoundary({
+      plugin: "share",
+      allowMawJs: ["maw-js/config"],
+      allowRelative: [
+        "../../../commands/plugins/tmux/impl",
+        "../../../core/serve-route-registry",
+        "../../../core/serve-ws-registry",
+        "../../../lib/federation-auth",
+        "../../../config",
+      ],
+    });
+  });
+
   test("manifest-backed sources expose the CLI command and serve hook", () => {
     const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/share/plugin.json"), "utf8"));
     expect(manifest.name).toBe("share");
@@ -169,6 +185,15 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
       const { slug, token: secret } = parseShareOutput(result.output, "k");
       expect(secret.length).toBeGreaterThanOrEqual(43);
 
+      const viewerSource = readFileSync(join(root, "src/vendor/mpr-plugins/share/viewer.html"), "utf8");
+      const indexSource = readFileSync(join(root, "src/vendor/mpr-plugins/share/index.ts"), "utf8");
+      expect(viewerSource).toContain("const e2eKey = params.get(\"k\") || \"\";");
+      expect(viewerSource).toContain("const wsProof = e2eKey ? await sha256Hex(e2eKey) : token;");
+      expect(viewerSource).toContain("?${e2eKey ? \"h\" : \"t\"}=");
+      expect(viewerSource).not.toContain("?${e2eKey ? \"k\" : \"t\"}=");
+      expect(viewerSource).not.toContain("const wsToken = e2eKey || token");
+      expect(indexSource).not.toContain('searchParams.get("k")');
+
       const viewer = await viewerRoute.handler(new Request(`http://127.0.0.1:4567/share/${slug}`));
       expect(viewer.status).toBe(200);
 
@@ -176,6 +201,8 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
       expect(share).toMatchObject({ encrypted: true, auth: "encrypted" });
       expect(share.encryptionKeyHash).toBe(shareCrypto.hashShareSecret(secret));
       expect(share.encryptionKey).toBeTruthy();
+      await expect(shareRuntimeImpl.verifyShare(slug, shareCrypto.hashShareSecret(secret))).resolves.toBe(true);
+      await expect(shareRuntimeImpl.verifyShare(slug, `${shareCrypto.hashShareSecret(secret).slice(0, -1)}0`)).resolves.toBe(false);
 
       const sent: Array<string | Uint8Array> = [];
       let childResolve: (() => void) | null = null;
@@ -208,6 +235,69 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  test("active websocket stream closes and tears down tmux pipe when TTL expires", async () => {
+    const share: Share = {
+      target: "neo:1",
+      panes: [],
+      readOnly: true,
+      tokenHash: "hash",
+      expiresAt: Date.now() + 50,
+      auth: "token",
+    };
+    const sent: Array<string | Uint8Array> = [];
+    const closed: Array<[number | undefined, string | undefined]> = [];
+    const pipeCalls: unknown[][] = [];
+    const clearedTimers: unknown[] = [];
+    const timers: Array<{ fn: () => void; ms: number; id: object }> = [];
+
+    await shareStream.attach(
+      share as any,
+      {
+        send: (data: string | Uint8Array) => sent.push(data),
+        close: (code?: number, reason?: string) => closed.push([code, reason]),
+      } as any,
+      {
+        tmux: {
+          capture: async () => "SNAPSHOT\n",
+          pipePane: async (...args: unknown[]) => {
+            pipeCalls.push(args);
+          },
+        },
+        spawnTail: async () => ({
+          kill: () => undefined,
+          exited: Promise.resolve(0),
+        }),
+        setTimeout: ((fn: () => void, ms: number) => {
+          const id = {};
+          timers.push({ fn, ms, id });
+          return id as any;
+        }) as any,
+        clearTimeout: ((id: unknown) => {
+          clearedTimers.push(id);
+        }) as any,
+      } as any,
+    );
+
+    expect(sent).toEqual(["SNAPSHOT\n"]);
+    const expiryTimer = timers.find((timer) => timer.ms <= 50);
+    expect(expiryTimer).toBeDefined();
+
+    expiryTimer!.fn();
+    for (let i = 0; i < 8; i += 1) await Promise.resolve();
+
+    expect(closed).toEqual([[1008, "share expired"]]);
+    expect(pipeCalls.some((call) => call[0] === "neo:1" && call.length === 1)).toBe(true);
+    expect(clearedTimers).toContain(expiryTimer!.id);
+  });
+
+  test("display URL fails loud for bind-only hosts", () => {
+    expect(() => sharePlugin.displayOriginForHost("0.0.0.0", 3457)).toThrow("bind-only host");
+    expect(() => sharePlugin.displayOriginForHost("::", 3457)).toThrow("bind-only host");
+    expect(() => sharePlugin.displayOriginForHost("http://localhost", 3457)).toThrow("without protocol");
+    expect(sharePlugin.displayOriginForHost("::1", 3457)).toBe("http://[::1]:3457");
+    expect(sharePlugin.displayOriginForHost("local", 3457)).toBe("http://local:3457");
   });
 
   test("serve hook registers create, viewer, metadata, and websocket routes", async () => {

--- a/test/vendor-share-hardening.test.ts
+++ b/test/vendor-share-hardening.test.ts
@@ -15,6 +15,11 @@ import {
   displayOriginForHost,
 } from "../src/vendor/mpr-plugins/share/index";
 
+function tamperHexDigest(hex: string): string {
+  const replacement = hex.endsWith("0") ? "1" : "0";
+  return `${hex.slice(0, -1)}${replacement}`;
+}
+
 describe("share hardening", () => {
   test("encrypted share verification accepts a server-visible hash proof without revealing fragment key", async () => {
     clearShareRegistry();
@@ -23,7 +28,7 @@ describe("share hardening", () => {
 
     expect(proof).not.toBe(share.token);
     await expect(verifyShare(share.slug, proof)).resolves.toBe(true);
-    await expect(verifyShare(share.slug, `${proof.slice(0, -1)}0`)).resolves.toBe(false);
+    await expect(verifyShare(share.slug, tamperHexDigest(proof))).resolves.toBe(false);
   });
 
   test("viewer keeps encrypted key out of server-visible websocket URL", () => {

--- a/test/vendor-share-hardening.test.ts
+++ b/test/vendor-share-hardening.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { hashShareSecret } from "../src/vendor/mpr-plugins/share/crypto";
+import {
+  clearShareRegistry,
+  createShare,
+  verifyShare,
+  type Share,
+} from "../src/vendor/mpr-plugins/share/impl";
+import { attach } from "../src/vendor/mpr-plugins/share/stream";
+import {
+  createShareViaDaemon,
+  displayOriginForHost,
+} from "../src/vendor/mpr-plugins/share/index";
+
+describe("share hardening", () => {
+  test("encrypted share verification accepts a server-visible hash proof without revealing fragment key", async () => {
+    clearShareRegistry();
+    const share = await createShare({ target: "session:0", auth: "encrypted", encrypted: true });
+    const proof = hashShareSecret(share.token);
+
+    expect(proof).not.toBe(share.token);
+    await expect(verifyShare(share.slug, proof)).resolves.toBe(true);
+    await expect(verifyShare(share.slug, `${proof.slice(0, -1)}0`)).resolves.toBe(false);
+  });
+
+  test("viewer keeps encrypted key out of server-visible websocket URL", () => {
+    const viewer = readFileSync(join(import.meta.dir, "../src/vendor/mpr-plugins/share/viewer.html"), "utf8");
+    const server = readFileSync(join(import.meta.dir, "../src/vendor/mpr-plugins/share/index.ts"), "utf8");
+
+    expect(viewer).toContain("const e2eKey = params.get(\"k\") || \"\";");
+    expect(viewer).toContain("const wsProof = e2eKey ? await sha256Hex(e2eKey) : token;");
+    expect(viewer).toContain("?${e2eKey ? \"h\" : \"t\"}=");
+    expect(viewer).not.toContain("?${e2eKey ? \"k\" : \"t\"}=");
+    expect(viewer).not.toContain("const wsToken = e2eKey || token");
+    expect(server).not.toContain('searchParams.get("k")');
+  });
+
+  test("active stream closes itself and websocket when TTL expires", async () => {
+    const share: Share = {
+      target: "session:0",
+      panes: [],
+      readOnly: true,
+      tokenHash: "hash",
+      expiresAt: Date.now() + 50,
+      auth: "token",
+    };
+    const sent: Array<string | Uint8Array> = [];
+    const closed: Array<[number | undefined, string | undefined]> = [];
+    const pipeCalls: unknown[][] = [];
+    const clearedTimers: unknown[] = [];
+    const timers: Array<{ fn: () => void; ms: number; id: object }> = [];
+
+    await attach(
+      share,
+      {
+        send: (data: string | Uint8Array) => sent.push(data),
+        close: (code?: number, reason?: string) => closed.push([code, reason]),
+      } as any,
+      {
+        tmux: {
+          capture: async () => "SNAPSHOT\n",
+          pipePane: async (...args: unknown[]) => {
+            pipeCalls.push(args);
+          },
+        },
+        spawnTail: async () => ({
+          kill: () => {},
+          exited: Promise.resolve(0),
+        }),
+        setTimeout: ((fn: () => void, ms: number) => {
+          const id = {};
+          timers.push({ fn, ms, id });
+          return id as any;
+        }) as any,
+        clearTimeout: ((id: unknown) => {
+          clearedTimers.push(id);
+        }) as any,
+      } as any,
+    );
+
+    expect(sent).toEqual(["SNAPSHOT\n"]);
+    const expiry = timers.find((timer) => timer.ms <= 50);
+    expect(expiry).toBeDefined();
+
+    expiry!.fn();
+    for (let i = 0; i < 8; i += 1) await Promise.resolve();
+
+    expect(closed).toEqual([[1008, "share expired"]]);
+    expect(pipeCalls.some((call) => call[0] === "session:0" && call.length === 1)).toBe(true);
+    expect(clearedTimers).toContain(expiry!.id);
+  });
+
+  test("display URL fails loud for bind-only hosts and formats IPv6 display hosts", () => {
+    expect(() => displayOriginForHost("0.0.0.0", 3457)).toThrow("bind-only host");
+    expect(() => displayOriginForHost("::", 3457)).toThrow("bind-only host");
+    expect(() => displayOriginForHost("http://localhost", 3457)).toThrow("without protocol");
+    expect(displayOriginForHost("::1", 3457)).toBe("http://[::1]:3457");
+    expect(displayOriginForHost("localhost", 3457)).toBe("http://localhost:3457");
+  });
+
+  test("daemon fetch failures name the failing endpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () => {
+        throw new Error("ECONNREFUSED");
+      }) as typeof fetch;
+
+      await expect(createShareViaDaemon("http://127.0.0.1:3999", { target: "session:0" }))
+        .rejects
+        .toThrow("share daemon request failed at http://127.0.0.1:3999/api/share: ECONNREFUSED");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- keep encrypted share E2E keys fragment-only; browser sends only a non-decrypting SHA-256 proof in the WS query
- close active share streams when TTL expires and clean tmux/tail resources
- fail loud for bind-only display hosts such as 0.0.0.0/::
- add endpoint-specific daemon request errors for down/missing share daemon paths

## Issues
Closes #2715
Closes #2716
Closes #2717
Closes #2718

## Verification
- MAW_TEST_MODE=1 bun test test/vendor-share-token.test.ts test/vendor-share-registry.test.ts test/vendor-share-readonly.test.ts test/vendor-share-hardening.test.ts
- bun run build

[m5:mawjs:codex-1]