### PR TITLE
fix: wake strips host/org before mixed-case pane naming (#2734)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -335,10 +335,17 @@ function stripGitSuffix(name: string): string {
   return name.replace(/\.git$/i, "");
 }
 
-function repoNameFromTarget(target: string, urlRepoName?: string): string {
-  if (urlRepoName?.trim()) return stripGitSuffix(urlRepoName.trim());
-  const cleaned = stripGitSuffix(target.trim().replace(/\/+$/, ""));
+function repoNameFromSlugish(value: string): string {
+  const cleaned = stripGitSuffix(value.trim().replace(/\/+$/, ""))
+    .replace(/^https?:\/\/github\.com\//i, "")
+    .replace(/^git@github\.com:/i, "")
+    .replace(/^github\.com\//i, "");
   return cleaned.split("/").filter(Boolean).pop() ?? cleaned;
+}
+
+function repoNameFromTarget(target: string, urlRepoName?: string): string {
+  if (urlRepoName?.trim()) return repoNameFromSlugish(urlRepoName);
+  return repoNameFromSlugish(target);
 }
 
 function detectWakeSessionMode(target: string, opts: Pick<WakeOptions, "sessionMode" | "urlRepoName" | "repoPath">): WakeSession {
@@ -350,8 +357,9 @@ function detectWakeSessionMode(target: string, opts: Pick<WakeOptions, "sessionM
 }
 
 function identityForWakeSession(session: WakeSession, repoName: string, currentIdentity: string): string {
-  if (session.mode === "work") return repoName;
-  return repoName.toLowerCase().endsWith("-oracle") ? repoName.replace(/-oracle$/i, "") : currentIdentity;
+  const normalizedRepoName = repoName.toLowerCase();
+  if (session.mode === "work") return normalizedRepoName;
+  return normalizedRepoName.endsWith("-oracle") ? normalizedRepoName.replace(/-oracle$/i, "") : currentIdentity.toLowerCase();
 }
 
 function mainWindowNameForWakeSession(session: WakeSession, identity: string): string {
@@ -949,7 +957,7 @@ async function resolveWakeFleetSessionRepo(meta: WakeFleetSessionMetadata): Prom
 
 export async function chooseWakeSessionName(oracle: string, urlRepoName?: string): Promise<string> {
   const mappedOrFleet = getSessionMap()[oracle] || resolveFleetSession(oracle);
-  const baseName = mappedOrFleet || canonicalSessionName(urlRepoName || oracle);
+  const baseName = mappedOrFleet || canonicalSessionName(repoNameFromTarget(oracle, urlRepoName));
   if (/^\d+-/.test(baseName)) return baseName;
   // #994 — auto-assign NN- prefix to match fleet convention (01-maw-m5, 02-...).
   // Scan existing sessions for numeric prefixes, pick max+1, zero-pad to 2 digits.

--- a/test/wake-cmd-cmdwake-coverage.test.ts
+++ b/test/wake-cmd-cmdwake-coverage.test.ts
@@ -1507,6 +1507,58 @@ describe("cmdWake main-suite coverage", () => {
     expect(findWorktreesCalls).toEqual([{ parentDir, repoName: "graph-oracle", taskSlug: undefined, scopeStem: undefined }]);
   });
 
+  test("#2734 mixed-case org slug strips host/org before deriving pane and session names", async () => {
+    parseWakeTargetReturn = {
+      oracle: "volt",
+      slug: "Arkkra-Co/volt-oracle",
+    };
+    repoName = "volt-oracle";
+    repoPath = join(parentDir, "Arkkra-Co", repoName);
+    parentDir = join(parentDir, "Arkkra-Co");
+    ghqFindReturn = repoPath;
+    mkdirSync(repoPath, { recursive: true });
+    sessions = [];
+    hasSessions = new Set();
+    detectSessionReturn = null;
+    shouldWakeDecision = { wake: true, reason: "missing" };
+
+    const { result } = await captureLogs(() =>
+      cmdWake("Arkkra-Co/volt-oracle", { noRehydrate: true, noFleet: true }),
+    );
+
+    expect(result).toBe("01-volt:volt-oracle");
+    expect(ensureClonedCalls).toEqual(["Arkkra-Co/volt-oracle"]);
+    expect(newSessionCalls).toEqual([{ name: "01-volt", opts: { window: "volt-oracle", cwd: repoPath } }]);
+    expect(sendTextCalls[0]?.target).toBe("01-volt:volt-oracle");
+    expect(sendTextCalls[0]?.target).not.toContain("comarkkra");
+    expect(sendTextCalls[0]?.target).not.toContain("github.com");
+  });
+
+  test("#2734 slug-ish urlRepoName strips github.com and org before session naming", async () => {
+    repoName = "volt-oracle";
+    repoPath = join(parentDir, "Arkkra-Co", repoName);
+    parentDir = join(parentDir, "Arkkra-Co");
+    mkdirSync(repoPath, { recursive: true });
+    sessions = [];
+    hasSessions = new Set();
+    detectSessionReturn = null;
+    shouldWakeDecision = { wake: true, reason: "missing" };
+
+    const { result } = await captureLogs(() =>
+      cmdWake("github.com/Arkkra-Co/volt-oracle", {
+        repoPath,
+        urlRepoName: "github.com/Arkkra-Co/volt-oracle",
+        noRehydrate: true,
+        noFleet: true,
+      }),
+    );
+
+    expect(result).toBe("01-volt:volt-oracle");
+    expect(newSessionCalls).toEqual([{ name: "01-volt", opts: { window: "volt-oracle", cwd: repoPath } }]);
+    expect(sendTextCalls[0]?.target).toBe("01-volt:volt-oracle");
+    expect(sendTextCalls[0]?.target).not.toContain("comarkkra");
+  });
+
   test("incubates missing repos with a github.com prefix and defaults the worktree slug", async () => {
     repoName = "new-tool";
     repoPath = join(parentDir, repoName);


### PR DESCRIPTION
Closes #2734

## Summary
- strip github.com and org segments before deriving wake pane/session identity
- lowercase derived wake identity while preserving cwd/repo path
- add mixed-case Arkkra-Co/volt-oracle regression

## Verify
- timeout 120 bun test test/wake-cmd-cmdwake-coverage.test.ts test/wake-target-parser.test.ts test/canonical-session-name.test.ts
- timeout 120 bun run build
- bun scripts/check-plugin-coverage-gate.ts origin/alpha