### PR TITLE
harden: tmux transport capture, pipe, and pane parsing

### DIFF
--- a/src/api/tmux-stream.ts
+++ b/src/api/tmux-stream.ts
@@ -80,8 +80,9 @@ export function createTmuxStreamConnection(ws: StreamWebSocket, deps: TmuxStream
       const entries = await Promise.all(panes.map(async pane => {
         try {
           return [pane.id, await capturePane(pane.id, captureLines)] as const;
-        } catch {
-          return [pane.id, ""] as const;
+        } catch (error) {
+          logStreamError(deps, `capture failed for pane ${pane.id}`, error);
+          return [pane.id, captures[pane.id] ?? ""] as const;
         }
       }));
       for (const [id, text] of entries) {

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -272,22 +272,26 @@ export class Tmux {
   async listPanes(): Promise<TmuxPane[]> {
     try {
       const raw = await this.run("list-panes", "-a", "-F",
-        "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}");
+        "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}|||#{pane_dead}");
       const num = (value: string | undefined) => {
+        if (value === undefined || value === "") return undefined;
         const n = Number(value);
         return Number.isFinite(n) ? n : undefined;
       };
       const bool = (value: string | undefined) => value === "1" || value === "true";
-      return raw.split("\n").filter(Boolean).map(line => {
-        const [id, command, target, title, pid, cwd, winAct, top, left, paneW, paneH, paneIdx, winIdx, winName, paneActive, winW, winH, winActive, attached] = line.split("|||");
-        return {
+      return raw.split("\n").filter(Boolean).flatMap(line => {
+        const parts = line.split("|||");
+        if (parts.length < 3) return [];
+        const [id, command, target, title, pid, cwd, winAct, top, left, paneW, paneH, paneIdx, winIdx, winName, paneActive, winW, winH, winActive, attached, dead] = parts;
+        if (!id?.startsWith("%") || !target || bool(dead)) return [];
+        return [{
           id,
           command,
           target,
           title,
-          pid: pid ? Number(pid) : undefined,
+          pid: num(pid),
           cwd: cwd || undefined,
-          lastActivity: winAct ? Number(winAct) : undefined,
+          lastActivity: num(winAct),
           top: num(top),
           left: num(left),
           w: num(paneW),
@@ -298,7 +302,7 @@ export class Tmux {
           active: bool(paneActive),
           window: { w: num(winW), h: num(winH), active: bool(winActive) },
           attached: bool(attached),
-        };
+        }];
       });
     } catch { return []; }
   }
@@ -346,13 +350,8 @@ export class Tmux {
   }
 
   async capture(target: string, lines = 80): Promise<string> {
-    if (lines > 50) {
-      return this.run("capture-pane", "-t", target, "-e", "-p", "-S", -lines);
-    }
-    // For shorter captures, pipe through tail (needs raw hostExec)
-    const socketFlag = this.socket ? `-S ${q(this.socket)} ` : "";
-    const cmd = `tmux ${socketFlag}capture-pane -t ${q(target)} -e -p 2>/dev/null | tail -${lines}`;
-    return hostExec(cmd, this.host);
+    const safeLines = Math.max(1, Math.floor(lines));
+    return this.run("capture-pane", "-t", target, "-e", "-p", "-S", -safeLines);
   }
 
   async resizePane(target: string, cols: number, rows: number): Promise<void> {
@@ -415,14 +414,17 @@ export class Tmux {
     /** Only open a new pipe if none exists (`-o`). */
     onlyIfClosed?: boolean;
   } = {}): Promise<void> {
+    if (command === undefined) {
+      await this.run("pipe-pane", "-t", target);
+      return;
+    }
     const args: (string | number)[] = [];
     const input = opts.input === true;
     const output = opts.output !== false || !input;
     if (input) args.push("-I");
     if (output) args.push("-O");
     if (opts.onlyIfClosed) args.push("-o");
-    args.push("-t", target);
-    if (command !== undefined) args.push(command);
+    args.push("-t", target, command);
     await this.run("pipe-pane", ...args);
   }
 

--- a/test/isolated/tmux-class-coverage.test.ts
+++ b/test/isolated/tmux-class-coverage.test.ts
@@ -130,7 +130,7 @@ describe("tmux-class isolated coverage", () => {
         host: "remote-box",
       },
       {
-        cmd: "tmux -S '/tmp/maw socket.sock' capture-pane -t sess:oracle.0 -e -p 2>/dev/null | tail -12",
+        cmd: "tmux -S '/tmp/maw socket.sock' capture-pane -t sess:oracle.0 -e -p -S -12",
         host: "remote-box",
       },
       {

--- a/test/isolated/tmux-class-eighth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-eighth-pass-coverage.test.ts
@@ -54,7 +54,7 @@ describe("tmux-class eighth-pass isolated coverage", () => {
         args: [
           "-a",
           "-F",
-          "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}",
+          "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}|||#{pane_dead}",
         ],
       },
     ]);

--- a/test/isolated/tmux-class-eleventh-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-eleventh-pass-coverage.test.ts
@@ -72,7 +72,7 @@ describe("tmux-class eleventh-pass isolated coverage", () => {
 
     expect(hostExecCalls).toEqual([
       { cmd: "tmux display-message 'hello world'", host: "remote-box" },
-      { cmd: "tmux capture-pane -t session:win.0 -e -p 2>/dev/null | tail -7", host: "remote-box" },
+      { cmd: "tmux capture-pane -t session:win.0 -e -p -S -7", host: "remote-box" },
       { cmd: "printf '%s' 'don'\\''t quote twice' | tmux load-buffer -", host: "remote-box" },
     ]);
   });

--- a/test/isolated/tmux-class-fifth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-fifth-pass-coverage.test.ts
@@ -113,7 +113,7 @@ describe("tmux-class fifth-pass isolated coverage", () => {
         args: [
           "-a",
           "-F",
-          "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}",
+          "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}|||#{pane_dead}",
         ],
       },
     ]);

--- a/test/isolated/tmux-class-fourteenth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-fourteenth-pass-coverage.test.ts
@@ -125,7 +125,7 @@ describe("tmux-class fourteenth-pass isolated coverage", () => {
         host: "remote-box",
       },
       {
-        cmd: "tmux -S '/tmp/fourteenth pass.sock' capture-pane -t 'alpha pane' -e -p 2>/dev/null | tail -8",
+        cmd: "tmux -S '/tmp/fourteenth pass.sock' capture-pane -t 'alpha pane' -e -p -S -8",
         host: "remote-box",
       },
       {

--- a/test/isolated/tmux-class-fourth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-fourth-pass-coverage.test.ts
@@ -147,7 +147,7 @@ describe("tmux-class fourth-pass isolated coverage", () => {
         host: "remote-box",
       },
       {
-        cmd: "tmux capture-pane -t 'pane target' -e -p 2>/dev/null | tail -4",
+        cmd: "tmux capture-pane -t 'pane target' -e -p -S -4",
         host: "remote-box",
       },
       {

--- a/test/isolated/tmux-class-ninth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-ninth-pass-coverage.test.ts
@@ -73,7 +73,7 @@ describe("tmux-class ninth-pass isolated coverage", () => {
         args: [
           "-a",
           "-F",
-          "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}",
+          "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}|||#{pane_dead}",
         ],
       },
       { subcommand: "kill-pane", args: ["-t", "%13"] },

--- a/test/isolated/tmux-class-seventh-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-seventh-pass-coverage.test.ts
@@ -121,7 +121,7 @@ describe("tmux-class seventh-pass isolated coverage", () => {
         host: "remote-box",
       },
       {
-        cmd: "tmux capture-pane -t 'alpha pane' -e -p 2>/dev/null | tail -3",
+        cmd: "tmux capture-pane -t 'alpha pane' -e -p -S -3",
         host: "remote-box",
       },
       {

--- a/test/isolated/tmux-class-sixth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-sixth-pass-coverage.test.ts
@@ -131,7 +131,7 @@ describe("tmux-class sixth-pass isolated coverage", () => {
         host: "remote-box",
       },
       {
-        cmd: "tmux -S '/tmp/explicit socket.sock' capture-pane -t 'pane target' -e -p 2>/dev/null | tail -50",
+        cmd: "tmux -S '/tmp/explicit socket.sock' capture-pane -t 'pane target' -e -p -S -50",
         host: "remote-box",
       },
       {

--- a/test/isolated/tmux-class-tenth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-tenth-pass-coverage.test.ts
@@ -120,10 +120,10 @@ describe("tmux-class tenth-pass isolated coverage", () => {
     ]);
   });
 
-  test("listPanes preserves malformed truthy numeric fields instead of dropping the pane", async () => {
+  test("listPanes keeps panes with malformed numeric fields but normalizes them to undefined", async () => {
     const t = new RecordingTmux().queue(
       "list-panes",
-      "%bad|||node|||alpha:debug.2|||debug|||not-a-pid|||/repo|||not-activity\n",
+      "%bad|||node|||alpha:debug.2|||debug|||not-a-pid|||/repo|||not-activity||||||||||||||||||||||||||||||||||||||||||||||||0\n",
     );
 
     const panes = await t.listPanes();
@@ -136,15 +136,15 @@ describe("tmux-class tenth-pass isolated coverage", () => {
       title: "debug",
       cwd: "/repo",
     });
-    expect(Number.isNaN(panes[0].pid)).toBe(true);
-    expect(Number.isNaN(panes[0].lastActivity)).toBe(true);
+    expect(panes[0].pid).toBeUndefined();
+    expect(panes[0].lastActivity).toBeUndefined();
     expect(t.calls).toEqual([
       {
         subcommand: "list-panes",
         args: [
           "-a",
           "-F",
-          "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}",
+          "#{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}|||#{pane_dead}",
         ],
       },
     ]);
@@ -153,7 +153,7 @@ describe("tmux-class tenth-pass isolated coverage", () => {
   test("listPanes parses spatial pane, window, and session metadata", async () => {
     const t = new RecordingTmux().queue(
       "list-panes",
-      "%7|||claude|||alpha:main.1|||main|||123|||/repo|||1700|||4|||9|||80|||24|||1|||2|||main|||1|||160|||48|||0|||1\n",
+      "%7|||claude|||alpha:main.1|||main|||123|||/repo|||1700|||4|||9|||80|||24|||1|||2|||main|||1|||160|||48|||0|||1|||0\n",
     );
 
     await expect(t.listPanes()).resolves.toEqual([{
@@ -175,6 +175,21 @@ describe("tmux-class tenth-pass isolated coverage", () => {
       window: { w: 160, h: 48, active: false },
       attached: true,
     }]);
+  });
+
+  test("listPanes skips dead panes and malformed rows", async () => {
+    const t = new RecordingTmux().queue(
+      "list-panes",
+      [
+        "not-a-pane-row",
+        "%8|||zsh|||alpha:dead.0|||dead|||999|||/repo|||1701|||0|||0|||80|||24|||0|||1|||dead|||0|||80|||24|||0|||0|||1",
+        "%9|||codex|||alpha:live.0|||live|||1000|||/repo|||1702|||0|||0|||80|||24|||0|||1|||live|||1|||80|||24|||1|||1|||0",
+      ].join("\n"),
+    );
+
+    const panes = await t.listPanes();
+
+    expect(panes.map(p => p.id)).toEqual(["%9"]);
   });
 
   test("getPaneCommands fails soft when the batch pane command lookup errors", async () => {

--- a/test/isolated/tmux-stream.test.ts
+++ b/test/isolated/tmux-stream.test.ts
@@ -46,4 +46,33 @@ describe("tmux websocket stream (#2048)", () => {
 
     connection.close();
   });
+
+  test("logs pane capture failures and keeps last good capture instead of blanking panes", async () => {
+    const sent: string[] = [];
+    const errors: string[] = [];
+    let fail = false;
+    const ws = { send: (payload: string) => { sent.push(payload); } };
+
+    const connection = createTmuxStreamConnection(ws, {
+      startTimers: false,
+      layoutRows: async () => [],
+      listPanes: async () => [{ id: "%1" }],
+      capturePane: async () => {
+        if (fail) throw new Error("pane disappeared");
+        return "healthy";
+      },
+      onError: (message, error) => errors.push(`${message}: ${error instanceof Error ? error.message : String(error)}`),
+    });
+
+    await connection.sendCapture({ force: true });
+    expect(JSON.parse(sent.at(-1)!).captures).toEqual({ "%1": "healthy" });
+
+    fail = true;
+    await connection.sendCapture({ force: true });
+
+    expect(errors).toEqual(["capture failed for pane %1: pane disappeared"]);
+    expect(JSON.parse(sent.at(-1)!).captures).toEqual({ "%1": "healthy" });
+    connection.close();
+  });
+
 });

--- a/test/isolated/tmux.test.ts
+++ b/test/isolated/tmux.test.ts
@@ -235,10 +235,10 @@ describe("Tmux", () => {
       expect(commands[0]).toBe("tmux capture-pane -t s:0 -e -p -S -80");
     });
 
-    test("uses tail for lines <= 50", async () => {
+    test("uses tmux capture directly for lines <= 50 so target errors surface", async () => {
       sshResult = "some output";
       await t.capture("s:0", 30);
-      expect(commands[0]).toBe("tmux capture-pane -t s:0 -e -p 2>/dev/null | tail -30");
+      expect(commands[0]).toBe("tmux capture-pane -t s:0 -e -p -S -30");
     });
   });
 
@@ -328,7 +328,7 @@ describe("Tmux", () => {
       expect(commands).toEqual([
         "tmux pipe-pane -O -o -t oracles:0.1 'cat > /tmp/out file'",
         "tmux pipe-pane -I -t oracles:0.1 cat",
-        "tmux pipe-pane -O -t oracles:0.1",
+        "tmux pipe-pane -t oracles:0.1",
       ]);
     });
 

--- a/test/tmux-class-command-builders.test.ts
+++ b/test/tmux-class-command-builders.test.ts
@@ -162,7 +162,7 @@ describe("Tmux command wrapper coverage", () => {
   test("pane list/info helpers parse optional fields and tolerate failures", async () => {
     const t = new FakeTmux(byCommand({
       "list-panes -a -F #{pane_id}": "%1\n%2\n",
-      "list-panes -a -F #{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}": [
+      "list-panes -a -F #{pane_id}|||#{pane_current_command}|||#{session_name}:#{window_name}.#{pane_index}|||#{pane_title}|||#{pane_pid}|||#{pane_current_path}|||#{window_activity}|||#{pane_top}|||#{pane_left}|||#{pane_width}|||#{pane_height}|||#{pane_index}|||#{window_index}|||#{window_name}|||#{pane_active}|||#{window_width}|||#{window_height}|||#{window_active}|||#{session_attached}|||#{pane_dead}": [
         "%1|||claude|||s:main.0|||oracle|||123|||/repo|||1715840000|||1|||2|||80|||24|||0|||3|||main|||1|||160|||48|||1|||1",
         "%2|||zsh|||s:shell.1||||||||||||||||||||||||||||||||||||||||||||||||",
       ].join("\n"),
@@ -175,7 +175,7 @@ describe("Tmux command wrapper coverage", () => {
     expect(await t.listPaneIds()).toEqual(new Set(["%1", "%2"]));
     expect(await t.listPanes()).toEqual([
       { id: "%1", command: "claude", target: "s:main.0", title: "oracle", pid: 123, cwd: "/repo", lastActivity: 1715840000, top: 1, left: 2, w: 80, h: 24, paneIdx: 0, winIdx: 3, winName: "main", active: true, window: { w: 160, h: 48, active: true }, attached: true },
-      { id: "%2", command: "zsh", target: "s:shell.1", title: "", pid: undefined, cwd: undefined, lastActivity: undefined, top: 0, left: 0, w: 0, h: 0, paneIdx: 0, winIdx: 0, winName: undefined, active: false, window: { w: 0, h: 0, active: false }, attached: false },
+      { id: "%2", command: "zsh", target: "s:shell.1", title: "", pid: undefined, cwd: undefined, lastActivity: undefined, top: undefined, left: undefined, w: undefined, h: undefined, paneIdx: undefined, winIdx: undefined, winName: undefined, active: false, window: { w: undefined, h: undefined, active: false }, attached: false },
     ]);
     expect(await t.getPaneCommand("s:main.0")).toBe("claude");
     expect(await t.getPaneCommands(["s:0", "s:missing"])).toEqual({ "s:0": "claude" });
@@ -221,7 +221,7 @@ describe("Tmux command wrapper coverage", () => {
       "select-layout -t s:0 tiled",
       "attach-session -r -t s",
       "pipe-pane -O -o -t s:0.1 cat > /tmp/out",
-      "pipe-pane -I -t s:0.1",
+      "pipe-pane -t s:0.1",
       "set-window-option -t s:0 synchronize-panes on",
       "send-keys -t s:0.1 C-c Enter",
       "send-keys -t s:0.1 -l hello world",


### PR DESCRIPTION
Harden core tmux/transport primitives used by share/peek/capture/attach.

What changed:
- `Tmux.capture()` now uses tmux argv directly for all line counts; no shell `tail` pipeline or `2>/dev/null`, so bad pane targets fail loudly instead of looking like empty captures.
- `Tmux.pipePane(target)` now emits the bare `pipe-pane -t <target>` disable command for cleanup, not `-O` output mode.
- `Tmux.listPanes()` now asks for `pane_dead`, filters dead/malformed rows, and normalizes malformed numeric metadata to `undefined` instead of leaking `NaN`/fake zeros.
- `tmux-stream` now reports per-pane capture failures and keeps the last good capture instead of blanking a pane silently.
- Audited `ssh.isAgentCommand`; existing coverage for configured process names, node false positives, versioned Claude binaries, and config-load failure remains green.

Verification:
- `bun test test/isolated/tmux.test.ts test/tmux-class-command-builders.test.ts test/isolated/tmux-class-tenth-pass-coverage.test.ts test/isolated/tmux-stream.test.ts`
- `bun test test/ssh-transport-default.test.ts test/is-agent-command.test.ts test/isolated/is-agent-command-config.test.ts`
- `bun test test/vendor-share-readonly.test.ts test/vendor-share-hardening.test.ts`
- `bun run build`
