### PR TITLE
fix: share viewer reconnects with fresh snapshots (#2739)

### DIFF
--- a/src/vendor/mpr-plugins/share/viewer.html
+++ b/src/vendor/mpr-plugins/share/viewer.html
@@ -29,6 +29,7 @@
         height: 100%;
       }
     </style>
+    <link rel="stylesheet" href="https://unpkg.com/@xterm/xterm/css/xterm.css" />
     <script src="https://unpkg.com/@xterm/xterm/lib/xterm.js"></script>
     <script src="https://unpkg.com/@xterm/addon-fit/lib/addon-fit.js"></script>
   </head>
@@ -78,8 +79,7 @@
         };
 
         const wsProof = e2eKey ? await sha256Hex(e2eKey) : token;
-        const socket = new WebSocket(`${wsProto}://${location.host}/ws/share/${encodeURIComponent(slug)}?${e2eKey ? "h" : "t"}=${encodeURIComponent(wsProof)}`);
-        socket.binaryType = "arraybuffer";
+        const wsUrl = () => `${wsProto}://${location.host}/ws/share/${encodeURIComponent(slug)}?${e2eKey ? "h" : "t"}=${encodeURIComponent(wsProof)}`;
 
         const decryptFrame = async (key, data) => {
           if (!key) return typeof data === "string" ? data : new TextDecoder().decode(data);
@@ -93,6 +93,13 @@
 
         let e2eKeyPromise = deriveE2EKey(e2eKey);
 
+        const RECONNECT_BASE_MS = 250;
+        const RECONNECT_MAX_MS = 5_000;
+        let socket = null;
+        let reconnectAttempt = 0;
+        let reconnectTimer = null;
+        let shouldReconnect = true;
+
         const fallback = document.getElementById("fallback");
         const termHost = document.getElementById("term");
         const pre = document.getElementById("ansi-fallback");
@@ -104,6 +111,40 @@
           termHost.style.display = "none";
         };
 
