### PR TITLE
release: v26.6.14-alpha.1154

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.13-alpha.1921",
+  "version": "26.6.14-alpha.1154",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Alpha cut rolling up 43 commits since v26.6.13-alpha.1921.

## Highlights
- **engine migration RFC #2400 complete** — config-driven engines, fail-loud on unresolvable (#2707/#2709/#2712)
- **maw share Phase 1+2** — LAN read-only viewer + E2E zero-knowledge (HKDF→AES-GCM, key in URL fragment) (#2685/#2704/#2706/#2711/#2714)
- **security** — federation malformed-envelope refuse (#2723), share stream protection from intermediaries (#2706)
- **data-loss** — maw done refuses dirty worktree removal without force (#2726)
- **hardening** — tmux transport (#2725), wake/scan (#2721), TLS lifecycle (#2720), ghq doubled-path normalization (#2713)
- **flaky test stabilized** — github-archive-wrapped stderr capture leak (#2728)

Version bump only; all 43 commits already merged + green on alpha. Merge → calver-release.yml auto-tags v26.6.14-alpha.1154 + publishes dist/maw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)