### PR TITLE
fix: maw done refuses dirty worktree removal without force (#2724)

### DIFF
--- a/src/commands/shared/done.ts
+++ b/src/commands/shared/done.ts
@@ -519,8 +519,11 @@ export async function removeWorktreeViaConfig(
         }
         let branch = "";
         try { branch = (await d.hostExec(`git -C '${fullPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
-        // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
-        await d.hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(fullPath)} --force`);
+        if (opts.force) {
+          await d.hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(fullPath)} --force`);
+        } else {
+          await d.hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(fullPath)}`);
+        }
         await d.hostExec(`git -C ${shellArg(mainPath)} worktree prune`);
         d.logger.log(`  \x1b[32m✓\x1b[0m removed worktree ${win.repo}`);
         if (branch && branch !== "main" && branch !== "HEAD") {
@@ -583,8 +586,11 @@ export async function removeWorktreeByGhqScan(
         }
         let branch = "";
         try { branch = (await d.hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
-        // #1968: force removes ignored engine scratch (for example .omx/) left in finished worktrees.
-        await d.hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(wtPath)} --force`);
+        if (opts.force) {
+          await d.hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(wtPath)} --force`);
+        } else {
+          await d.hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(wtPath)}`);
+        }
         await d.hostExec(`git -C ${shellArg(mainPath)} worktree prune`);
         d.logger.log(`  \x1b[32m✓\x1b[0m removed worktree ${base}`);
         removed = true;

--- a/src/vendor/mpr-plugins/done/done-worktree.ts
+++ b/src/vendor/mpr-plugins/done/done-worktree.ts
@@ -9,6 +9,7 @@ export interface DoneBranchCleanupOpts {
   branchBase?: string;
   dryRun?: boolean;
   cwd?: string;
+  force?: boolean;
 }
 
 function activeFleetConfigFiles(): Array<{ file: string; path: string }> {
@@ -34,6 +35,11 @@ function shellArg(value: string): string {
 function isNotWorkingTreeError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /not a working tree/i.test(message);
+}
+
+function isDirtyWorktreeRemovalError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /has uncommitted changes; rerun maw done --force/i.test(message);
 }
 
 function archivePathFor(wtPath: string): string {
@@ -196,7 +202,10 @@ export async function removeWorktreeViaConfig(
         } catch (removeErr: any) {
           const msg = String(removeErr.message || removeErr);
           if (/modified or untracked|contains modified/i.test(msg)) {
-            console.log(`  \x1b[33m⚠\x1b[0m worktree has uncommitted changes, force-removing`);
+            if (!opts.force) {
+              throw new Error(`worktree remove failed and ${fullPath} has uncommitted changes; rerun maw done --force to delete it`);
+            }
+            console.log(`  \x1b[33m⚠\x1b[0m worktree has uncommitted changes, force-removing (--force)`);
             await hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(fullPath)} --force`);
           } else {
             throw removeErr;
@@ -207,6 +216,7 @@ export async function removeWorktreeViaConfig(
         await cleanupDoneBranch(mainPath, branch, opts);
         return true;
       } catch (e: any) {
+        if (isDirtyWorktreeRemovalError(e)) throw e;
         if (isNotWorkingTreeError(e) && await movePrunedWorktreeDir(fullPath, mainPath)) {
           return true;
         }
@@ -214,7 +224,10 @@ export async function removeWorktreeViaConfig(
       }
       break;
     }
-  } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m fleet scan failed: ${e}`); }
+  } catch (e) {
+    if (isDirtyWorktreeRemovalError(e)) throw e;
+    console.error(`  \x1b[33m⚠\x1b[0m fleet scan failed: ${e}`);
+  }
   return false;
 }
 
@@ -268,7 +281,10 @@ export async function removeWorktreeByGhqScan(
         } catch (removeErr: any) {
           const msg = String(removeErr.message || removeErr);
           if (/modified or untracked|contains modified/i.test(msg)) {
-            console.log(`  \x1b[33m⚠\x1b[0m worktree has uncommitted changes, force-removing`);
+            if (!opts.force) {
+              throw new Error(`worktree remove failed and ${wtPath} has uncommitted changes; rerun maw done --force to delete it`);
+            }
+            console.log(`  \x1b[33m⚠\x1b[0m worktree has uncommitted changes, force-removing (--force)`);
             await hostExec(`git -C ${shellArg(mainPath)} worktree remove ${shellArg(wtPath)} --force`);
           } else {
             throw removeErr;
@@ -279,6 +295,7 @@ export async function removeWorktreeByGhqScan(
         removed = true;
         await cleanupDoneBranch(mainPath, branch, opts);
       } catch (e) {
+        if (isDirtyWorktreeRemovalError(e)) throw e;
         if (isNotWorkingTreeError(e) && await movePrunedWorktreeDir(wtPath, mainPath)) {
           removed = true;
           continue;
@@ -286,7 +303,10 @@ export async function removeWorktreeByGhqScan(
         console.error(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e}`);
       }
     }
-  } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m worktree scan failed: ${e}`); }
+  } catch (e) {
+    if (isDirtyWorktreeRemovalError(e)) throw e;
+    console.error(`  \x1b[33m⚠\x1b[0m worktree scan failed: ${e}`);
+  }
   return removed;
 }
 

--- a/test/done-command.test.ts
+++ b/test/done-command.test.ts
@@ -491,9 +491,35 @@ describe("done worktree cleanup helpers", () => {
 
     expect(h.commands).toEqual([
       "git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' rev-parse --abbrev-ref HEAD",
-      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree remove '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1' --force",
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree remove '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1'",
       "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree prune",
     ]);
+  });
+
+  test("removeWorktreeViaConfig fails loud instead of force-removing dirty worktrees without --force", async () => {
+    const h = createHarness({
+      files: {
+        "/fleet/team.json": JSON.stringify({
+          windows: [{ name: "tile-1", repo: "Soul-Brews-Studio/maw-js.wt-tile-1" }],
+        }),
+      },
+      hostExec: (command) => {
+        if (command.includes("rev-parse")) return "feature/dirty\n";
+        if (command.includes("worktree remove")) throw new Error("fatal: contains modified or untracked files");
+        if (command.includes("status --porcelain")) return "?? notes.txt\n";
+        return "";
+      },
+    });
+
+    await expect(removeWorktreeViaConfig("tile-1", "/repos/github.com", h.deps)).rejects.toThrow(
+      "has uncommitted changes; rerun maw done --force",
+    );
+
+    expect(h.commands).toContain(
+      "git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree remove '/repos/github.com/Soul-Brews-Studio/maw-js.wt-tile-1'",
+    );
+    expect(h.commands.some(command => command.includes("worktree remove") && command.includes("--force"))).toBe(false);
+    expect(h.commands).not.toContain("git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree prune");
   });
 
   test("removeWorktreeViaConfig reads state fleet configs before duplicate legacy configs", async () => {
@@ -570,7 +596,7 @@ describe("done worktree cleanup helpers", () => {
     await expect(removeWorktreeByGhqScan("6-tile-1", "/repos/github.com", h.deps)).resolves.toBe(true);
 
     expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/maw-js.wt-6-tile-1' rev-parse --abbrev-ref HEAD");
-    expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree remove '/repos/github.com/Soul-Brews-Studio/maw-js.wt-6-tile-1' --force");
+    expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/maw-js' worktree remove '/repos/github.com/Soul-Brews-Studio/maw-js.wt-6-tile-1'");
     expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/maw-js' merge-base --is-ancestor 'feature/scan' 'alpha'");
     expect(h.commands).toContain("gh pr list --head 'feature/scan' --state merged --json number --limit 1");
     expect(h.logs.join("\n")).toContain("removed worktree maw-js.wt-6-tile-1");
@@ -618,7 +644,7 @@ describe("done worktree cleanup helpers", () => {
     await expect(removeWorktreeByGhqScan("mawjs-trio-coder", "/repos/github.com", h.deps, { cwd: "/repos/github.com/Soul-Brews-Studio/mawjs-oracle" })).resolves.toBe(true);
 
     expect(h.logs.join("\n")).toContain("scoped ambiguous worktree 'trio-coder' to cwd repo /repos/github.com/Soul-Brews-Studio/mawjs-oracle");
-    expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/mawjs-oracle' worktree remove '/repos/github.com/Soul-Brews-Studio/mawjs-oracle/agents/1-trio-coder' --force");
+    expect(h.commands).toContain("git -C '/repos/github.com/Soul-Brews-Studio/mawjs-oracle' worktree remove '/repos/github.com/Soul-Brews-Studio/mawjs-oracle/agents/1-trio-coder'");
     expect(h.commands.join("\n")).not.toContain("ccc-oracle.wt-trio-coder' --force");
   });
 

--- a/test/isolated/done-worktree-coverage.test.ts
+++ b/test/isolated/done-worktree-coverage.test.ts
@@ -230,6 +230,23 @@ describe("removeWorktreeViaConfig", () => {
     expect(output).toContain("worktree remove failed: busy worktree");
   });
 
+  test("fails loud instead of force-removing dirty configured worktrees without --force", async () => {
+    writeFleetConfig("oracle.json", {
+      windows: [{ name: "dirty", repo: "org/repo.wt-dirty" }],
+    });
+    hostExecHandler = (command) => {
+      if (command.includes("rev-parse --abbrev-ref HEAD")) return "feature/dirty\n";
+      if (command.includes("worktree remove")) throw new Error("fatal: contains modified or untracked files");
+      return "";
+    };
+
+    await expect(captureConsole(async () => {
+      await removeWorktreeViaConfig("dirty", REPOS_ROOT);
+    })).rejects.toThrow("has uncommitted changes; rerun maw done --force");
+
+    expect(hostExecCalls.some(command => command.includes("worktree remove") && command.includes("--force"))).toBe(false);
+  });
+
   test("ignores configured non-worktree repos", async () => {
     writeFleetConfig("oracle.json", {
       windows: [{ name: "plain", repo: "org/repo" }],

--- a/test/isolated/done-worktree-force-real.test.ts
+++ b/test/isolated/done-worktree-force-real.test.ts
@@ -72,7 +72,26 @@ afterEach(() => {
 });
 
 describe("vendor done worktree forced removal", () => {
-  test("removes a configured worktree containing engine scratch", async () => {
+  test("refuses a configured worktree containing engine scratch without --force", async () => {
+    const { root, reposRoot, mainPath, worktreePath } = setupRepo();
+    const fleetDir = join(root, "fleet");
+    mkdirSync(fleetDir, { recursive: true });
+    writeFileSync(join(fleetDir, "test.json"), JSON.stringify({
+      windows: [{ name: "Codex", repo: "Soul-Brews-Studio/maw-js/agents/1-codex" }],
+    }));
+    fleetDirs = [fleetDir];
+    writeFileSync(join(worktreePath, "README.md"), "dirty local edit\n");
+
+    await expect(silenceConsole(() =>
+      removeWorktreeViaConfig("codex", reposRoot, { branchBase: "alpha" }),
+    )).rejects.toThrow("has uncommitted changes; rerun maw done --force");
+
+    expect(existsSync(worktreePath)).toBe(true);
+    expect(hostExecCommands.some(command => /worktree remove .* --force/.test(command))).toBe(false);
+    expect(sh("git branch --list feature/codex", mainPath).trim()).toContain("feature/codex");
+  });
+
+  test("removes a configured worktree containing engine scratch with explicit --force", async () => {
     const { root, reposRoot, mainPath, worktreePath } = setupRepo();
     const fleetDir = join(root, "fleet");
     mkdirSync(fleetDir, { recursive: true });
@@ -82,7 +101,7 @@ describe("vendor done worktree forced removal", () => {
     fleetDirs = [fleetDir];
 
     const removed = await silenceConsole(() =>
-      removeWorktreeViaConfig("codex", reposRoot, { branchBase: "alpha" }),
+      removeWorktreeViaConfig("codex", reposRoot, { branchBase: "alpha", force: true }),
     );
 
     expect(removed).toBe(true);

--- a/test/isolated/plugin-done-standalone.test.ts
+++ b/test/isolated/plugin-done-standalone.test.ts
@@ -1,18 +1,49 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+let fleetReadDirs: string[] = [];
+let hostExecCalls: string[] = [];
+let hostExecHandler: (command: string) => string | Promise<string> = () => "";
+const tmpRoots: string[] = [];
+
+mock.module("maw-js/sdk", () => ({
+  hostExec: async (command: string) => {
+    hostExecCalls.push(command);
+    return await hostExecHandler(command);
+  },
+}));
+
+mock.module("maw-js/commands/shared/fleet-load", () => ({
+  fleetDirsForRead: () => fleetReadDirs,
+}));
 
 const { inferRetrospectiveCommand } = await import(
   "../../src/vendor/mpr-plugins/done/retrospective-command.ts?plugin-done-standalone"
 );
+const { removeWorktreeViaConfig } = await import(
+  "../../src/vendor/mpr-plugins/done/done-worktree.ts?plugin-done-standalone"
+);
+
+afterEach(() => {
+  fleetReadDirs = [];
+  hostExecCalls = [];
+  hostExecHandler = () => "";
+  for (const root of tmpRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
 
 describe("done command plugin standalone boundary", () => {
   test("touched done autosave files keep explicit standalone import boundaries", () => {
     const imports = expectStandalonePluginBoundary({
       plugin: "done",
-      files: ["impl.ts", "done-autosave.ts", "retrospective-command.ts"],
+      files: ["impl.ts", "done-autosave.ts", "done-worktree.ts", "retrospective-command.ts"],
       allowRelative: ["./done-autosave", "./done-worktree", "../../../core/xdg"],
       allowMawJs: [
         /^maw-js\/core\/matcher\/normalize-target$/,
+        /^maw-js\/core\/fleet\/worktree-layout$/,
+        /^maw-js\/commands\/shared\/fleet-load$/,
         /^maw-js\/commands\/shared\/wake-resolve$/,
         /^maw-js\/config\/ghq-root$/,
         /^maw-js\/vendor\/mpr-plugins\/team\/team-charter$/,
@@ -32,5 +63,37 @@ describe("done command plugin standalone boundary", () => {
     expect(inferRetrospectiveCommand("codex")).toBeNull();
     expect(inferRetrospectiveCommand("aider")).toBeNull();
     expect(inferRetrospectiveCommand("opencode")).toBeNull();
+  });
+
+  test("done worktree cleanup refuses dirty removals unless force is explicit", async () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-plugin-done-boundary-"));
+    tmpRoots.push(root);
+    const fleetDir = join(root, "fleet");
+    mkdirSync(fleetDir, { recursive: true });
+    writeFileSync(join(fleetDir, "team.json"), JSON.stringify({
+      windows: [{ name: "codex-1", repo: "Soul-Brews-Studio/maw-js.wt-codex-1" }],
+    }));
+    fleetReadDirs = [fleetDir];
+
+    const reposRoot = join(root, "github.com");
+    const worktreePath = join(reposRoot, "Soul-Brews-Studio", "maw-js.wt-codex-1");
+    hostExecHandler = (command) => {
+      if (command.includes("rev-parse --abbrev-ref HEAD")) return "feature/done\n";
+      if (command.includes("worktree remove") && !command.includes("--force")) {
+        throw new Error("fatal: contains modified or untracked files");
+      }
+      return "";
+    };
+
+    await expect(removeWorktreeViaConfig("codex-1", reposRoot)).rejects.toThrow(
+      "has uncommitted changes; rerun maw done --force",
+    );
+
+    expect(hostExecCalls).toContain(`git -C '${worktreePath}' rev-parse --abbrev-ref HEAD`);
+    expect(hostExecCalls.some(command => command.includes("worktree remove") && command.includes("--force"))).toBe(false);
+
+    hostExecCalls = [];
+    await expect(removeWorktreeViaConfig("codex-1", reposRoot, { force: true })).resolves.toBe(true);
+    expect(hostExecCalls.some(command => command.includes("worktree remove") && command.includes("--force"))).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #2724\n\n## Summary\n- stop shared done cleanup from using forced worktree removal unless --force is explicit\n- make vendor done cleanup fail loud instead of force-removing dirty worktrees by default\n- add targeted regressions for dirty-worktree refusal and explicit-force removal\n\n## Verify\n- timeout 120 bun test test/done-command.test.ts test/isolated/done-worktree-coverage.test.ts test/isolated/done-worktree-force-real.test.ts\n- timeout 120 bun run build