+        let term = null;
+        let fit = null;
+        let resizeObserver = null;
+
+        const resetForFreshSnapshot = () => {
+          if (term) {
+            term.reset();
+            return;
+          }
+          pre.textContent = "";
+        };
+
+        const handleFrame = (event) => {
+          void (async () => {
+            try {
+              const plain = await decryptFrame(await e2eKeyPromise, event.data);
+              if (term) term.write(plain);
+              else writeFallback(plain);
+            } catch {
+              if (term) {
+                fallback.textContent = "Unable to decrypt encrypted share frame.";
+                fallback.style.display = "block";
+              } else {
+                writeFallback("\n[unable to decrypt encrypted share frame]\n");
+              }
+            }
+          })();
+        };
+
+        const fitTerminal = () => {
+          if (!fit) return;
+          try { fit.fit(); } catch { /* resize is advisory */ }
+        };
+
         const initTerminal = () => {
           if (!window.Terminal || !window.FitAddon) {
             fallback.textContent = "xterm.js unavailable; using fallback terminal.";
@@ -111,65 +152,83 @@
             return false;
           }
 
-          const term = new window.Terminal({
+          term = new window.Terminal({
             theme: { background: "#0d0d0d", foreground: "#d1d5db" },
             convertEol: true,
             disableStdin: true,
             cursorBlink: false,
           });
 
-          const fit = new window.FitAddon.FitAddon();
+          fit = new window.FitAddon.FitAddon();
           term.loadAddon(fit);
           term.open(termHost);
-          const resize = () => {
-            try { fit.fit(); } catch { /* resize is advisory */ }
-          };
-          window.addEventListener("resize", resize);
-          resize();
-
-          socket.addEventListener("message", (event) => {
-            void (async () => {
-              try {
-                term.write(await decryptFrame(await e2eKeyPromise, event.data));
-              } catch {
-                fallback.textContent = "Unable to decrypt encrypted share frame.";
-                fallback.style.display = "block";
-              }
-            })();
-          });
+          window.addEventListener("resize", fitTerminal);
+          window.visualViewport?.addEventListener("resize", fitTerminal);
+          if (window.ResizeObserver) {
+            resizeObserver = new ResizeObserver(fitTerminal);
+            resizeObserver.observe(termHost);
+          }
+          requestAnimationFrame(fitTerminal);
+          fitTerminal();
           return true;
         };
 
-        if (!initTerminal()) {
-          socket.addEventListener("message", (event) => {
-            void (async () => {
-              try {
-                writeFallback(await decryptFrame(await e2eKeyPromise, event.data));
-              } catch {
-                writeFallback("\n[unable to decrypt encrypted share frame]\n");
-              }
-            })();
+        initTerminal();
+
+        const connect = () => {
+          if (reconnectTimer) {
+            clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+          }
+
+          const current = new WebSocket(wsUrl());
+          socket = current;
+          current.binaryType = "arraybuffer";
+
+          current.addEventListener("open", () => {
+            if (socket !== current) return;
+            reconnectAttempt = 0;
+            if (term) fallback.style.display = "none";
+            resetForFreshSnapshot();
+            fitTerminal();
+            try {
+              current.send("ping");
+            } catch {
+              // ignore
+            }
           });
-        }
 
-        socket.addEventListener("open", () => {
-          try {
-            socket.send("ping");
-          } catch {
-            // ignore
-          }
+          current.addEventListener("message", handleFrame);
+
+          current.addEventListener("close", (event) => {
+            if (socket !== current || !shouldReconnect) return;
+            if (event.code === 1008) {
+              shouldReconnect = false;
+              fallback.textContent = event.reason || "Share expired or token rejected.";
+              fallback.style.display = "block";
+              return;
+            }
+            const delay = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * (2 ** reconnectAttempt));
+            reconnectAttempt += 1;
+            reconnectTimer = setTimeout(connect, delay);
+          });
+
+          current.addEventListener("error", () => {
+            if (fallback.style.display === "none") {
+              fallback.textContent = "Connection lost; reconnecting…";
+              fallback.style.display = "block";
+            }
+          });
+        };
+
+        window.addEventListener("beforeunload", () => {
+          shouldReconnect = false;
+          if (reconnectTimer) clearTimeout(reconnectTimer);
+          resizeObserver?.disconnect();
+          socket?.close();
         });
 
-        socket.addEventListener("close", () => {
-          // read-only: nothing to do
-        });
-
-        socket.addEventListener("error", () => {
-          if (fallback.style.display === "none") {
-            fallback.textContent = "Connection error while opening share.";
-            fallback.style.display = "block";
-          }
-        });
+        connect();
       })();
     </script>
   </body>

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -102,6 +102,16 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(stream).not.toContain('cmd: ["tail"');
     expect(stream).not.toContain("cat >>");
     expect(stream).not.toContain("mkdtempSync");
+
+    const viewer = readFileSync(join(root, "src/vendor/mpr-plugins/share/viewer.html"), "utf8");
+    expect(viewer).toContain("const wsUrl = () =>");
+    expect(viewer).toContain("resetForFreshSnapshot();");
+    expect(viewer).toContain("term.reset();");
+    expect(viewer).toContain("reconnectTimer = setTimeout(connect, delay);");
+    expect(viewer).toContain("new window.FitAddon.FitAddon()");
+    expect(viewer).toContain('window.addEventListener("resize", fitTerminal)');
+    expect(viewer).toContain('window.visualViewport?.addEventListener("resize", fitTerminal)');
+    expect(viewer).toContain("new ResizeObserver(fitTerminal)");
   });
 
   test("cli share dispatch posts to daemon and daemon serves minted viewer", async () => {

--- a/test/vendor-share-hardening.test.ts
+++ b/test/vendor-share-hardening.test.ts
@@ -37,10 +37,25 @@ describe("share hardening", () => {
 
     expect(viewer).toContain("const e2eKey = params.get(\"k\") || \"\";");
     expect(viewer).toContain("const wsProof = e2eKey ? await sha256Hex(e2eKey) : token;");
+    expect(viewer).toContain("const wsUrl = () =>");
     expect(viewer).toContain("?${e2eKey ? \"h\" : \"t\"}=");
     expect(viewer).not.toContain("?${e2eKey ? \"k\" : \"t\"}=");
     expect(viewer).not.toContain("const wsToken = e2eKey || token");
     expect(server).not.toContain('searchParams.get("k")');
+  });
+
+  test("viewer reconnect resets display for fresh snapshot and fits on resize", () => {
+    const viewer = readFileSync(join(import.meta.dir, "../src/vendor/mpr-plugins/share/viewer.html"), "utf8");
+
+    expect(viewer).toContain("const RECONNECT_BASE_MS = 250;");
+    expect(viewer).toContain("reconnectTimer = setTimeout(connect, delay);");
+    expect(viewer).toContain("resetForFreshSnapshot();");
+    expect(viewer).toContain("term.reset();");
+    expect(viewer).toContain("new window.FitAddon.FitAddon()");
+    expect(viewer).toContain('window.addEventListener("resize", fitTerminal)');
+    expect(viewer).toContain('window.visualViewport?.addEventListener("resize", fitTerminal)');
+    expect(viewer).toContain("new ResizeObserver(fitTerminal)");
+    expect(viewer).toContain('<link rel="stylesheet" href="https://unpkg.com/@xterm/xterm/css/xterm.css" />');
   });
 
   test("active stream closes itself and websocket when TTL expires", async () => {

--- a/test/vendor-share-readonly.test.ts
+++ b/test/vendor-share-readonly.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { attach } from "../src/vendor/mpr-plugins/share/stream";
+import { __resetShareStreamBusesForTests, attach } from "../src/vendor/mpr-plugins/share/stream";
 import type { Share } from "../src/vendor/mpr-plugins/share/impl";
 
 type WsMessage = string | Uint8Array;
@@ -29,6 +29,7 @@ describe("share readonly stream", () => {
   let sendKeysCalls: number = 0;
 
   beforeEach(() => {
+    __resetShareStreamBusesForTests();
     killCalls = [];
     pipeCalls = [];
     captures = [];
@@ -91,5 +92,59 @@ describe("share readonly stream", () => {
 
     expect(pipeCalls.some((call) => call[0] === "session:0" && call.length === 1)).toBe(true);
     expect(killCalls.length).toBeGreaterThan(0);
+  });
+
+  test("reconnect attach sends a fresh snapshot before resuming live pipe", async () => {
+    const share: Share = {
+      target: "session:0",
+      panes: [],
+      readOnly: true,
+      tokenHash: "hash",
+      expiresAt: Date.now() + 1_000_000,
+      auth: "token",
+    };
+    const sentA: Array<WsMessage> = [];
+    const sentB: Array<WsMessage> = [];
+    const localPipeCalls: Array<Array<unknown>> = [];
+    const liveHandlers: Array<(chunk: Uint8Array) => void> = [];
+    const childResolvers: Array<() => void> = [];
+    const localKillCalls: Array<unknown> = [];
+    let captureCount = 0;
+
+    const deps = {
+      tmux: {
+        capture: async () => `SNAPSHOT-${++captureCount}\n`,
+        pipePane: async (...args: unknown[]) => {
+          localPipeCalls.push(args);
+        },
+      },
+      makeFifo: async () => undefined,
+      spawnPipeReader: async (_path: string, onChunk: (chunk: Uint8Array) => void) => {
+        liveHandlers.push(onChunk);
+        return {
+          kill: (signal?: string | number) => { localKillCalls.push(signal); },
+          exited: new Promise((resolve) => { childResolvers.push(() => resolve(0)); }),
+        };
+      },
+    } as any;
+
+    const first = await attach(share, { send: (data: WsMessage) => sentA.push(data) } as any, deps);
+    liveHandlers[0]!(bytes("LIVE-OLD\n"));
+    expect(sentA).toEqual(["SNAPSHOT-1\n", bytes("LIVE-OLD\n")]);
+
+    childResolvers[0]?.();
+    await first.close();
+
+    const second = await attach(share, { send: (data: WsMessage) => sentB.push(data) } as any, deps);
+    liveHandlers[1]!(bytes("LIVE-NEW\n"));
+    expect(sentB).toEqual(["SNAPSHOT-2\n", bytes("LIVE-NEW\n")]);
+
+    expect(captureCount).toBe(2);
+    expect(liveHandlers).toHaveLength(2);
+    expect(localPipeCalls.map((call) => call.length)).toEqual([3, 1, 3]);
+    expect(localKillCalls).toContain("SIGTERM");
+
+    childResolvers[1]?.();
+    await second.close();
   });
 });


### PR DESCRIPTION
Closes #2739

## Summary
- add share viewer websocket auto-reconnect with bounded backoff
- reset xterm/fallback display on each successful reconnect so the server fresh snapshot becomes the resumed screen state
- wire xterm FitAddon to window, visualViewport, and ResizeObserver resize paths
- add reconnect snapshot regression while preserving one pipe/target share stream lifecycle

## Verify
- timeout 120 bun test test/vendor-share-crypto.test.ts test/vendor-share-hardening.test.ts test/vendor-share-readonly.test.ts test/vendor-share-registry.test.ts test/vendor-share-token.test.ts
- timeout 120 bash scripts/test-isolated.sh test/isolated/plugin-share-standalone.test.ts
- timeout 120 bun run build
- timeout 120 bun scripts/check-plugin-coverage-gate.ts origin/alpha