### PR TITLE
fix: preserve share stream tmux instance (#2744)

### DIFF
--- a/src/vendor/mpr-plugins/share/stream.ts
+++ b/src/vendor/mpr-plugins/share/stream.ts
@@ -301,16 +301,24 @@ function normalizePing(message: string): string {
   return message.trim().toLowerCase();
 }
 
-export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<StreamDeps> = {}): Promise<ShareStreamHandle> {
+function resolveStreamDeps(deps: Partial<StreamDeps> = {}): StreamDeps {
   const baseDeps = defaultDeps();
-  const resolved = {
+  return {
     ...baseDeps,
     ...deps,
-    tmux: {
-      ...(baseDeps.tmux),
-      ...(deps.tmux ?? {}),
-    },
+    // Tmux is a class instance; object spread strips prototype methods such as
+    // capture() and pipePane(). Preserve the instance unless tests inject a full
+    // tmux shape.
+    tmux: deps.tmux ?? baseDeps.tmux,
   };
+}
+
+export function __resolveShareStreamDepsForTests(deps: Partial<StreamDeps> = {}): StreamDeps {
+  return resolveStreamDeps(deps);
+}
+
+export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<StreamDeps> = {}): Promise<ShareStreamHandle> {
+  const resolved = resolveStreamDeps(deps);
 
   if (share.expiresAt <= Date.now()) {
     throw new Error("share expired before stream attach");

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -116,6 +116,15 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(viewer).toContain("const tileToggle = document.getElementById(\"tile-toggle\")");
   });
 
+  test("stream default deps preserve real Tmux prototype methods", () => {
+    const stream = readFileSync(join(root, "src/vendor/mpr-plugins/share/stream.ts"), "utf8");
+    expect(stream).toContain("tmux: deps.tmux ?? baseDeps.tmux");
+
+    const resolved = shareStream.__resolveShareStreamDepsForTests();
+    expect(typeof resolved.tmux.capture).toBe("function");
+    expect(typeof resolved.tmux.pipePane).toBe("function");
+  });
+
   test("cli share dispatch posts to daemon and daemon serves minted viewer", async () => {
     const { httpRoutes } = await makeServeHarness();
     const createRoute = httpRoutes.find((route) => route.method === "POST" && route.path === "/api/share")!;

--- a/test/vendor-share-readonly.test.ts
+++ b/test/vendor-share-readonly.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { __resetShareStreamBusesForTests, attach } from "../src/vendor/mpr-plugins/share/stream";
+import { __resetShareStreamBusesForTests, __resolveShareStreamDepsForTests, attach } from "../src/vendor/mpr-plugins/share/stream";
 import type { Share } from "../src/vendor/mpr-plugins/share/impl";
 
 type WsMessage = string | Uint8Array;
@@ -34,6 +34,13 @@ describe("share readonly stream", () => {
     pipeCalls = [];
     captures = [];
     sendKeysCalls = 0;
+  });
+
+  test("default stream deps preserve real Tmux prototype methods", () => {
+    const resolved = __resolveShareStreamDepsForTests();
+
+    expect(typeof resolved.tmux.capture).toBe("function");
+    expect(typeof resolved.tmux.pipePane).toBe("function");
   });
 
   test("dropping inbound ws messages does not write pane text", async () => {


### PR DESCRIPTION
Closes #2744

## Summary
- preserve the real Tmux instance in share stream deps instead of object-spreading away prototype methods
- add regression coverage for defaultDeps/class-prototype path in share unit and standalone boundary tests
- verified real encrypted share streaming end-to-end via fresh maw serve + maw share --encrypt + WS h=proof frame receive

## Verify
- timeout 120 bun test test/vendor-share-crypto.test.ts test/vendor-share-hardening.test.ts test/vendor-share-readonly.test.ts test/vendor-share-registry.test.ts test/vendor-share-token.test.ts
- timeout 120 bash scripts/test-isolated.sh test/isolated/plugin-share-standalone.test.ts
- timeout 120 bun scripts/check-plugin-coverage-gate.ts origin/alpha
- timeout 120 bun run build
- real E2E smoke: fresh maw serve, maw share --encrypt, WebSocket /ws/share/<slug>?h=<proof> received encrypted frame and closed 1000 (not 1011)

## Note
- timeout 120 bun run test is currently blocked by a pre-existing origin/alpha failure in test/comm-send-cmdsend-coverage.test.ts; reproduced the same failure on clean dcff631dd before opening this PR.