### PR TITLE
fix: share supports multi-pane viewer fan-out (#2742)

### DIFF
--- a/src/vendor/mpr-plugins/share/index.ts
+++ b/src/vendor/mpr-plugins/share/index.ts
@@ -14,7 +14,7 @@ export const command = {
   description: "Share a live read-only tmux session/pane in a browser via a temporary link.",
 };
 
-const SHARE_USAGE = "usage: maw share <session-or-pane> [--read-only] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]";
+const SHARE_USAGE = "usage: maw share <session-or-pane> [additional-pane ...] [--read-only] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]";
 const DEFAULT_TTL_SECONDS = 3600;
 const DEFAULT_READ_ONLY = true;
 
@@ -366,18 +366,22 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       "--encrypt": Boolean,
     }, 0);
 
-    const target = flags._[0];
+    const targets = flags._;
+    const target = targets[0];
     if (!target || target === "--help" || target === "-h") {
       return { ok: false, error: `${SHARE_USAGE}` };
     }
-    if (target.startsWith("-")) {
+    if (targets.some((candidate) => candidate.startsWith("-"))) {
       return { ok: false, error: `${SHARE_USAGE}\n  target looks like a flag` };
     }
 
-    const hit = resolveTmuxTarget(target);
-    if (!hit) {
-      return { ok: false, error: `cannot resolve tmux target: ${target}` };
+    const hits = targets.map((candidate) => ({ candidate, hit: resolveTmuxTarget(candidate) }));
+    const missing = hits.find((entry) => !entry.hit);
+    if (missing) {
+      return { ok: false, error: `cannot resolve tmux target: ${missing.candidate}` };
     }
+    const resolvedTargets = hits.map((entry) => entry.hit!.resolved);
+    const hit = hits[0]!.hit!;
 
     const readOnly = flags["--read-only"] === undefined ? DEFAULT_READ_ONLY : Boolean(flags["--read-only"]);
     const ttl = typeof flags["--ttl"] === "number" && Number.isFinite(flags["--ttl"]) ? flags["--ttl"] : DEFAULT_TTL_SECONDS;
@@ -386,6 +390,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     const request: CreateShareRequest = {
       target: hit.resolved,
+      panes: resolvedTargets.length > 1 ? resolvedTargets : undefined,
       readOnly,
       ttl,
       auth,

--- a/src/vendor/mpr-plugins/share/stream.ts
+++ b/src/vendor/mpr-plugins/share/stream.ts
@@ -28,6 +28,19 @@ type Subscriber = {
   send: (chunk: string | Uint8Array) => void;
 };
 
+type AttachedBus = {
+  target: string;
+  bus: TargetBus;
+  subscriberId: symbol;
+};
+
+type ShareWireFrame = {
+  type: "maw-share-frame";
+  pane: string;
+  data: string;
+  snapshot?: boolean;
+};
+
 type TargetBus = {
   target: string;
   fifoPath: string;
@@ -197,6 +210,29 @@ function sendSafe(ws: ServerWebSocket, data: string | Uint8Array): void {
   }
 }
 
+function shareTargets(share: Share): string[] {
+  const seen = new Set<string>();
+  const targets = (share.panes.length > 0 ? share.panes : [share.target])
+    .map((target) => target.trim())
+    .filter((target) => target.length > 0)
+    .filter((target) => {
+      if (seen.has(target)) return false;
+      seen.add(target);
+      return true;
+    });
+  return targets.length > 0 ? targets : [share.target];
+}
+
+function encodeWireData(data: string | Uint8Array): string {
+  return typeof data === "string" ? data : new TextDecoder().decode(data);
+}
+
+function taggedFrame(target: string, data: string | Uint8Array, snapshot = false): string {
+  const frame: ShareWireFrame = { type: "maw-share-frame", pane: target, data: encodeWireData(data) };
+  if (snapshot) frame.snapshot = true;
+  return JSON.stringify(frame);
+}
+
 function nextEncryptedFrame(share: Share, data: string | Uint8Array): string | Uint8Array {
   if (!share.encrypted) return data;
   if (!share.encryptionKey) throw new Error("encrypted share is missing its RAM-only key");
@@ -282,15 +318,16 @@ export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<St
 
   let closed = false;
   let expiryTimer: ReturnType<typeof setTimeout> | null = null;
-  let bus: TargetBus | null = null;
-  const subscriberId = Symbol(`share:${share.target}`);
+  const targets = shareTargets(share);
+  const multiplex = targets.length > 1;
+  const attachedBuses: AttachedBus[] = [];
 
   const detach = async (): Promise<void> => {
-    if (!bus) return;
-    const targetBus = bus;
-    bus = null;
-    targetBus.subscribers.delete(subscriberId);
-    if (targetBus.subscribers.size === 0) await teardownBus(targetBus);
+    const pending = attachedBuses.splice(0);
+    await Promise.all(pending.map(async ({ bus: targetBus, subscriberId }) => {
+      targetBus.subscribers.delete(subscriberId);
+      if (targetBus.subscribers.size === 0) await teardownBus(targetBus);
+    }));
   };
 
   const close = async (): Promise<void> => {
@@ -324,21 +361,27 @@ export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<St
   };
 
   try {
-    const snapshot = await resolved.tmux.capture(share.target, DEFAULT_SNAPSHOT_LINES);
-    if (snapshot) sendSafe(ws, nextEncryptedFrame(share, snapshot));
+    for (const target of targets) {
+      const snapshot = await resolved.tmux.capture(target, DEFAULT_SNAPSHOT_LINES);
+      if (snapshot) sendSafe(ws, nextEncryptedFrame(share, multiplex ? taggedFrame(target, snapshot, true) : snapshot));
+    }
 
-    bus = await getTargetBus(share.target, resolved);
-    if (closed) {
-      await detach();
-    } else {
+    for (const target of targets) {
+      const targetBus = await getTargetBus(target, resolved);
+      const subscriberId = Symbol(`share:${target}`);
+      attachedBuses.push({ target, bus: targetBus, subscriberId });
+      if (closed) {
+        await detach();
+        break;
+      }
       const subscriber = {
         send: (chunk: string | Uint8Array) => {
           if (closed) return;
-          sendSafe(ws, nextEncryptedFrame(share, chunk));
+          sendSafe(ws, nextEncryptedFrame(share, multiplex ? taggedFrame(target, chunk) : chunk));
         },
       };
-      bus.subscribers.set(subscriberId, subscriber);
-      for (const chunk of drainBacklog(bus)) subscriber.send(chunk);
+      targetBus.subscribers.set(subscriberId, subscriber);
+      for (const chunk of drainBacklog(targetBus)) subscriber.send(chunk);
     }
   } catch (error) {
     await close();

--- a/src/vendor/mpr-plugins/share/viewer.html
+++ b/src/vendor/mpr-plugins/share/viewer.html
@@ -11,6 +11,9 @@
         background: #0d0d0d;
         color: #d1d5db;
         height: 100%;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
       }
 
       #fallback {
@@ -19,14 +22,83 @@
         white-space: pre-wrap;
       }
 
+      #toolbar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-height: 34px;
+        padding: 4px 8px;
+        background: #111827;
+        border-bottom: 1px solid #1f2937;
+        box-sizing: border-box;
+        overflow-x: auto;
+      }
+
+      #tabs {
+        display: flex;
+        gap: 4px;
+        flex: 1 1 auto;
+      }
+
+      .tab, #tile-toggle {
+        color: #d1d5db;
+        background: #1f2937;
+        border: 1px solid #374151;
+        border-radius: 6px;
+        padding: 4px 8px;
+        font: 12px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        white-space: nowrap;
+      }
+
+      .tab.active, #tile-toggle.active {
+        background: #2563eb;
+        border-color: #60a5fa;
+        color: white;
+      }
+
       #term {
