### PR TITLE
fix: share streams without tmpfile tail relay (#2736)

### DIFF
--- a/src/vendor/mpr-plugins/share/stream.ts
+++ b/src/vendor/mpr-plugins/share/stream.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ServerWebSocket } from "bun";
@@ -14,12 +14,12 @@ type ChildProcessLike = {
 type TmuxShape = Pick<Tmux, "capture" | "pipePane">;
 
 type StreamDeps = {
-  mkdtempSync: typeof mkdtempSync;
   tmpdir: typeof tmpdir;
   join: typeof join;
-  rmSync: typeof rmSync;
+  unlinkSync: typeof unlinkSync;
   tmux: TmuxShape;
-  spawnTail: (path: string, onChunk: (chunk: Uint8Array) => void) => Promise<ChildProcessLike>;
+  makeFifo: (path: string) => Promise<void>;
+  spawnPipeReader: (path: string, onChunk: (chunk: Uint8Array) => void) => Promise<ChildProcessLike>;
   setTimeout: typeof setTimeout;
   clearTimeout: typeof clearTimeout;
 };
@@ -30,8 +30,7 @@ type Subscriber = {
 
 type TargetBus = {
   target: string;
-  tempDir: string;
-  consumerPath: string;
+  fifoPath: string;
   child: ChildProcessLike | null;
   subscribers: Map<symbol, Subscriber>;
   backlog: Uint8Array[];
@@ -43,12 +42,10 @@ type TargetBus = {
 const targetBuses = new Map<string, Promise<TargetBus>>();
 
 async function createTargetBus(target: string, deps: StreamDeps): Promise<TargetBus> {
-  const tempDir = deps.mkdtempSync(join(deps.tmpdir(), "maw-share-"));
-  const consumerPath = makeStreamConsumerPath(tempDir, target);
+  const fifoPath = makeStreamFifoPath(deps.tmpdir(), target);
   const bus: TargetBus = {
     target,
-    tempDir,
-    consumerPath,
+    fifoPath,
     child: null,
     subscribers: new Map(),
     backlog: [],
@@ -58,19 +55,21 @@ async function createTargetBus(target: string, deps: StreamDeps): Promise<Target
   };
 
   try {
-    await Bun.write(consumerPath, "");
-    const command = `cat >> ${shellEscapeArg(consumerPath)}`;
-    // tmux has one pipe-pane slot per pane. Use -o/onlyIfClosed so a second
-    // viewer for the same target never clobbers the existing producer; all
-    // viewers subscribe to this per-target fan-out bus instead.
-    await deps.tmux.pipePane(target, command, { onlyIfClosed: true });
-    bus.child = await deps.spawnTail(consumerPath, (chunk) => {
+    await deps.makeFifo(fifoPath);
+    bus.child = await deps.spawnPipeReader(fifoPath, (chunk) => {
       if (bus.subscribers.size === 0) {
         bufferBacklog(bus, chunk);
         return;
       }
       for (const subscriber of bus.subscribers.values()) subscriber.send(chunk);
     });
+    const command = `cat > ${shellEscapeArg(fifoPath)}`;
+    // tmux has one pipe-pane slot per pane. Use -o/onlyIfClosed so a second
+    // viewer for the same target never clobbers the existing producer; all
+    // viewers subscribe to this per-target fan-out bus instead. The FIFO
+    // removes the old tmpfile + tail -f relay: tmux writes into the FIFO and
+    // our single per-target cat subprocess exposes stdout directly to Bun.
+    await deps.tmux.pipePane(target, command, { onlyIfClosed: true });
     return bus;
   } catch (error) {
     targetBuses.delete(target);
@@ -102,7 +101,7 @@ async function teardownBus(bus: TargetBus): Promise<void> {
     bus.child = null;
 
     try {
-      bus.deps.rmSync(bus.tempDir, { recursive: true, force: true });
+      bus.deps.unlinkSync(bus.fifoPath);
     } catch {
       // best effort
     }
@@ -126,14 +125,25 @@ const MAX_BACKLOG_BYTES = 1024 * 1024;
 
 function defaultDeps(): StreamDeps {
   return {
-    mkdtempSync,
     tmpdir,
     join,
-    rmSync,
+    unlinkSync,
     tmux: new Tmux(),
-    spawnTail: async (path, onChunk) => {
+    makeFifo: async (path) => {
       const child = Bun.spawn({
-        cmd: ["tail", "-n", "0", "-f", path],
+        cmd: ["mkfifo", path],
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+      const code = await child.exited;
+      if (code !== 0) {
+        const detail = await new Response(child.stderr).text();
+        throw new Error(`share stream failed to create FIFO ${path}: ${detail.trim() || `mkfifo exited ${code}`}`);
+      }
+    },
+    spawnPipeReader: async (path, onChunk) => {
+      const child = Bun.spawn({
+        cmd: ["cat", path],
         stdout: "pipe",
         stderr: "inherit",
       });
@@ -173,8 +183,10 @@ function decodeInboundMessage(message: unknown): string | null {
   return null;
 }
 
-function makeStreamConsumerPath(tmpDir: string, target: string): string {
-  return join(tmpDir, `${Date.now().toString(36)}-${target.replace(/[^a-zA-Z0-9._-]/g, "-")}`);
+function makeStreamFifoPath(tmpDir: string, target: string): string {
+  const safeTarget = target.replace(/[^a-zA-Z0-9._-]/g, "-");
+  const random = Math.random().toString(36).slice(2);
+  return join(tmpDir, `maw-share-${process.pid}-${Date.now().toString(36)}-${random}-${safeTarget}.fifo`);
 }
 
 function sendSafe(ws: ServerWebSocket, data: string | Uint8Array): void {

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -94,6 +94,14 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     const index = readFileSync(join(root, "src/vendor/mpr-plugins/share/index.ts"), "utf8");
     expect(index).toContain("export async function serve");
     expect(index).toContain("export default async function handler");
+
+    const stream = readFileSync(join(root, "src/vendor/mpr-plugins/share/stream.ts"), "utf8");
+    expect(stream).toContain('cmd: ["cat", path]');
+    expect(stream).toContain('cmd: ["mkfifo", path]');
+    expect(stream).toContain("cat > ${shellEscapeArg(fifoPath)}");
+    expect(stream).not.toContain('cmd: ["tail"');
+    expect(stream).not.toContain("cat >>");
+    expect(stream).not.toContain("mkdtempSync");
   });
 
   test("cli share dispatch posts to daemon and daemon serves minted viewer", async () => {
@@ -218,7 +226,8 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
           capture: async () => "SNAPSHOT-PLAINTEXT\n",
           pipePane: async () => undefined,
         },
-        spawnTail: async (_path: string, onChunk: (chunk: Uint8Array) => void) => {
+        makeFifo: async () => undefined,
+        spawnPipeReader: async (_path: string, onChunk: (chunk: Uint8Array) => void) => {
           liveChunk = onChunk;
           return {
             kill: () => undefined,
@@ -258,21 +267,22 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     const sentB: Array<string | Uint8Array> = [];
     const pipeCalls: unknown[][] = [];
     const killed: Array<string | number | undefined> = [];
-    const removedTmpDirs: string[] = [];
+    const createdFifos: string[] = [];
+    const removedFifos: string[] = [];
     const chunkHandlers: Array<(chunk: Uint8Array) => void> = [];
     const encoder = new TextEncoder();
     let childResolve: (() => void) | null = null;
 
     const deps = {
-      mkdtempSync: () => "/tmp/maw-share-fanout-test",
       tmpdir: () => "/tmp",
       join: (...parts: string[]) => parts.join("/"),
-      rmSync: (path: string) => { removedTmpDirs.push(path); },
+      unlinkSync: (path: string) => { removedFifos.push(path); },
       tmux: {
         capture: async () => "SNAPSHOT\n",
         pipePane: async (...args: unknown[]) => { pipeCalls.push(args); },
       },
-      spawnTail: async (_path: string, onChunk: (chunk: Uint8Array) => void) => {
+      makeFifo: async (path: string) => { createdFifos.push(path); },
+      spawnPipeReader: async (_path: string, onChunk: (chunk: Uint8Array) => void) => {
         chunkHandlers.push(onChunk);
         return {
           kill: (signal?: string | number) => { killed.push(signal); },
@@ -288,7 +298,10 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(sentB).toEqual(["SNAPSHOT\n"]);
     expect(chunkHandlers).toHaveLength(1);
     expect(pipeCalls).toHaveLength(1);
-    expect(pipeCalls[0]).toEqual(["neo:1", expect.stringContaining("cat >>"), { onlyIfClosed: true }]);
+    expect(createdFifos).toHaveLength(1);
+    expect(createdFifos[0]).toStartWith("/tmp/maw-share-");
+    expect(createdFifos[0]).toEndWith("-neo-1.fifo");
+    expect(pipeCalls[0]).toEqual(["neo:1", `cat > '${createdFifos[0]}'`, { onlyIfClosed: true }]);
 
     chunkHandlers[0]!(encoder.encode("LIVE-1\n"));
     expect(sentA.at(-1)).toEqual(encoder.encode("LIVE-1\n"));
@@ -297,7 +310,7 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     await first.close();
     expect(pipeCalls).toHaveLength(1);
     expect(killed).toEqual([]);
-    expect(removedTmpDirs).toEqual([]);
+    expect(removedFifos).toEqual([]);
 
     chunkHandlers[0]!(encoder.encode("LIVE-2\n"));
     expect(sentA.map((entry) => entry instanceof Uint8Array ? new TextDecoder().decode(entry) : entry)).toEqual(["SNAPSHOT\n", "LIVE-1\n"]);
@@ -306,13 +319,13 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     if (childResolve) childResolve();
     await second.close();
     expect(pipeCalls).toEqual([
-      ["neo:1", expect.stringContaining("cat >>"), { onlyIfClosed: true }],
+      ["neo:1", `cat > '${createdFifos[0]}'`, { onlyIfClosed: true }],
       ["neo:1"],
     ]);
     expect(killed).toContain("SIGTERM");
-    expect(removedTmpDirs).toEqual(["/tmp/maw-share-fanout-test"]);
+    expect(removedFifos).toEqual([createdFifos[0]]);
 
-    const lsof = Bun.spawnSync(["sh", "-lc", "command -v lsof >/dev/null 2>&1 && lsof +D /tmp/maw-share-fanout-test 2>/dev/null || true"]);
+    const lsof = Bun.spawnSync(["sh", "-lc", `command -v lsof >/dev/null 2>&1 && lsof ${createdFifos[0]} 2>/dev/null || true`]);
     expect(new TextDecoder().decode(lsof.stdout)).toBe("");
   });
 
@@ -344,7 +357,8 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
             pipeCalls.push(args);
           },
         },
-        spawnTail: async () => ({
+        makeFifo: async () => undefined,
+        spawnPipeReader: async () => ({
           kill: () => undefined,
           exited: Promise.resolve(0),
         }),

--- a/test/vendor-share-crypto.test.ts
+++ b/test/vendor-share-crypto.test.ts
@@ -103,7 +103,8 @@ describe("share crypto hardening", () => {
             pipeCalls.push(args);
           },
         },
-        spawnTail: async (_path: string, onChunk: (chunk: Uint8Array) => void) => {
+        makeFifo: async () => undefined,
+        spawnPipeReader: async (_path: string, onChunk: (chunk: Uint8Array) => void) => {
           onChunk(bytes("LIVE-SECRET-1\n"));
           onChunk(bytes("LIVE-SECRET-2\n"));
           return {

--- a/test/vendor-share-hardening.test.ts
+++ b/test/vendor-share-hardening.test.ts
@@ -71,7 +71,8 @@ describe("share hardening", () => {
             pipeCalls.push(args);
           },
         },
-        spawnTail: async () => ({
+        makeFifo: async () => undefined,
+        spawnPipeReader: async () => ({
           kill: () => {},
           exited: Promise.resolve(0),
         }),

--- a/test/vendor-share-readonly.test.ts
+++ b/test/vendor-share-readonly.test.ts
@@ -63,7 +63,8 @@ describe("share readonly stream", () => {
             sendKeysCalls += 1;
           },
         },
-        spawnTail: async (_path: string, onChunk: (chunk: Uint8Array) => void) => {
+        makeFifo: async () => undefined,
+        spawnPipeReader: async (_path: string, onChunk: (chunk: Uint8Array) => void) => {
           onChunk(bytes("LIVE\n"));
           return {
             kill: (signal?: string | number) => {


### PR DESCRIPTION
Closes #2736

## Summary
- replace share tmpfile + tail -f relay with FIFO-backed direct cat reader
- preserve one pipe-pane per target with onlyIfClosed fan-out/refcount teardown
- keep teardown on real kill timers and update share standalone boundary assertions

## Verify
- timeout 120 bun test test/vendor-share-crypto.test.ts test/vendor-share-hardening.test.ts test/vendor-share-readonly.test.ts test/vendor-share-registry.test.ts test/vendor-share-token.test.ts
- timeout 120 bash scripts/test-isolated.sh test/isolated/plugin-share-standalone.test.ts
- timeout 120 bun run build
- timeout 120 bun scripts/check-plugin-coverage-gate.ts origin/alpha