### PR TITLE
fix: stream dashboard tmux output with pipe-pane push (#2731)

### DIFF
--- a/src/api/tmux-stream.ts
+++ b/src/api/tmux-stream.ts
@@ -1,4 +1,7 @@
 import type { ServerWebSocket } from "bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { tmuxLsJsonRows } from "../commands/plugins/tmux/impl";
 import { Tmux } from "../core/transport/tmux";
 import type { WSData } from "../core/types";
@@ -10,6 +13,22 @@ type TimerHandle = ReturnType<typeof setInterval>;
 type StreamWebSocket = Pick<ServerWebSocket<WSData>, "send">;
 
 type PaneRef = { id?: string };
+type ChildProcessLike = {
+  kill: (signal?: string | number) => void;
+  exited: Promise<unknown>;
+};
+type PipePaneFn = (paneId: string, command?: string, opts?: { onlyIfClosed?: boolean }) => Promise<void>;
+type PipeSubscriber = (chunk: Uint8Array) => void;
+type PanePipeEntry = {
+  paneId: string;
+  dir: string;
+  file: string;
+  child: ChildProcessLike | null;
+  refs: number;
+  subscribers: Set<PipeSubscriber>;
+};
+
+const panePipeRegistry = new Map<string, PanePipeEntry>();
 
 export interface TmuxStreamDeps {
   intervalMs?: number;
@@ -17,6 +36,12 @@ export interface TmuxStreamDeps {
   layoutRows?: () => Promise<unknown[]>;
   listPanes?: () => Promise<PaneRef[]>;
   capturePane?: (paneId: string, lines: number) => Promise<string>;
+  pipePane?: PipePaneFn;
+  spawnTail?: (path: string, onChunk: (chunk: Uint8Array) => void) => Promise<ChildProcessLike>;
+  mkdtempSync?: typeof mkdtempSync;
+  tmpdir?: typeof tmpdir;
+  join?: typeof join;
+  rmSync?: typeof rmSync;
   setIntervalFn?: typeof setInterval;
   clearIntervalFn?: typeof clearInterval;
   startTimers?: boolean;
@@ -38,6 +63,96 @@ function logStreamError(deps: TmuxStreamDeps, message: string, error: unknown): 
   else console.warn(`[tmux-stream] ${message}: ${error instanceof Error ? error.message : String(error)}`);
 }
 
+function shellEscapeArg(value: string): string {
+  if (value === "") return "''";
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function defaultSpawnTail(path: string, onChunk: (chunk: Uint8Array) => void): Promise<ChildProcessLike> {
+  const child = Bun.spawn({
+    cmd: ["tail", "-n", "0", "-f", path],
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  void (async () => {
+    for await (const chunk of child.stdout) {
+      if (!chunk || chunk.byteLength === 0) continue;
+      onChunk(chunk as Uint8Array);
+    }
+  })();
+  return Promise.resolve({
+    kill: (signal) => {
+      try { child.kill(signal); } catch { /* best-effort cleanup */ }
+    },
+    exited: child.exited,
+  });
+}
+
+async function acquirePanePipe(
+  paneId: string,
+  subscriber: PipeSubscriber,
+  deps: {
+    pipePane: PipePaneFn;
+    spawnTail: (path: string, onChunk: (chunk: Uint8Array) => void) => Promise<ChildProcessLike>;
+    mkTempDir: typeof mkdtempSync;
+    getTmpdir: typeof tmpdir;
+    joinPath: typeof join;
+    removeDir: typeof rmSync;
+  },
+): Promise<void> {
+  const existing = panePipeRegistry.get(paneId);
+  if (existing) {
+    existing.refs += 1;
+    existing.subscribers.add(subscriber);
+    return;
+  }
+
+  const dir = deps.mkTempDir(deps.joinPath(deps.getTmpdir(), "maw-tmux-stream-"));
+  const file = deps.joinPath(dir, `${paneId.replace(/[^a-zA-Z0-9._-]/g, "-")}.log`);
+  await Bun.write(file, "");
+  const entry: PanePipeEntry = {
+    paneId,
+    dir,
+    file,
+    child: null,
+    refs: 1,
+    subscribers: new Set([subscriber]),
+  };
+  panePipeRegistry.set(paneId, entry);
+
+  try {
+    entry.child = await deps.spawnTail(file, (chunk) => {
+      for (const send of [...entry.subscribers]) send(chunk);
+    });
+    void entry.child.exited.catch(() => {});
+    await deps.pipePane(paneId, `cat >> ${shellEscapeArg(file)}`, { onlyIfClosed: true });
+  } catch (error) {
+    panePipeRegistry.delete(paneId);
+    try { entry.child?.kill("SIGTERM"); } catch { /* best-effort tail cleanup */ }
+    try { deps.removeDir(dir, { recursive: true, force: true }); } catch { /* best-effort temp cleanup */ }
+    throw error;
+  }
+}
+
+async function releasePanePipe(
+  paneId: string,
+  subscriber: PipeSubscriber,
+  deps: {
+    pipePane: PipePaneFn;
+    removeDir: typeof rmSync;
+  },
+): Promise<void> {
+  const entry = panePipeRegistry.get(paneId);
+  if (!entry) return;
+  if (entry.subscribers.delete(subscriber)) entry.refs -= 1;
+  if (entry.refs > 0) return;
+
+  panePipeRegistry.delete(paneId);
+  try { await deps.pipePane(paneId); } catch { /* pane may already be gone */ }
+  try { entry.child?.kill("SIGTERM"); } catch { /* best-effort tail cleanup */ }
+  try { deps.removeDir(entry.dir, { recursive: true, force: true }); } catch { /* best-effort temp cleanup */ }
+}
+
 export function layoutPayload(rows: unknown[]): string {
   return JSON.stringify({ type: "layout", panes: rows });
 }
@@ -47,19 +162,26 @@ export function capturePayload(captures: Record<string, string>): string {
 }
 
 export function createTmuxStreamConnection(ws: StreamWebSocket, deps: TmuxStreamDeps = {}): TmuxStreamConnection {
-  const tmux = deps.listPanes && deps.capturePane ? null : new Tmux();
+  const tmux = deps.listPanes && deps.capturePane && deps.pipePane ? null : new Tmux();
   const intervalMs = deps.intervalMs ?? TMUX_STREAM_INTERVAL_MS;
   const captureLines = deps.captureLines ?? TMUX_STREAM_CAPTURE_LINES;
   const layoutRows = deps.layoutRows ?? (() => tmuxLsJsonRows({ all: true, compact: true, teams: true, channels: true }));
   const listPanes = deps.listPanes ?? (() => tmux!.listPanes());
   const capturePane = deps.capturePane ?? ((paneId: string, lines: number) => tmux!.capture(paneId, lines));
+  const pipePane = deps.pipePane ?? ((paneId: string, command?: string, opts?: { onlyIfClosed?: boolean }) => tmux!.pipePane(paneId, command, opts));
+  const spawnTail = deps.spawnTail ?? defaultSpawnTail;
+  const mkTempDir = deps.mkdtempSync ?? mkdtempSync;
+  const getTmpdir = deps.tmpdir ?? tmpdir;
+  const joinPath = deps.join ?? join;
+  const removeDir = deps.rmSync ?? rmSync;
   const setIntervalFn = deps.setIntervalFn ?? setInterval;
   const clearIntervalFn = deps.clearIntervalFn ?? clearInterval;
   const captures: Record<string, string> = {};
+  const acquiredPipes = new Map<string, PipeSubscriber>();
+  const decoder = new TextDecoder();
   let captureRunning = false;
   let closed = false;
   let layoutTimer: TimerHandle | undefined;
-  let captureTimer: TimerHandle | undefined;
 
   async function sendLayout(): Promise<void> {
     if (closed) return;
@@ -97,6 +219,7 @@ export function createTmuxStreamConnection(ws: StreamWebSocket, deps: TmuxStream
           changed = true;
         }
       }
+      await syncPanePipes(liveIds);
       if (opts.force || changed) safeSend(ws, capturePayload(captures));
     } catch (error) {
       logStreamError(deps, "capture refresh failed", error);
@@ -105,17 +228,47 @@ export function createTmuxStreamConnection(ws: StreamWebSocket, deps: TmuxStream
     }
   }
 
+  function appendPipeChunk(paneId: string, chunk: Uint8Array): void {
+    if (closed) return;
+    const text = decoder.decode(chunk, { stream: true });
+    if (!text) return;
+    captures[paneId] = (captures[paneId] ?? "") + text;
+    safeSend(ws, capturePayload(captures));
+  }
+
+  async function startPanePipe(paneId: string): Promise<void> {
+    if (closed || acquiredPipes.has(paneId)) return;
+    const subscriber = (chunk: Uint8Array) => appendPipeChunk(paneId, chunk);
+    try {
+      await acquirePanePipe(paneId, subscriber, { pipePane, spawnTail, mkTempDir, getTmpdir, joinPath, removeDir });
+      acquiredPipes.set(paneId, subscriber);
+    } catch (error) {
+      logStreamError(deps, `pipe setup failed for pane ${paneId}`, error);
+    }
+  }
+
+  async function stopPanePipe(paneId: string): Promise<void> {
+    const subscriber = acquiredPipes.get(paneId);
+    if (!subscriber) return;
+    acquiredPipes.delete(paneId);
+    await releasePanePipe(paneId, subscriber, { pipePane, removeDir });
+  }
+
+  async function syncPanePipes(liveIds: Set<string>): Promise<void> {
+    await Promise.all([...acquiredPipes.keys()].filter((id) => !liveIds.has(id)).map((id) => stopPanePipe(id)));
+    await Promise.all([...liveIds].filter((id) => !acquiredPipes.has(id)).map((id) => startPanePipe(id)));
+  }
+
   function close(): void {
     closed = true;
     if (layoutTimer) clearIntervalFn(layoutTimer);
-    if (captureTimer) clearIntervalFn(captureTimer);
+    void Promise.all([...acquiredPipes.keys()].map((id) => stopPanePipe(id)));
   }
 
   if (deps.startTimers !== false) {
     void sendLayout();
     void sendCapture({ force: true });
     layoutTimer = setIntervalFn(() => { void sendLayout(); }, intervalMs);
-    captureTimer = setIntervalFn(() => { void sendCapture(); }, intervalMs);
   }
 
   return { sendLayout, sendCapture, close };

--- a/test/isolated/tmux-stream.test.ts
+++ b/test/isolated/tmux-stream.test.ts
@@ -17,6 +17,7 @@ describe("tmux websocket stream (#2048)", () => {
   test("sends immediate snapshots, then capture updates only when content changes", async () => {
     const sent: string[] = [];
     const callbacks: Array<() => void> = [];
+    const pipeCalls: Array<{ paneId: string; command?: string; opts?: unknown }> = [];
     let captureText = "first";
     const ws = { send: (payload: string) => { sent.push(payload); } };
 
@@ -24,6 +25,8 @@ describe("tmux websocket stream (#2048)", () => {
       layoutRows: async () => [{ id: "%1", target: "demo:0.0", top: 0, left: 0, w: 80, h: 24 }],
       listPanes: async () => [{ id: "%1" }],
       capturePane: async () => captureText,
+      pipePane: async (paneId, command, opts) => { pipeCalls.push({ paneId, command, opts }); },
+      spawnTail: async () => ({ kill: () => {}, exited: new Promise(() => {}) }),
       setIntervalFn: ((fn: () => void, ms?: number) => {
         expect(ms).toBe(TMUX_STREAM_INTERVAL_MS);
         callbacks.push(fn);
@@ -34,6 +37,9 @@ describe("tmux websocket stream (#2048)", () => {
 
     await Bun.sleep(0);
     expect(sent.map(payload => JSON.parse(payload).type)).toEqual(["layout", "capture"]);
+    expect(callbacks).toHaveLength(1);
+    expect(pipeCalls).toHaveLength(1);
+    expect(pipeCalls[0]).toMatchObject({ paneId: "%1", opts: { onlyIfClosed: true } });
     expect(JSON.parse(sent[0]!).panes[0]).toMatchObject({ id: "%1", top: 0, left: 0, w: 80, h: 24 });
     expect(JSON.parse(sent[1]!).captures).toEqual({ "%1": "first" });
 
@@ -45,11 +51,57 @@ describe("tmux websocket stream (#2048)", () => {
     expect(JSON.parse(sent.at(-1)!).captures).toEqual({ "%1": "second" });
 
     connection.close();
+    await Bun.sleep(0);
+  });
+
+  test("pushes pane output through one refcounted pipe across multiple viewers", async () => {
+    const sentA: string[] = [];
+    const sentB: string[] = [];
+    const pipeCalls: Array<{ paneId: string; command?: string; opts?: unknown }> = [];
+    const killCalls: string[] = [];
+    let onChunk: ((chunk: Uint8Array) => void) | undefined;
+    const commonDeps = {
+      startTimers: false,
+      layoutRows: async () => [],
+      listPanes: async () => [{ id: "%1" }],
+      capturePane: async () => "snapshot\n",
+      pipePane: async (paneId: string, command?: string, opts?: unknown) => {
+        pipeCalls.push({ paneId, command, opts });
+      },
+      spawnTail: async (_path: string, chunk: (data: Uint8Array) => void) => {
+        onChunk = chunk;
+        return { kill: (signal?: string | number) => { killCalls.push(String(signal)); }, exited: new Promise(() => {}) };
+      },
+    };
+
+    const one = createTmuxStreamConnection({ send: (payload: string) => sentA.push(payload) }, commonDeps);
+    await one.sendCapture({ force: true });
+    const two = createTmuxStreamConnection({ send: (payload: string) => sentB.push(payload) }, commonDeps);
+    await two.sendCapture({ force: true });
+
+    expect(pipeCalls).toHaveLength(1);
+    expect(pipeCalls[0]).toMatchObject({ paneId: "%1", opts: { onlyIfClosed: true } });
+
+    onChunk!(new TextEncoder().encode("live\n"));
+    await Bun.sleep(0);
+    expect(JSON.parse(sentA.at(-1)!).captures["%1"]).toBe("snapshot\nlive\n");
+    expect(JSON.parse(sentB.at(-1)!).captures["%1"]).toBe("snapshot\nlive\n");
+
+    one.close();
+    await Bun.sleep(0);
+    expect(pipeCalls).toHaveLength(1);
+    expect(killCalls).toEqual([]);
+
+    two.close();
+    await Bun.sleep(0);
+    expect(pipeCalls.at(-1)).toEqual({ paneId: "%1", command: undefined, opts: undefined });
+    expect(killCalls).toEqual(["SIGTERM"]);
   });
 
   test("logs pane capture failures and keeps last good capture instead of blanking panes", async () => {
     const sent: string[] = [];
     const errors: string[] = [];
+    const pipeCalls: string[] = [];
     let fail = false;
     const ws = { send: (payload: string) => { sent.push(payload); } };
 
@@ -61,6 +113,8 @@ describe("tmux websocket stream (#2048)", () => {
         if (fail) throw new Error("pane disappeared");
         return "healthy";
       },
+      pipePane: async (paneId, command) => { pipeCalls.push(`${paneId}:${command ?? "<close>"}`); },
+      spawnTail: async () => ({ kill: () => {}, exited: new Promise(() => {}) }),
       onError: (message, error) => errors.push(`${message}: ${error instanceof Error ? error.message : String(error)}`),
     });
 
@@ -73,6 +127,7 @@ describe("tmux websocket stream (#2048)", () => {
     expect(errors).toEqual(["capture failed for pane %1: pane disappeared"]);
     expect(JSON.parse(sent.at(-1)!).captures).toEqual({ "%1": "healthy" });
     connection.close();
+    await Bun.sleep(0);
   });
 
 });


### PR DESCRIPTION
Closes #2731\n\n## Summary\n- replace /ws/tmux content capture polling with pipePane + tail push streams\n- keep existing layout/capture JSON protocol and layout refresh interval\n- use a refcounted per-pane registry so multiple dashboard viewers share one tmux pipe and teardown only happens after the last viewer disconnects\n- close pipePane, kill tail, and remove tmpdir on release\n\n## Verify\n- bash scripts/test-isolated.sh test/isolated/tmux-stream.test.ts\n- bun run build\n- bun scripts/check-plugin-coverage-gate.ts origin/alpha