### PR TITLE
fix: harden TLS serve listener cleanup

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -134,6 +134,29 @@ export function isAddressInUseError(err: unknown): boolean {
     || (e.syscall === "listen" && typeof e.message === "string" && /port .*in use|address.*in use|EADDRINUSE/i.test(e.message));
 }
 
+function bindTlsServerStop(primary: ReturnType<typeof Bun.serve>, tlsServer: ReturnType<typeof Bun.serve>): ReturnType<typeof Bun.serve> {
+  const originalStop = primary.stop;
+  primary.stop = ((closeActiveConnections?: boolean) => {
+    let primaryResult: unknown;
+    let primaryError: unknown;
+    try {
+      primaryResult = originalStop.call(primary, closeActiveConnections);
+    } catch (err) {
+      primaryError = err;
+    }
+
+    try {
+      tlsServer.stop(closeActiveConnections);
+    } catch (err) {
+      if (!primaryError) primaryError = err;
+    }
+
+    if (primaryError) throw primaryError;
+    return primaryResult;
+  }) as typeof primary.stop;
+  return primary;
+}
+
 export function servePortInUseInstructions(port: number, hostname: string): string[] {
   const bind = hostname === "0.0.0.0" ? `port ${port}` : `${hostname}:${port}`;
   return [
@@ -532,7 +555,18 @@ export async function startBunGatewayServer(
   if (tlsCfg?.cert && tlsCfg?.key && existsSync(tlsCfg.cert) && existsSync(tlsCfg.key)) {
     const tlsPort = port + 1;
     const tls = { cert: readFileSync(tlsCfg.cert), key: readFileSync(tlsCfg.key) };
-    Bun.serve({ port: tlsPort, tls, fetch: fetchHandler, websocket: wsConfig });
+    let tlsServer: ReturnType<typeof Bun.serve>;
+    try {
+      tlsServer = Bun.serve({ port: tlsPort, tls, fetch: fetchHandler, websocket: wsConfig });
+    } catch (err) {
+      try { server.stop(true); } catch { /* best effort: startup is already failing */ }
+      if (isAddressInUseError(err)) {
+        for (const line of servePortInUseInstructions(tlsPort, hostname)) log.error(line);
+        throw new UserError(`maw serve TLS port ${tlsPort} is already in use`);
+      }
+      throw err;
+    }
+    bindTlsServerStop(server, tlsServer);
     log.info(`maw serve → https://localhost:${tlsPort} (wss://localhost:${tlsPort}/ws) [TLS]`);
   }
 

--- a/test/isolated/core-server-more-coverage-2.test.ts
+++ b/test/isolated/core-server-more-coverage-2.test.ts
@@ -10,6 +10,8 @@ delete process.env.MAW_CLI;
 
 let config: Record<string, any> = {};
 let serveCalls: any[] = [];
+let stoppedPorts: Array<{ port: number; force?: boolean }> = [];
+let serveThrowOnCall: number | null = null;
 let stopShouldThrow = false;
 let lifecycleShouldThrow = false;
 let sessionsShouldThrow = false;
@@ -155,8 +157,12 @@ const original = {
 
 Bun.serve = ((opts: any) => {
   serveCalls.push(opts);
+  if (serveThrowOnCall === serveCalls.length) {
+    throw Object.assign(new Error("TLS port busy"), { code: "EADDRINUSE", syscall: "listen" });
+  }
   return {
-    stop: (_force?: boolean) => {
+    stop: (force?: boolean) => {
+      stoppedPorts.push({ port: opts.port, force });
       if (stopShouldThrow) throw new Error("stop failed");
     },
   } as never;
@@ -179,6 +185,8 @@ describe("core server remaining isolated coverage", () => {
     process.chdir(tmp);
     config = { bind: "127.0.0.1", federationToken: "1234567890123456" };
     serveCalls = [];
+    stoppedPorts = [];
+    serveThrowOnCall = null;
     stopShouldThrow = false;
     lifecycleShouldThrow = false;
     sessionsShouldThrow = false;
@@ -309,6 +317,35 @@ describe("core server remaining isolated coverage", () => {
     stopShouldThrow = true;
 
     await expect(startServer(4791)).rejects.toThrow("lifecycle failed");
+  });
+
+  test("TLS bind failure stops the already-started HTTP server and fails loud", async () => {
+    const cert = join(tmp, "cert.pem");
+    const key = join(tmp, "key.pem");
+    writeFileSync(cert, "fake-cert");
+    writeFileSync(key, "fake-key");
+    config = { bind: "127.0.0.1", tls: { cert, key } };
+    serveThrowOnCall = 2;
+
+    await expect(startServer(4800)).rejects.toThrow("maw serve TLS port 4801 is already in use");
+
+    expect(serveCalls.map(call => call.port)).toEqual([4800, 4801]);
+    expect(stoppedPorts).toEqual([{ port: 4800, force: true }]);
+    expect(errors.join("\n")).toContain("maw serve cannot start: 127.0.0.1:4801 is already in use");
+  });
+
+  test("stopping a TLS-enabled server also stops the TLS listener", async () => {
+    const cert = join(tmp, "cert.pem");
+    const key = join(tmp, "key.pem");
+    writeFileSync(cert, "fake-cert");
+    writeFileSync(key, "fake-key");
+    config = { bind: "127.0.0.1", tls: { cert, key } };
+
+    const server = await startServer(4802) as { stop: (force?: boolean) => void };
+    server.stop(true);
+
+    expect(serveCalls.map(call => call.port)).toEqual([4802, 4803]);
+    expect(stoppedPorts).toEqual([{ port: 4802, force: true }, { port: 4803, force: true }]);
   });
 });
 


### PR DESCRIPTION
HARDENING serve/gateway/ws layer follow-up.

Found/fixed: `maw serve` starts the HTTP listener before the optional TLS listener. If the TLS `Bun.serve` call failed, startup threw after leaving the HTTP port bound. If TLS succeeded, callers only received the HTTP handle, so `stop()` left the TLS listener alive.

Changes:
- Fail loud with TLS-specific port-in-use error and existing serve instructions.
- Stop the already-started HTTP server when TLS startup fails.
- Chain TLS listener shutdown into the returned server handle.

Tests:
- `timeout 120 bash scripts/test-isolated.sh test/isolated/core-server-more-coverage-2.test.ts`
- `bun run build`