+        width: 100%;
+        flex: 1 1 auto;
+        min-height: 0;
+      }
+
+      #terms {
+        width: 100%;
+        height: 100%;
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-auto-rows: minmax(0, 1fr);
+      }
+
+      #terms.tile {
+        grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+      }
+
+      .pane {
+        min-width: 0;
+        min-height: 0;
+        width: 100%;
+        height: 100%;
+        display: none;
+        border: 1px solid #111827;
+        box-sizing: border-box;
+      }
+
+      #terms.tile .pane,
+      .pane.active {
+        display: block;
+      }
+
+      .pane-host, .fallback-pane, .xterm {
         width: 100%;
         height: 100%;
       }
 
-      xterm-host, #xterm {
-        width: 100%;
-        height: 100%;
+      .fallback-pane {
+        display: none;
+        margin: 0;
+        overflow: auto;
+        font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
       }
     </style>
     <link rel="stylesheet" href="https://unpkg.com/@xterm/xterm/css/xterm.css" />
@@ -35,8 +107,11 @@
   </head>
   <body>
     <div id="fallback" style="display:none;">xterm.js failed to load; falling back to static display.</div>
-    <div id="term"></div>
-    <pre id="ansi-fallback" style="display:none; margin:0;"></pre>
+    <div id="toolbar" style="display:none;">
+      <div id="tabs"></div>
+      <button id="tile-toggle" type="button">tile</button>
+    </div>
+    <div id="term"><div id="terms"></div></div>
 
     <script>
       void (async () => {
@@ -91,6 +166,18 @@
           return new TextDecoder().decode(plain);
         };
 
+        const parseWireFrame = (plain) => {
+          try {
+            const parsed = JSON.parse(plain);
+            if (parsed && typeof parsed === "object" && parsed.type === "maw-share-frame" && typeof parsed.pane === "string" && typeof parsed.data === "string") {
+              return { pane: parsed.pane, data: parsed.data, snapshot: parsed.snapshot === true, tagged: true };
+            }
+          } catch {
+            // legacy single-pane raw frame
+          }
+          return { pane: "main", data: plain, snapshot: false, tagged: false };
+        };
+
         let e2eKeyPromise = deriveE2EKey(e2eKey);
 
         const RECONNECT_BASE_MS = 250;
@@ -99,81 +186,136 @@
         let reconnectAttempt = 0;
         let reconnectTimer = null;
         let shouldReconnect = true;
+        let tileMode = false;
+        let activePane = "main";
 
         const fallback = document.getElementById("fallback");
-        const termHost = document.getElementById("term");
-        const pre = document.getElementById("ansi-fallback");
+        const toolbar = document.getElementById("toolbar");
+        const tabs = document.getElementById("tabs");
+        const tileToggle = document.getElementById("tile-toggle");
+        const terms = document.getElementById("terms");
+        const panes = new Map();
 
-        const writeFallback = (chunk) => {
-          pre.textContent += chunk;
-          pre.parentElement?.appendChild(pre);
-          pre.style.display = "block";
-          termHost.style.display = "none";
+        const terminalAvailable = () => Boolean(window.Terminal && window.FitAddon);
+
+        const fitPane = (pane) => {
+          if (!pane?.fit) return;
+          try { pane.fit.fit(); } catch { /* resize is advisory */ }
         };
 
-        let term = null;
-        let fit = null;
-        let resizeObserver = null;
+        const fitAll = () => {
+          for (const pane of panes.values()) fitPane(pane);
+        };
 
-        const resetForFreshSnapshot = () => {
-          if (term) {
-            term.reset();
+        const updateLayout = () => {
+          toolbar.style.display = panes.size > 1 ? "flex" : "none";
+          terms.classList.toggle("tile", tileMode && panes.size > 1);
+          tileToggle.classList.toggle("active", tileMode);
+          for (const [id, pane] of panes.entries()) {
+            pane.root.classList.toggle("active", id === activePane);
+            pane.tab.classList.toggle("active", id === activePane);
+          }
+          requestAnimationFrame(fitAll);
+          fitAll();
+        };
+
+        const selectPane = (id) => {
+          activePane = id;
+          updateLayout();
+        };
+
+        const createPane = (id) => {
+          const existing = panes.get(id);
+          if (existing) return existing;
+
+          const root = document.createElement("section");
+          root.className = "pane";
+          root.dataset.pane = id;
+          const host = document.createElement("div");
+          host.className = "pane-host";
+          const pre = document.createElement("pre");
+          pre.className = "fallback-pane";
+          root.appendChild(host);
+          root.appendChild(pre);
+          terms.appendChild(root);
+
+          const tab = document.createElement("button");
+          tab.className = "tab";
+          tab.type = "button";
+          tab.textContent = id;
+          tab.addEventListener("click", () => selectPane(id));
+          tabs.appendChild(tab);
+
+          let term = null;
+          let fit = null;
+          if (terminalAvailable()) {
+            term = new window.Terminal({
+              theme: { background: "#0d0d0d", foreground: "#d1d5db" },
+              convertEol: true,
+              disableStdin: true,
+              cursorBlink: false,
+            });
+            fit = new window.FitAddon.FitAddon();
+            term.loadAddon(fit);
+            term.open(host);
+          } else {
+            fallback.textContent = "xterm.js unavailable; using fallback terminal.";
+            fallback.style.display = "block";
+            host.style.display = "none";
+            pre.style.display = "block";
+          }
+
+          const pane = { id, root, host, pre, tab, term, fit };
+          panes.set(id, pane);
+          if (panes.size === 1) activePane = id;
+          updateLayout();
+          return pane;
+        };
+
+        const resetPane = (pane) => {
+          if (pane.term) {
+            pane.term.reset();
             return;
           }
-          pre.textContent = "";
+          pane.pre.textContent = "";
+        };
+
+        const writePane = (pane, chunk) => {
+          if (pane.term) {
+            pane.term.write(chunk);
+            return;
+          }
+          pane.pre.textContent += chunk;
+          pane.pre.style.display = "block";
+        };
+
+        const resetForFreshSnapshot = () => {
+          for (const pane of panes.values()) resetPane(pane);
         };
 
         const handleFrame = (event) => {
           void (async () => {
             try {
               const plain = await decryptFrame(await e2eKeyPromise, event.data);
-              if (term) term.write(plain);
-              else writeFallback(plain);
+              const frame = parseWireFrame(plain);
+              const pane = createPane(frame.pane);
+              if (frame.snapshot) resetPane(pane);
+              writePane(pane, frame.data);
             } catch {
-              if (term) {
-                fallback.textContent = "Unable to decrypt encrypted share frame.";
-                fallback.style.display = "block";
-              } else {
-                writeFallback("\n[unable to decrypt encrypted share frame]\n");
-              }
+              fallback.textContent = "Unable to decrypt or route share frame.";
+              fallback.style.display = "block";
             }
           })();
         };
 
-        const fitTerminal = () => {
-          if (!fit) return;
-          try { fit.fit(); } catch { /* resize is advisory */ }
-        };
-
-        const initTerminal = () => {
-          if (!window.Terminal || !window.FitAddon) {
-            fallback.textContent = "xterm.js unavailable; using fallback terminal.";
-            fallback.style.display = "block";
-            return false;
-          }
-
-          term = new window.Terminal({
-            theme: { background: "#0d0d0d", foreground: "#d1d5db" },
-            convertEol: true,
-            disableStdin: true,
-            cursorBlink: false,
-          });
-
-          fit = new window.FitAddon.FitAddon();
-          term.loadAddon(fit);
-          term.open(termHost);
-          window.addEventListener("resize", fitTerminal);
-          window.visualViewport?.addEventListener("resize", fitTerminal);
-          if (window.ResizeObserver) {
-            resizeObserver = new ResizeObserver(fitTerminal);
-            resizeObserver.observe(termHost);
-          }
-          requestAnimationFrame(fitTerminal);
-          fitTerminal();
-          return true;
-        };
-
-        initTerminal();
+        const resizeObserver = window.ResizeObserver ? new ResizeObserver(fitAll) : null;
+        resizeObserver?.observe(terms);
+        window.addEventListener("resize", fitAll);
+        window.visualViewport?.addEventListener("resize", fitAll);
+        tileToggle.addEventListener("click", () => {
+          tileMode = !tileMode;
+          updateLayout();
+        });
 
         const connect = () => {
           if (reconnectTimer) {
@@ -188,9 +330,9 @@
           current.addEventListener("open", () => {
             if (socket !== current) return;
             reconnectAttempt = 0;
-            if (term) fallback.style.display = "none";
+            fallback.style.display = "none";
             resetForFreshSnapshot();
-            fitTerminal();
+            fitAll();
             try {
               current.send("ping");
             } catch {

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -106,12 +106,14 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     const viewer = readFileSync(join(root, "src/vendor/mpr-plugins/share/viewer.html"), "utf8");
     expect(viewer).toContain("const wsUrl = () =>");
     expect(viewer).toContain("resetForFreshSnapshot();");
-    expect(viewer).toContain("term.reset();");
+    expect(viewer).toContain("resetPane(pane);");
     expect(viewer).toContain("reconnectTimer = setTimeout(connect, delay);");
     expect(viewer).toContain("new window.FitAddon.FitAddon()");
-    expect(viewer).toContain('window.addEventListener("resize", fitTerminal)');
-    expect(viewer).toContain('window.visualViewport?.addEventListener("resize", fitTerminal)');
-    expect(viewer).toContain("new ResizeObserver(fitTerminal)");
+    expect(viewer).toContain('window.addEventListener("resize", fitAll)');
+    expect(viewer).toContain('window.visualViewport?.addEventListener("resize", fitAll)');
+    expect(viewer).toContain("new ResizeObserver(fitAll)");
+    expect(viewer).toContain("const parseWireFrame = (plain) =>");
+    expect(viewer).toContain("const tileToggle = document.getElementById(\"tile-toggle\")");
   });
 
   test("cli share dispatch posts to daemon and daemon serves minted viewer", async () => {
@@ -165,6 +167,38 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     }
   });
 
+
+  test("cli share accepts multiple pane targets under one token", async () => {
+    const { httpRoutes } = await makeServeHarness();
+    const createRoute = httpRoutes.find((route) => route.method === "POST" && route.path === "/api/share")!;
+    const originalFetch = globalThis.fetch;
+    const postedBodies: unknown[] = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      postedBodies.push(await req.clone().json());
+      return createRoute.handler(req);
+    }) as typeof fetch;
+
+    try {
+      const result = await shareHandler({
+        source: "cli",
+        args: ["neo:1.0", "neo:1.1", "--port", "4567"],
+      } as any);
+
+      expect(result.ok).toBe(true);
+      expect(resolvedTargets).toEqual(["neo:1.0", "neo:1.1"]);
+      expect(postedBodies).toEqual([{
+        target: "neo:1.0:resolved",
+        panes: ["neo:1.0:resolved", "neo:1.1:resolved"],
+        readOnly: true,
+        ttl: 3600,
+        auth: "token",
+      }]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
   test("crypto frames roundtrip and reject tamper or wrong key", () => {
     const secret = shareCrypto.mintShareSecret();
     const key = shareCrypto.deriveShareKey(secret);

--- a/test/vendor-share-hardening.test.ts
+++ b/test/vendor-share-hardening.test.ts
@@ -50,11 +50,13 @@ describe("share hardening", () => {
     expect(viewer).toContain("const RECONNECT_BASE_MS = 250;");
     expect(viewer).toContain("reconnectTimer = setTimeout(connect, delay);");
     expect(viewer).toContain("resetForFreshSnapshot();");
-    expect(viewer).toContain("term.reset();");
+    expect(viewer).toContain("resetPane(pane);");
     expect(viewer).toContain("new window.FitAddon.FitAddon()");
-    expect(viewer).toContain('window.addEventListener("resize", fitTerminal)');
-    expect(viewer).toContain('window.visualViewport?.addEventListener("resize", fitTerminal)');
-    expect(viewer).toContain("new ResizeObserver(fitTerminal)");
+    expect(viewer).toContain('window.addEventListener("resize", fitAll)');
+    expect(viewer).toContain('window.visualViewport?.addEventListener("resize", fitAll)');
+    expect(viewer).toContain("new ResizeObserver(fitAll)");
+    expect(viewer).toContain("const parseWireFrame = (plain) =>");
+    expect(viewer).toContain("const tileToggle = document.getElementById(\"tile-toggle\")");
     expect(viewer).toContain('<link rel="stylesheet" href="https://unpkg.com/@xterm/xterm/css/xterm.css" />');
   });
 

--- a/test/vendor-share-readonly.test.ts
+++ b/test/vendor-share-readonly.test.ts
@@ -147,4 +147,58 @@ describe("share readonly stream", () => {
     childResolvers[1]?.();
     await second.close();
   });
+
+  test("multi-pane share tags snapshots and live chunks per pane with independent pipe teardown", async () => {
+    const share: Share = {
+      target: "session:0",
+      panes: ["session:0.0", "session:0.1"],
+      readOnly: true,
+      tokenHash: "hash",
+      expiresAt: Date.now() + 1_000_000,
+      auth: "token",
+    };
+    const sent: Array<WsMessage> = [];
+    const localPipeCalls: Array<Array<unknown>> = [];
+    const liveHandlers = new Map<string, (chunk: Uint8Array) => void>();
+    const childResolvers = new Map<string, () => void>();
+    const localKillCalls: Array<[string, unknown]> = [];
+
+    const handle = await attach(share, { send: (data: WsMessage) => sent.push(data) } as any, {
+      tmux: {
+        capture: async (target: string) => `SNAPSHOT ${target}\n`,
+        pipePane: async (...args: unknown[]) => { localPipeCalls.push(args); },
+      },
+      makeFifo: async () => undefined,
+      spawnPipeReader: async (path: string, onChunk: (chunk: Uint8Array) => void) => {
+        const target = path.includes("session-0.0") ? "session:0.0" : "session:0.1";
+        liveHandlers.set(target, onChunk);
+        return {
+          kill: (signal?: string | number) => { localKillCalls.push([target, signal]); },
+          exited: new Promise((resolve) => { childResolvers.set(target, () => resolve(0)); }),
+        };
+      },
+      tmpdir: () => "/tmp",
+      join: (...parts: string[]) => parts.join("/"),
+    } as any);
+
+    expect(sent.slice(0, 2).map((frame) => JSON.parse(String(frame)))).toEqual([
+      { type: "maw-share-frame", pane: "session:0.0", data: "SNAPSHOT session:0.0\n", snapshot: true },
+      { type: "maw-share-frame", pane: "session:0.1", data: "SNAPSHOT session:0.1\n", snapshot: true },
+    ]);
+    expect(localPipeCalls.filter((call) => call.length === 3).map((call) => call[0]).sort()).toEqual(["session:0.0", "session:0.1"]);
+
+    liveHandlers.get("session:0.0")!(bytes("LIVE A\n"));
+    liveHandlers.get("session:0.1")!(bytes("LIVE B\n"));
+    expect(sent.slice(2).map((frame) => JSON.parse(String(frame)))).toEqual([
+      { type: "maw-share-frame", pane: "session:0.0", data: "LIVE A\n" },
+      { type: "maw-share-frame", pane: "session:0.1", data: "LIVE B\n" },
+    ]);
+
+    childResolvers.get("session:0.0")?.();
+    childResolvers.get("session:0.1")?.();
+    await handle.close();
+
+    expect(localPipeCalls.filter((call) => call.length === 1).map((call) => call[0]).sort()).toEqual(["session:0.0", "session:0.1"]);
+    expect(localKillCalls.map(([target, signal]) => `${target}:${signal}`).sort()).toEqual(["session:0.0:SIGTERM", "session:0.1:SIGTERM"]);
+  });
 });


### PR DESCRIPTION
Closes #2742

## Summary
- multiplex share.panes with one independent FIFO fan-out bus per pane target
- tag multi-pane snapshot/live frames with a type-discriminated pane protocol while preserving raw single-pane frames
- render viewer tabs/tile grid with per-pane xterm FitAddon resize handling
- add CLI multi-pane target support under one share token

## Verify
- timeout 120 bun test test/vendor-share-crypto.test.ts test/vendor-share-hardening.test.ts test/vendor-share-readonly.test.ts test/vendor-share-registry.test.ts test/vendor-share-token.test.ts
- timeout 120 bash scripts/test-isolated.sh test/isolated/plugin-share-standalone.test.ts
- timeout 120 bun run test
- timeout 120 bun run build
- timeout 120 bun scripts/check-plugin-coverage-gate.ts origin/alpha