### PR TITLE
harden: wake/fleet/oracle-scan fail loud on corrupt inputs

### DIFF
--- a/src/commands/shared/fleet-load.ts
+++ b/src/commands/shared/fleet-load.ts
@@ -58,6 +58,10 @@ export function resolveFleetSession(oracle: string): string | null {
   try {
     const resolved = resolveFleetWindowSessionTarget(oracle, loadFleet());
     if (resolved.kind === "fuzzy" || resolved.kind === "exact") return resolved.match.name;
-  } catch { /* fleet dir may not exist */ }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith("invalid fleet JSON ")) throw error;
+    /* fleet dir may not exist */
+  }
   return null;
 }

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -875,11 +875,14 @@ async function loadWakeFleetSessions(): Promise<FleetSession[]> {
   try {
     const { loadFleet } = await import("./fleet-load");
     return loadFleet();
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith("invalid fleet JSON ")) throw error;
     // Some isolated tests mock the SDK facade narrowly and intentionally omit
     // fleet constants. Fleet metadata is an optimization for exact numeric
     // targets, so a load failure should fall back to the pre-#1892 resolver
-    // path rather than breaking ordinary wake paths.
+    // path rather than breaking ordinary wake paths. Malformed readable fleet
+    // files are rethrown above so corrupt JSON cannot silently reroute wake.
     return [];
   }
 }

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -74,18 +74,25 @@ async function acquireWorktreePathLock(
 function normalizeWorktreeEngineName(engine: string | undefined, fallbackToClaude = false): string | undefined {
   const normalized = ((engine ?? (fallbackToClaude ? "claude" : ""))).trim().split(/\r?\n/, 1)[0]?.trim();
   if (!normalized) return undefined;
-  // Engine names are config keys / built-ins. Ignore unsafe file contents rather
-  // than letting a compromised worktree marker become a shell command.
+  // Engine names are config keys / built-ins. Reject unsafe file contents
+  // loudly at read-time so rehydrate never silently falls back to the wrong engine.
   if (!/^[A-Za-z0-9_.:-]+$/.test(normalized)) return undefined;
   return normalized;
 }
 
 export function readWorktreeEngineFile(wtPath: string): string | undefined {
+  const marker = join(wtPath, WORKTREE_ENGINE_FILE);
+  let raw: string;
   try {
-    return normalizeWorktreeEngineName(readFileSync(join(wtPath, WORKTREE_ENGINE_FILE), "utf-8"));
+    raw = readFileSync(marker, "utf-8");
   } catch {
     return undefined;
   }
+  const normalized = normalizeWorktreeEngineName(raw);
+  if (!normalized) {
+    throw new Error(`invalid worktree engine marker ${marker}: expected /^[A-Za-z0-9_.:-]+$/`);
+  }
+  return normalized;
 }
 
 export function writeWorktreeEngineFile(

--- a/src/commands/shared/wake-target.ts
+++ b/src/commands/shared/wake-target.ts
@@ -70,8 +70,8 @@ export function parseWakeTarget(target: string): ParsedWakeTarget | null {
 
 /**
  * Ensure a repo is cloned via ghq. Checks locally first (fast),
- * clones from GitHub only if not found. Silent on failure — lets
- * resolveOracle handle the error downstream.
+ * clones from GitHub only if not found. Clone failures are fatal for an
+ * explicit GitHub target so wake does not silently resolve a different repo.
  */
 export async function ensureCloned(slug: string): Promise<void> {
   const ghqHit = await ghqFind(`/${slug}`);
@@ -80,6 +80,7 @@ export async function ensureCloned(slug: string): Promise<void> {
   try {
     await hostExec(`ghq get github.com/${slug}`);
   } catch (e: any) {
-    console.log(`\x1b[33m⚠\x1b[0m clone failed: ${e.message || e}\n  falling back to normal resolution`);
+    const message = e?.message || String(e);
+    throw new Error(`ghq get failed for ${slug}: ${message}`);
   }
 }

--- a/src/core/fleet/fleet-load-core.ts
+++ b/src/core/fleet/fleet-load-core.ts
@@ -63,9 +63,9 @@ function readFleetFiles(dirs: string[]): Array<{ file: string; path: string; ses
       const path = join(dir, file);
       try {
         byName.set(file, { file, path, session: JSON.parse(readFileSync(path, "utf-8")) as FleetSession });
-      } catch {
-        // Keep looking in fallback dirs. A malformed state-first fleet file
-        // should not shadow a valid legacy config with the same filename.
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`invalid fleet JSON ${path}: ${message}`);
       }
     }
   }

--- a/src/core/fleet/registry-oracle-scan-local.ts
+++ b/src/core/fleet/registry-oracle-scan-local.ts
@@ -26,23 +26,53 @@ interface FleetLineage {
 }
 
 
+function isLikelyHostName(segment: string): boolean {
+  if (segment === "github.com") return true;
+  return /^[a-z0-9.-]+\.[a-z]{2,}$/i.test(segment);
+}
+
+function isArchivedSegment(segment: string): boolean {
+  return /^_?\.?archive(?:d)?$/i.test(segment);
+}
+
+function normalizeFleetRepoRef(ref: unknown, source: string): string {
+  if (typeof ref !== "string") {
+    throw new Error(`invalid fleet repo reference in ${source}: expected string, got ${typeof ref}`);
+  }
+  const normalized = ref
+    .trim()
+    .replace(/^https?:\/\/github\.com\//i, "")
+    .replace(/^git@github\.com:/i, "")
+    .replace(/\.git$/i, "")
+    .replace(/^github\.com\//i, "");
+  const parsed = parseFleetRepoSlug(normalized);
+  if (!parsed) {
+    throw new Error(`invalid fleet repo reference in ${source}: ${ref}`);
+  }
+  return `${parsed.org}/${parsed.repo}`;
+}
+
 function addFleetLineageConfig(map: Map<string, FleetLineage>, config: any): void {
-  const repos: string[] = config.project_repos || [];
+  const repos: unknown[] = config.project_repos || [];
   for (const r of repos) {
-    map.set(r, {
-      repo: r,
+    const repoRef = normalizeFleetRepoRef(r, "project_repos");
+    map.set(repoRef, {
+      repo: repoRef,
       budded_from: config.budded_from || null,
       budded_at: config.budded_at || null,
     });
   }
   // Also check windows for repo references
   for (const w of config.windows || []) {
-    if (w.repo && !map.has(w.repo)) {
-      map.set(w.repo, {
-        repo: w.repo,
-        budded_from: config.budded_from || null,
-        budded_at: config.budded_at || null,
-      });
+    if (w.repo) {
+      const repoRef = normalizeFleetRepoRef(w.repo, "windows[].repo");
+      if (!map.has(repoRef)) {
+        map.set(repoRef, {
+          repo: repoRef,
+          budded_from: config.budded_from || null,
+          budded_at: config.budded_at || null,
+        });
+      }
     }
   }
 }
@@ -53,15 +83,25 @@ export function readFleetLineage(fleetDir?: string | string[]): Map<string, Flee
   const seenFiles = new Set<string>();
   const dirs = Array.isArray(fleetDir) ? fleetDir : fleetDir ? [fleetDir] : fleetDirsForRead();
   for (const dir of dirs) {
+    let files: string[];
     try {
-      for (const file of readdirSync(dir).filter(f => f.endsWith(".json")).sort()) {
-        if (seenFiles.has(file)) continue;
-        seenFiles.add(file);
-        try {
-          addFleetLineageConfig(map, JSON.parse(readFileSync(join(dir, file), "utf-8")));
-        } catch { /* invalid fleet file, skip */ }
+      files = readdirSync(dir).filter(f => f.endsWith(".json")).sort();
+    } catch {
+      // Missing/unreadable fleet dirs are optional read locations; malformed
+      // files inside a readable dir are not optional and must fail loud.
+      continue;
+    }
+    for (const file of files) {
+      if (seenFiles.has(file)) continue;
+      seenFiles.add(file);
+      const path = join(dir, file);
+      try {
+        addFleetLineageConfig(map, JSON.parse(readFileSync(path, "utf-8")));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`invalid fleet lineage JSON ${path}: ${message}`);
       }
-    } catch { /* fleet dir may not exist */ }
+    }
   }
   return map;
 }
@@ -82,17 +122,12 @@ interface ScanLocalDeps {
   fleetLineage?: Map<string, FleetLineage>;
 }
 
-function isLikelyHostName(segment: string): boolean {
-  if (segment === "github.com") return true;
-  return /^[a-z0-9.-]+\.[a-z]{2,}$/i.test(segment);
-}
-
 function parseFleetRepoSlug(key: string): { org: string; repo: string } | null {
   const parts = key.split("/").filter(Boolean);
   if (parts.length !== 2) return null;
   const [org, repo] = parts;
   if (!org || !repo) return null;
-  if (isLikelyHostName(org)) return null;
+  if (isLikelyHostName(org) || isArchivedSegment(org) || isArchivedSegment(repo)) return null;
   return { org, repo };
 }
 
@@ -119,8 +154,8 @@ export function scanLocal(verbose = true, deps: ScanLocalDeps = {}): OracleEntry
   // Walk reposRoot: <reposRoot>/<org>/<repo>/
   try {
     for (const org of readdirSync(reposRoot)) {
-      if (isLikelyHostName(org)) {
-        if (verbose) console.log(`  \x1b[90m  ⏭ skipping host-like org segment: ${org}\x1b[0m`);
+      if (isLikelyHostName(org) || isArchivedSegment(org)) {
+        if (verbose) console.log(`  \x1b[90m  ⏭ skipping non-repo org segment: ${org}\x1b[0m`);
         continue;
       }
       const orgPath = join(reposRoot, org);
@@ -132,6 +167,7 @@ export function scanLocal(verbose = true, deps: ScanLocalDeps = {}): OracleEntry
       let oracleCount = 0;
 
       for (const repo of readdirSync(orgPath)) {
+        if (isArchivedSegment(repo)) continue;
         const repoPath = join(orgPath, repo);
         try {
           if (!statSync(repoPath).isDirectory()) continue;

--- a/test/isolated/coverage-core-shared-helpers.test.ts
+++ b/test/isolated/coverage-core-shared-helpers.test.ts
@@ -201,16 +201,17 @@ describe("coverage core shared helpers", () => {
     expect(wakeTarget.parseWakeTarget("neo")).toBeNull();
   });
 
-  test("ensureCloned skips existing ghq hits and degrades on clone failure", async () => {
+  test("ensureCloned skips existing ghq hits and fails loud on clone failure", async () => {
     ghqHit = "/gh/Soul-Brews-Studio/neo-oracle";
     await wakeTarget.ensureCloned("Soul-Brews-Studio/neo-oracle");
     expect(hostExecCalls).toEqual([]);
 
     ghqHit = "";
     hostExecShouldReject = true;
-    await wakeTarget.ensureCloned("Soul-Brews-Studio/missing-oracle");
+    await expect(wakeTarget.ensureCloned("Soul-Brews-Studio/missing-oracle")).rejects.toThrow(
+      "ghq get failed for Soul-Brews-Studio/missing-oracle",
+    );
     expect(hostExecCalls).toEqual(["ghq get github.com/Soul-Brews-Studio/missing-oracle"]);
-    expect(logs.join("\n")).toContain("clone failed");
   });
 
   test("PID lock signal handlers remove the lock file before exiting", () => {

--- a/test/isolated/coverage-next-core-wake-session-resolve.test.ts
+++ b/test/isolated/coverage-next-core-wake-session-resolve.test.ts
@@ -83,7 +83,7 @@ describe("coverage next wake-session", () => {
     expect(wakeSession.readWorktreeEngineFile(wt)).toBe("opencode");
 
     writeFileSync(join(wt, ".maw-engine"), "bad;rm -rf /\n", "utf-8");
-    expect(wakeSession.readWorktreeEngineFile(wt)).toBeUndefined();
+    expect(() => wakeSession.readWorktreeEngineFile(wt)).toThrow("invalid worktree engine marker");
   });
 
   test("ensureSessionRunning retries idle shells with default commands and skips busy panes", async () => {

--- a/test/isolated/team-ensure-config-and-fleet-load-coverage.test.ts
+++ b/test/isolated/team-ensure-config-and-fleet-load-coverage.test.ts
@@ -134,6 +134,13 @@ describe("fleet-load coverage", () => {
     ]);
   });
 
+  test("loadFleetEntries fails loud on truncated active fleet JSON", () => {
+    const broken = join(fleetDir, "008-broken.json");
+    writeFileSync(broken, "{not json");
+
+    expect(() => fleetLoad.loadFleetEntries()).toThrow(`invalid fleet JSON ${broken}:`);
+  });
+
   test("loadFleetEntries reads XDG state fleet first with legacy config fallback", () => {
     writeFileSync(join(fleetDir, "10-legacy-only.json"), JSON.stringify({ name: "legacy", windows: [] }));
     writeFileSync(join(fleetDir, "20-overlap.json"), JSON.stringify({ name: "legacy-overlap", windows: [] }));
@@ -185,7 +192,7 @@ describe("fleet-load coverage", () => {
     ]);
   });
 
-  test("loadFleetEntries falls back past malformed XDG state fleet files", () => {
+  test("loadFleetEntries fails loud on malformed XDG state fleet files instead of silently using legacy fallback", () => {
     writeFileSync(join(fleetDir, "20-overlap.json"), JSON.stringify({
       name: "legacy-overlap",
       windows: [{ name: "legacy-recovers" }],
@@ -194,20 +201,10 @@ describe("fleet-load coverage", () => {
       name: "state",
       windows: [{ name: "state-oracle" }],
     }));
-    writeFileSync(join(stateFleetDir, "20-overlap.json"), "{not json");
+    const broken = join(stateFleetDir, "20-overlap.json");
+    writeFileSync(broken, "{not json");
 
-    expect(fleetLoad.loadFleetEntries().map(({ file, path, session }) => ({ file, path, session }))).toEqual([
-      {
-        file: "10-state-only.json",
-        path: join(stateFleetDir, "10-state-only.json"),
-        session: { name: "state", windows: [{ name: "state-oracle" }] },
-      },
-      {
-        file: "20-overlap.json",
-        path: join(fleetDir, "20-overlap.json"),
-        session: { name: "legacy-overlap", windows: [{ name: "legacy-recovers" }] },
-      },
-    ]);
+    expect(() => fleetLoad.loadFleetEntries()).toThrow(`invalid fleet JSON ${broken}:`);
   });
 
   test("getSessionNames returns trimmed tmux session names and [] on tmux errors", async () => {

--- a/test/registry-oracle-scan-local.test.ts
+++ b/test/registry-oracle-scan-local.test.ts
@@ -34,7 +34,7 @@ afterEach(() => {
 });
 
 describe("registry-oracle-scan-local", () => {
-  test("readFleetLineage merges project_repos and window repo references while skipping invalid files", () => {
+  test("readFleetLineage merges project_repos and window repo references", () => {
     const root = tmpRoot("lineage");
     const fleetDir = join(root, "fleet");
     mkdirp(fleetDir);
@@ -42,12 +42,11 @@ describe("registry-oracle-scan-local", () => {
       project_repos: ["Soul-Brews-Studio/mawjs-oracle", "Soul-Brews-Studio/fleet-only-oracle"],
       windows: [
         { name: "mawjs", repo: "Soul-Brews-Studio/mawjs-oracle" },
-        { name: "issuer", repo: "Soul-Brews-Studio/mawjs-issuer-oracle" },
+        { name: "issuer", repo: "github.com/Soul-Brews-Studio/mawjs-issuer-oracle.git" },
       ],
       budded_from: "seed-oracle",
       budded_at: "2026-05-16T00:00:00.000Z",
     });
-    writeFileSync(join(fleetDir, "broken.json"), "{ nope");
     writeJson(join(fleetDir, "ignored.json.disabled"), {
       project_repos: ["Soul-Brews-Studio/ignored-oracle"],
     });
@@ -64,6 +63,16 @@ describe("registry-oracle-scan-local", () => {
       budded_at: "2026-05-16T00:00:00.000Z",
     });
     expect(readFleetLineage(join(root, "missing")).size).toBe(0);
+  });
+
+  test("readFleetLineage fails loud on truncated or malformed fleet JSON", () => {
+    const root = tmpRoot("lineage-broken");
+    const fleetDir = join(root, "fleet");
+    mkdirp(fleetDir);
+    const broken = join(fleetDir, "broken.json");
+    writeFileSync(broken, "{ nope");
+
+    expect(() => readFleetLineage(fleetDir)).toThrow(`invalid fleet lineage JSON ${broken}:`);
   });
 
   test("deriveName removes only the canonical -oracle suffix", () => {
@@ -160,19 +169,34 @@ describe("registry-oracle-scan-local", () => {
     expect(entries.map((entry) => `${entry.org}/${entry.repo}`)).toEqual(["Soul-Brews-Studio/valid-oracle"]);
   });
 
-  test("scanLocal treats malformed fleet lineage key github.com/owner as non-oracle", () => {
+  test("readFleetLineage fails loud on malformed owner-only fleet repo refs", () => {
     const root = tmpRoot("malformed-lineage");
-    const ghqRoot = join(root, "ghq");
     const fleetDir = join(root, "fleet");
     mkdirp(fleetDir);
 
-    writeJson(join(fleetDir, "fleet.json"), {
+    const file = join(fleetDir, "fleet.json");
+    writeJson(file, {
       project_repos: ["github.com/laris-co"],
     });
 
+    expect(() => readFleetLineage(fleetDir)).toThrow(`invalid fleet lineage JSON ${file}: invalid fleet repo reference in project_repos: github.com/laris-co`);
+  });
+
+  test("scanLocal skips doubled host trees and archived repo segments", () => {
+    const root = tmpRoot("archive-skip");
+    const ghqRoot = join(root, "ghq");
+    const fleetDir = join(root, "fleet");
+    mkdirp(fleetDir);
+    writeJson(join(fleetDir, "fleet.json"), { project_repos: [], windows: [] });
+
+    makeRepo(ghqRoot, "Soul-Brews-Studio", "valid-oracle", { psi: true });
+    makeRepo(ghqRoot, "github.com", "doubled-oracle", { psi: true });
+    makeRepo(ghqRoot, "_archive", "archived-oracle", { psi: true });
+    makeRepo(ghqRoot, "Soul-Brews-Studio", "_archive", { psi: true });
+
     const entries = scanLocal(false, { ghqRoot, fleetDir });
 
-    expect(entries).toHaveLength(0);
+    expect(entries.map((entry) => `${entry.org}/${entry.repo}`)).toEqual(["Soul-Brews-Studio/valid-oracle"]);
   });
 
   test("scanLocal verbose mode reports scan sources, fleet-only refs, enrichment, and walk failures", () => {

--- a/test/wake-target-ensure-cloned.test.ts
+++ b/test/wake-target-ensure-cloned.test.ts
@@ -77,13 +77,10 @@ describe("ensureCloned", () => {
     expect(rendered.join("\n")).toContain("cloning org/repo");
   });
 
-  test("logs clone failures and leaves downstream resolution to continue", async () => {
+  test("throws clone failures for explicit targets", async () => {
     hostExecError = new Error("network down");
 
-    const rendered = await captureLogs(() => ensureCloned("org/repo"));
-
+    await expect(captureLogs(() => ensureCloned("org/repo"))).rejects.toThrow("ghq get failed for org/repo: network down");
     expect(hostExecCalls).toEqual(["ghq get github.com/org/repo"]);
-    expect(rendered.join("\n")).toContain("clone failed: network down");
-    expect(rendered.join("\n")).toContain("falling back to normal resolution");
   });
 });


### PR DESCRIPTION
Harden wake/fleet/oracle-scan paths Nat uses daily.

What changed:
- Fail loudly when explicit `maw wake org/repo` ghq clone fails instead of falling through to fuzzy local resolution.
- Fail loudly on invalid `.maw-engine` rehydrate markers instead of silently using the wrong engine.
- Fail loudly on truncated/malformed active fleet JSON and fleet lineage JSON.
- Normalize valid GitHub repo refs in fleet lineage while rejecting owner-only/malformed refs.
- Skip doubled host trees and archive segments during local oracle scanning.

Verification:
- `bun test test/registry-oracle-scan-local.test.ts test/wake-target-ensure-cloned.test.ts test/isolated/team-ensure-config-and-fleet-load-coverage.test.ts`
- `bun test test/isolated/coverage-core-shared-helpers.test.ts`
- `bun test test/isolated/coverage-next-core-wake-session-resolve.test.ts`
- `bun test test/wake-cmd-cmdwake-coverage.test.ts test/isolated/wake-cmd-dryrun-coverage.test.ts`
- `bun run build`
