### PR TITLE
fix: refuse malformed from-signing envelopes

### DIFF
--- a/src/lib/federation-auth.ts
+++ b/src/lib/federation-auth.ts
@@ -500,7 +500,7 @@ export function verifyRequest(args: {
   const partialV3 = hasAnyV3Header && !hasV3Sig;
   const partialLegacy = !hasV3Sig && hasAnyLegacyHeader && !hasLegacySig;
 
-  if ((from && !hasAnyV3Header && !hasAnyLegacyHeader) || partialV3 || partialLegacy) {
+  if (partialV3 || partialLegacy) {
     if (!from) return { kind: "refuse-malformed", reason: "missing-from" };
     if (partialV3 && !v3Sig) return { kind: "refuse-malformed", reason: "missing-signature" };
     if (partialV3 && !v3Timestamp) return { kind: "refuse-malformed", reason: "invalid-timestamp" };

--- a/src/lib/federation-auth.ts
+++ b/src/lib/federation-auth.ts
@@ -495,6 +495,19 @@ export function verifyRequest(args: {
   const legacySignedAtIso = (headers.get("x-maw-signed-at") ?? "").trim();
   const hasV3Sig = !!from && !!v3Sig && !!v3Timestamp;
   const hasLegacySig = !!from && !!legacySig && !!legacySignedAtIso;
+  const hasAnyV3Header = !!v3Sig || !!v3Timestamp;
+  const hasAnyLegacyHeader = !!legacySig || !!legacySignedAtIso;
+  const partialV3 = hasAnyV3Header && !hasV3Sig;
+  const partialLegacy = !hasV3Sig && hasAnyLegacyHeader && !hasLegacySig;
+
+  if ((from && !hasAnyV3Header && !hasAnyLegacyHeader) || partialV3 || partialLegacy) {
+    if (!from) return { kind: "refuse-malformed", reason: "missing-from" };
+    if (partialV3 && !v3Sig) return { kind: "refuse-malformed", reason: "missing-signature" };
+    if (partialV3 && !v3Timestamp) return { kind: "refuse-malformed", reason: "invalid-timestamp" };
+    if (partialLegacy && !legacySig) return { kind: "refuse-malformed", reason: "missing-signature" };
+    if (partialLegacy && !legacySignedAtIso) return { kind: "refuse-malformed", reason: "invalid-signed-at" };
+    return { kind: "refuse-malformed", reason: "missing-signature" };
+  }
 
   const cached = from ? (args.lookupPubkey(from) ?? undefined) : undefined;
   // "Signed" means the v3 from-signing trio is present. During alpha, accept

--- a/test/isolated/federation-auth-runtime-coverage.test.ts
+++ b/test/isolated/federation-auth-runtime-coverage.test.ts
@@ -138,6 +138,38 @@ describe("federationAuth protected runtime branches", () => {
 });
 
 describe("verifyRequest current-v3 malformed and edge branches", () => {
+  test("uncached partial v3 headers refuse malformed instead of falling back to legacy", () => {
+    const decision = verifyRequest({
+      method: "POST",
+      path: "/api/send",
+      headers: {
+        "x-maw-from": FROM,
+        "x-maw-signature-v3": "0".repeat(64),
+      },
+      body: "",
+      lookupPubkey: () => undefined,
+      now: 1_700_000_000,
+    });
+
+    expect(decision).toEqual({ kind: "refuse-malformed", reason: "invalid-timestamp" });
+  });
+
+  test("uncached partial legacy from-signing headers refuse malformed", () => {
+    const decision = verifyRequest({
+      method: "POST",
+      path: "/api/send",
+      headers: {
+        "x-maw-from": FROM,
+        "x-maw-signed-at": new Date(1_700_000_000_000).toISOString(),
+      },
+      body: "",
+      lookupPubkey: () => undefined,
+      now: 1_700_000_000,
+    });
+
+    expect(decision).toEqual({ kind: "refuse-malformed", reason: "missing-signature" });
+  });
+
   test("cached v3 request with malformed unix timestamp refuses as invalid-timestamp", () => {
     const decision = verifyRequest({
       method: "POST",


### PR DESCRIPTION
HARDENING coordination layer follow-up.

Found/fixed: `verifyRequest` treated partial from-signing headers from an uncached peer as unsigned legacy traffic. Example: `X-Maw-From` + `X-Maw-Signature-V3` without `X-Maw-Timestamp` was accepted via the no-cache/no-sig legacy branch instead of failing loud.

Changes:
- Detect partial current-v3 and legacy from-signing envelopes before TOFU/legacy fallback.
- Return `refuse-malformed` with specific reasons for missing signature/from/timestamp fields.
- Preserve complete v3 preference over legacy fallback.

Tests:
- `timeout 120 bash scripts/test-isolated.sh test/isolated/federation-auth-runtime-coverage.test.ts`
- `bun run build`