### PR TITLE
fix: share viewer uses source pane dimensions (#2746)

### DIFF
--- a/src/vendor/mpr-plugins/share/stream.ts
+++ b/src/vendor/mpr-plugins/share/stream.ts
@@ -11,7 +11,7 @@ type ChildProcessLike = {
   exited: Promise<number | void>;
 };
 
-type TmuxShape = Pick<Tmux, "capture" | "pipePane">;
+type TmuxShape = Pick<Tmux, "capture" | "pipePane" | "run">;
 
 type StreamDeps = {
   tmpdir: typeof tmpdir;
@@ -22,6 +22,8 @@ type StreamDeps = {
   spawnPipeReader: (path: string, onChunk: (chunk: Uint8Array) => void) => Promise<ChildProcessLike>;
   setTimeout: typeof setTimeout;
   clearTimeout: typeof clearTimeout;
+  setInterval: typeof setInterval;
+  clearInterval: typeof clearInterval;
 };
 
 type Subscriber = {
@@ -34,11 +36,14 @@ type AttachedBus = {
   subscriberId: symbol;
 };
 
+type PaneDimensions = { cols: number; rows: number };
+
 type ShareWireFrame = {
   type: "maw-share-frame";
   pane: string;
   data: string;
   snapshot?: boolean;
+  dimensions?: PaneDimensions;
 };
 
 type TargetBus = {
@@ -132,6 +137,7 @@ export interface ShareStreamHandle {
 }
 
 const DEFAULT_SNAPSHOT_LINES = 120;
+const DIMENSIONS_POLL_MS = 1_000;
 const CLOSE_TIMEOUT_MS = 50;
 const MAX_BACKLOG_CHUNKS = 64;
 const MAX_BACKLOG_BYTES = 1024 * 1024;
@@ -179,6 +185,8 @@ function defaultDeps(): StreamDeps {
     },
     setTimeout,
     clearTimeout,
+    setInterval,
+    clearInterval,
   };
 }
 
@@ -227,9 +235,33 @@ function encodeWireData(data: string | Uint8Array): string {
   return typeof data === "string" ? data : new TextDecoder().decode(data);
 }
 
-function taggedFrame(target: string, data: string | Uint8Array, snapshot = false): string {
+function dimensionsKey(dimensions: PaneDimensions): string {
+  return `${dimensions.cols}x${dimensions.rows}`;
+}
+
+function parsePaneDimensions(raw: string, target: string): PaneDimensions {
+  const line = raw.split("\n").find((candidate) => candidate.trim().length > 0)?.trim() ?? "";
+  const match = line.match(/^(\d+)\s+(\d+)$/);
+  if (!match) {
+    throw new Error(`share stream failed to read source pane dimensions for ${target}: ${line || "empty tmux response"}`);
+  }
+  const cols = Number(match[1]);
+  const rows = Number(match[2]);
+  if (!Number.isInteger(cols) || !Number.isInteger(rows) || cols <= 0 || rows <= 0) {
+    throw new Error(`share stream got invalid source pane dimensions for ${target}: ${line}`);
+  }
+  return { cols, rows };
+}
+
+async function getPaneDimensions(tmux: TmuxShape, target: string): Promise<PaneDimensions> {
+  const raw = await tmux.run("list-panes", "-t", target, "-F", "#{pane_width} #{pane_height}");
+  return parsePaneDimensions(raw, target);
+}
+
+function taggedFrame(target: string, data: string | Uint8Array, snapshot = false, dimensions?: PaneDimensions): string {
   const frame: ShareWireFrame = { type: "maw-share-frame", pane: target, data: encodeWireData(data) };
   if (snapshot) frame.snapshot = true;
+  if (dimensions) frame.dimensions = dimensions;
   return JSON.stringify(frame);
 }
 
@@ -326,9 +358,10 @@ export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<St
 
   let closed = false;
   let expiryTimer: ReturnType<typeof setTimeout> | null = null;
+  let dimensionsTimer: ReturnType<typeof setInterval> | null = null;
   const targets = shareTargets(share);
-  const multiplex = targets.length > 1;
   const attachedBuses: AttachedBus[] = [];
+  const lastDimensions = new Map<string, PaneDimensions>();
 
   const detach = async (): Promise<void> => {
     const pending = attachedBuses.splice(0);
@@ -345,6 +378,10 @@ export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<St
     if (expiryTimer) {
       resolved.clearTimeout(expiryTimer);
       expiryTimer = null;
+    }
+    if (dimensionsTimer) {
+      resolved.clearInterval(dimensionsTimer);
+      dimensionsTimer = null;
     }
 
     await detach();
@@ -368,11 +405,38 @@ export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<St
     // read-only mode intentionally ignores inbound traffic
   };
 
+  const sendTaggedFrame = (target: string, data: string | Uint8Array, snapshot = false, dimensions?: PaneDimensions): void => {
+    sendSafe(ws, nextEncryptedFrame(share, taggedFrame(target, data, snapshot, dimensions)));
+  };
+
+  const pollDimensions = async (): Promise<void> => {
+    await Promise.all(targets.map(async (target) => {
+      const dimensions = await getPaneDimensions(resolved.tmux, target);
+      const previous = lastDimensions.get(target);
+      if (previous && dimensionsKey(previous) === dimensionsKey(dimensions)) return;
+      lastDimensions.set(target, dimensions);
+      if (!closed) sendTaggedFrame(target, "", false, dimensions);
+    }));
+  };
+
   try {
     for (const target of targets) {
+      const dimensions = await getPaneDimensions(resolved.tmux, target);
+      lastDimensions.set(target, dimensions);
       const snapshot = await resolved.tmux.capture(target, DEFAULT_SNAPSHOT_LINES);
-      if (snapshot) sendSafe(ws, nextEncryptedFrame(share, multiplex ? taggedFrame(target, snapshot, true) : snapshot));
+      sendTaggedFrame(target, snapshot, true, dimensions);
     }
+
+    dimensionsTimer = resolved.setInterval(() => {
+      void pollDimensions().catch((error) => {
+        void close();
+        try {
+          ws.close(1011, error instanceof Error ? error.message : "share dimension poll failed");
+        } catch {
+          // socket may already be closed
+        }
+      });
+    }, DIMENSIONS_POLL_MS);
 
     for (const target of targets) {
       const targetBus = await getTargetBus(target, resolved);
@@ -385,7 +449,7 @@ export async function attach(share: Share, ws: ServerWebSocket, deps: Partial<St
       const subscriber = {
         send: (chunk: string | Uint8Array) => {
           if (closed) return;
-          sendSafe(ws, nextEncryptedFrame(share, multiplex ? taggedFrame(target, chunk) : chunk));
+          sendTaggedFrame(target, chunk);
         },
       };
       targetBus.subscribers.set(subscriberId, subscriber);

--- a/src/vendor/mpr-plugins/share/viewer.html
+++ b/src/vendor/mpr-plugins/share/viewer.html
@@ -80,6 +80,7 @@
         width: 100%;
         height: 100%;
         display: none;
+        overflow: auto;
         border: 1px solid #111827;
         box-sizing: border-box;
       }
@@ -89,9 +90,14 @@
         display: block;
       }
 
-      .pane-host, .fallback-pane, .xterm {
-        width: 100%;
-        height: 100%;
+      .pane-host, .fallback-pane {
+        min-width: 100%;
+        min-height: 100%;
+      }
+
+      .pane-host.source-sized {
+        width: max-content;
+        height: max-content;
       }
 
       .fallback-pane {
@@ -103,7 +109,6 @@
     </style>
     <link rel="stylesheet" href="https://unpkg.com/@xterm/xterm/css/xterm.css" />
     <script src="https://unpkg.com/@xterm/xterm/lib/xterm.js"></script>
-    <script src="https://unpkg.com/@xterm/addon-fit/lib/addon-fit.js"></script>
   </head>
   <body>
     <div id="fallback" style="display:none;">xterm.js failed to load; falling back to static display.</div>
@@ -166,16 +171,30 @@
           return new TextDecoder().decode(plain);
         };
 
+        const parseDimensions = (value) => {
+          if (!value || typeof value !== "object") return null;
+          const cols = Number(value.cols);
+          const rows = Number(value.rows);
+          if (!Number.isInteger(cols) || !Number.isInteger(rows) || cols <= 0 || rows <= 0) return null;
+          return { cols, rows };
+        };
+
         const parseWireFrame = (plain) => {
           try {
             const parsed = JSON.parse(plain);
-            if (parsed && typeof parsed === "object" && parsed.type === "maw-share-frame" && typeof parsed.pane === "string" && typeof parsed.data === "string") {
-              return { pane: parsed.pane, data: parsed.data, snapshot: parsed.snapshot === true, tagged: true };
+            if (parsed && typeof parsed === "object" && parsed.type === "maw-share-frame" && typeof parsed.pane === "string") {
+              return {
+                pane: parsed.pane,
+                data: typeof parsed.data === "string" ? parsed.data : "",
+                dimensions: parseDimensions(parsed.dimensions),
+                snapshot: parsed.snapshot === true,
+                tagged: true,
+              };
             }
           } catch {
             // legacy single-pane raw frame
           }
-          return { pane: "main", data: plain, snapshot: false, tagged: false };
+          return { pane: "main", data: plain, dimensions: null, snapshot: false, tagged: false };
         };
 
         let e2eKeyPromise = deriveE2EKey(e2eKey);
@@ -196,15 +215,24 @@
         const terms = document.getElementById("terms");
         const panes = new Map();
 
-        const terminalAvailable = () => Boolean(window.Terminal && window.FitAddon);
+        const terminalAvailable = () => Boolean(window.Terminal);
 
-        const fitPane = (pane) => {
-          if (!pane?.fit) return;
-          try { pane.fit.fit(); } catch { /* resize is advisory */ }
+        const syncPaneDimensions = (pane, dimensions) => {
+          if (!dimensions) return;
+          const same = pane.dimensions && pane.dimensions.cols === dimensions.cols && pane.dimensions.rows === dimensions.rows;
+          pane.dimensions = dimensions;
+          pane.root.dataset.cols = String(dimensions.cols);
+          pane.root.dataset.rows = String(dimensions.rows);
+          pane.host.classList.add("source-sized");
+          if (pane.term && !same) {
+            pane.term.resize(dimensions.cols, dimensions.rows);
+          }
         };
 
-        const fitAll = () => {
-          for (const pane of panes.values()) fitPane(pane);
+        const syncAllDimensions = () => {
+          for (const pane of panes.values()) {
+            if (pane.dimensions) syncPaneDimensions(pane, pane.dimensions);
+          }
         };
 
         const updateLayout = () => {
@@ -215,8 +243,8 @@
             pane.root.classList.toggle("active", id === activePane);
             pane.tab.classList.toggle("active", id === activePane);
           }
-          requestAnimationFrame(fitAll);
-          fitAll();
+          requestAnimationFrame(syncAllDimensions);
+          syncAllDimensions();
         };
 
         const selectPane = (id) => {
@@ -247,7 +275,6 @@
           tabs.appendChild(tab);
 
           let term = null;
-          let fit = null;
           if (terminalAvailable()) {
             term = new window.Terminal({
               theme: { background: "#0d0d0d", foreground: "#d1d5db" },
@@ -255,8 +282,6 @@
               disableStdin: true,
               cursorBlink: false,
             });
-            fit = new window.FitAddon.FitAddon();
-            term.loadAddon(fit);
             term.open(host);
           } else {
             fallback.textContent = "xterm.js unavailable; using fallback terminal.";
@@ -265,7 +290,7 @@
             pre.style.display = "block";
           }
 
-          const pane = { id, root, host, pre, tab, term, fit };
+          const pane = { id, root, host, pre, tab, term, dimensions: null };
           panes.set(id, pane);
           if (panes.size === 1) activePane = id;
           updateLayout();
@@ -299,8 +324,9 @@
               const plain = await decryptFrame(await e2eKeyPromise, event.data);
               const frame = parseWireFrame(plain);
               const pane = createPane(frame.pane);
+              if (frame.dimensions) syncPaneDimensions(pane, frame.dimensions);
               if (frame.snapshot) resetPane(pane);
-              writePane(pane, frame.data);
+              if (frame.data) writePane(pane, frame.data);
             } catch {
               fallback.textContent = "Unable to decrypt or route share frame.";
               fallback.style.display = "block";
@@ -308,10 +334,10 @@
           })();
         };
 
-        const resizeObserver = window.ResizeObserver ? new ResizeObserver(fitAll) : null;
+        const resizeObserver = window.ResizeObserver ? new ResizeObserver(syncAllDimensions) : null;
         resizeObserver?.observe(terms);
-        window.addEventListener("resize", fitAll);
-        window.visualViewport?.addEventListener("resize", fitAll);
+        window.addEventListener("resize", syncAllDimensions);
+        window.visualViewport?.addEventListener("resize", syncAllDimensions);
         tileToggle.addEventListener("click", () => {
           tileMode = !tileMode;
           updateLayout();
@@ -332,7 +358,7 @@
             reconnectAttempt = 0;
             fallback.style.display = "none";
             resetForFreshSnapshot();
-            fitAll();
+            syncAllDimensions();
             try {
               current.send("ping");
             } catch {

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -50,6 +50,14 @@ function tamperHexDigest(hex: string): string {
   return `${hex.slice(0, -1)}${replacement}`;
 }
 
+function decodeWire(data: string | Uint8Array): string {
+  return typeof data === "string" ? data : new TextDecoder().decode(data);
+}
+
+function parseWire(data: string | Uint8Array): any {
+  return JSON.parse(decodeWire(data));
+}
+
 async function makeServeHarness() {
   const httpRoutes: Array<{ method: string; path: string; handler: (req: Request) => Response | Promise<Response> }> = [];
   const wsRoutes: Array<{ path: string; data: (req: Request) => unknown; handlers: Record<string, unknown> }> = [];
@@ -108,10 +116,11 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(viewer).toContain("resetForFreshSnapshot();");
     expect(viewer).toContain("resetPane(pane);");
     expect(viewer).toContain("reconnectTimer = setTimeout(connect, delay);");
-    expect(viewer).toContain("new window.FitAddon.FitAddon()");
-    expect(viewer).toContain('window.addEventListener("resize", fitAll)');
-    expect(viewer).toContain('window.visualViewport?.addEventListener("resize", fitAll)');
-    expect(viewer).toContain("new ResizeObserver(fitAll)");
+    expect(viewer).toContain("const syncPaneDimensions = (pane, dimensions) =>");
+    expect(viewer).toContain("pane.term.resize(dimensions.cols, dimensions.rows)");
+    expect(viewer).toContain('window.addEventListener("resize", syncAllDimensions)');
+    expect(viewer).toContain('window.visualViewport?.addEventListener("resize", syncAllDimensions)');
+    expect(viewer).toContain("new ResizeObserver(syncAllDimensions)");
     expect(viewer).toContain("const parseWireFrame = (plain) =>");
     expect(viewer).toContain("const tileToggle = document.getElementById(\"tile-toggle\")");
   });
@@ -276,6 +285,7 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
       let liveChunk: ((chunk: Uint8Array) => void) | null = null;
       const handle = await shareStream.attach(share as any, { send: (data: string | Uint8Array) => sent.push(data) } as any, {
         tmux: {
+          run: async () => "80 24",
           capture: async () => "SNAPSHOT-PLAINTEXT\n",
           pipePane: async () => undefined,
         },
@@ -297,8 +307,14 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
         expect(shareCrypto.isEncryptedShareFrame(frame)).toBe(true);
       }
       const key = shareCrypto.deriveShareKey(secret);
-      expect(new TextDecoder().decode(shareCrypto.decryptShareFrame(key, sent[0] as Uint8Array))).toBe("SNAPSHOT-PLAINTEXT\n");
-      expect(new TextDecoder().decode(shareCrypto.decryptShareFrame(key, sent[1] as Uint8Array))).toBe("LIVE-PLAINTEXT\n");
+      expect(JSON.parse(new TextDecoder().decode(shareCrypto.decryptShareFrame(key, sent[0] as Uint8Array)))).toEqual({
+        type: "maw-share-frame",
+        pane: "neo:1:resolved",
+        data: "SNAPSHOT-PLAINTEXT\n",
+        snapshot: true,
+        dimensions: { cols: 80, rows: 24 },
+      });
+      expect(JSON.parse(new TextDecoder().decode(shareCrypto.decryptShareFrame(key, sent[1] as Uint8Array)))).toEqual({ type: "maw-share-frame", pane: "neo:1:resolved", data: "LIVE-PLAINTEXT\n" });
 
       if (childResolve) childResolve();
       await handle.close();
@@ -331,6 +347,7 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
       join: (...parts: string[]) => parts.join("/"),
       unlinkSync: (path: string) => { removedFifos.push(path); },
       tmux: {
+        run: async () => "80 24",
         capture: async () => "SNAPSHOT\n",
         pipePane: async (...args: unknown[]) => { pipeCalls.push(args); },
       },
@@ -347,8 +364,8 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     const first = await shareStream.attach(share as any, { send: (data: string | Uint8Array) => sentA.push(data) } as any, deps);
     const second = await shareStream.attach(share as any, { send: (data: string | Uint8Array) => sentB.push(data) } as any, deps);
 
-    expect(sentA).toEqual(["SNAPSHOT\n"]);
-    expect(sentB).toEqual(["SNAPSHOT\n"]);
+    expect(sentA.map(parseWire)).toEqual([{ type: "maw-share-frame", pane: "neo:1", data: "SNAPSHOT\n", snapshot: true, dimensions: { cols: 80, rows: 24 } }]);
+    expect(sentB.map(parseWire)).toEqual([{ type: "maw-share-frame", pane: "neo:1", data: "SNAPSHOT\n", snapshot: true, dimensions: { cols: 80, rows: 24 } }]);
     expect(chunkHandlers).toHaveLength(1);
     expect(pipeCalls).toHaveLength(1);
     expect(createdFifos).toHaveLength(1);
@@ -357,8 +374,8 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(pipeCalls[0]).toEqual(["neo:1", `cat > '${createdFifos[0]}'`, { onlyIfClosed: true }]);
 
     chunkHandlers[0]!(encoder.encode("LIVE-1\n"));
-    expect(sentA.at(-1)).toEqual(encoder.encode("LIVE-1\n"));
-    expect(sentB.at(-1)).toEqual(encoder.encode("LIVE-1\n"));
+    expect(parseWire(sentA.at(-1)!)).toEqual({ type: "maw-share-frame", pane: "neo:1", data: "LIVE-1\n" });
+    expect(parseWire(sentB.at(-1)!)).toEqual({ type: "maw-share-frame", pane: "neo:1", data: "LIVE-1\n" });
 
     await first.close();
     expect(pipeCalls).toHaveLength(1);
@@ -366,8 +383,15 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(removedFifos).toEqual([]);
 
     chunkHandlers[0]!(encoder.encode("LIVE-2\n"));
-    expect(sentA.map((entry) => entry instanceof Uint8Array ? new TextDecoder().decode(entry) : entry)).toEqual(["SNAPSHOT\n", "LIVE-1\n"]);
-    expect(sentB.map((entry) => entry instanceof Uint8Array ? new TextDecoder().decode(entry) : entry)).toEqual(["SNAPSHOT\n", "LIVE-1\n", "LIVE-2\n"]);
+    expect(sentA.map(parseWire)).toEqual([
+      { type: "maw-share-frame", pane: "neo:1", data: "SNAPSHOT\n", snapshot: true, dimensions: { cols: 80, rows: 24 } },
+      { type: "maw-share-frame", pane: "neo:1", data: "LIVE-1\n" },
+    ]);
+    expect(sentB.map(parseWire)).toEqual([
+      { type: "maw-share-frame", pane: "neo:1", data: "SNAPSHOT\n", snapshot: true, dimensions: { cols: 80, rows: 24 } },
+      { type: "maw-share-frame", pane: "neo:1", data: "LIVE-1\n" },
+      { type: "maw-share-frame", pane: "neo:1", data: "LIVE-2\n" },
+    ]);
 
     if (childResolve) childResolve();
     await second.close();
@@ -405,6 +429,7 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
       } as any,
       {
         tmux: {
+          run: async () => "80 24",
           capture: async () => "SNAPSHOT\n",
           pipePane: async (...args: unknown[]) => {
             pipeCalls.push(args);
@@ -426,7 +451,7 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
       } as any,
     );
 
-    expect(sent).toEqual(["SNAPSHOT\n"]);
+    expect(sent.map(parseWire)).toEqual([{ type: "maw-share-frame", pane: "neo:1", data: "SNAPSHOT\n", snapshot: true, dimensions: { cols: 80, rows: 24 } }]);
     const expiryTimer = timers.find((timer) => timer.ms <= 50);
     expect(expiryTimer).toBeDefined();
 

--- a/test/vendor-share-crypto.test.ts
+++ b/test/vendor-share-crypto.test.ts
@@ -98,6 +98,7 @@ describe("share crypto hardening", () => {
       { send: (data: string | Uint8Array) => sent.push(data) } as any,
       {
         tmux: {
+          run: async () => "80 24",
           capture: async () => "SNAPSHOT-SECRET\n",
           pipePane: async (...args: unknown[]) => {
             pipeCalls.push(args);
@@ -136,9 +137,15 @@ describe("share crypto hardening", () => {
     }
 
     const key = deriveShareKey(created.token);
-    expect(dec.decode(decryptShareFrame(key, encryptedFrames[0]!))).toBe("SNAPSHOT-SECRET\n");
-    expect(dec.decode(decryptShareFrame(key, encryptedFrames[1]!))).toBe("LIVE-SECRET-1\n");
-    expect(dec.decode(decryptShareFrame(key, encryptedFrames[2]!))).toBe("LIVE-SECRET-2\n");
+    expect(JSON.parse(dec.decode(decryptShareFrame(key, encryptedFrames[0]!)))).toEqual({
+      type: "maw-share-frame",
+      pane: "session:0",
+      data: "SNAPSHOT-SECRET\n",
+      snapshot: true,
+      dimensions: { cols: 80, rows: 24 },
+    });
+    expect(JSON.parse(dec.decode(decryptShareFrame(key, encryptedFrames[1]!)))).toEqual({ type: "maw-share-frame", pane: "session:0", data: "LIVE-SECRET-1\n" });
+    expect(JSON.parse(dec.decode(decryptShareFrame(key, encryptedFrames[2]!)))).toEqual({ type: "maw-share-frame", pane: "session:0", data: "LIVE-SECRET-2\n" });
     expect(share.encryptionFrameCounter).toBe(3n);
 
     await handle.close();

--- a/test/vendor-share-hardening.test.ts
+++ b/test/vendor-share-hardening.test.ts
@@ -51,10 +51,11 @@ describe("share hardening", () => {
     expect(viewer).toContain("reconnectTimer = setTimeout(connect, delay);");
     expect(viewer).toContain("resetForFreshSnapshot();");
     expect(viewer).toContain("resetPane(pane);");
-    expect(viewer).toContain("new window.FitAddon.FitAddon()");
-    expect(viewer).toContain('window.addEventListener("resize", fitAll)');
-    expect(viewer).toContain('window.visualViewport?.addEventListener("resize", fitAll)');
-    expect(viewer).toContain("new ResizeObserver(fitAll)");
+    expect(viewer).toContain("const syncPaneDimensions = (pane, dimensions) =>");
+    expect(viewer).toContain("pane.term.resize(dimensions.cols, dimensions.rows)");
+    expect(viewer).toContain('window.addEventListener("resize", syncAllDimensions)');
+    expect(viewer).toContain('window.visualViewport?.addEventListener("resize", syncAllDimensions)');
+    expect(viewer).toContain("new ResizeObserver(syncAllDimensions)");
     expect(viewer).toContain("const parseWireFrame = (plain) =>");
     expect(viewer).toContain("const tileToggle = document.getElementById(\"tile-toggle\")");
     expect(viewer).toContain('<link rel="stylesheet" href="https://unpkg.com/@xterm/xterm/css/xterm.css" />');
@@ -83,6 +84,7 @@ describe("share hardening", () => {
       } as any,
       {
         tmux: {
+          run: async () => "80 24",
           capture: async () => "SNAPSHOT\n",
           pipePane: async (...args: unknown[]) => {
             pipeCalls.push(args);
@@ -104,7 +106,13 @@ describe("share hardening", () => {
       } as any,
     );
 
-    expect(sent).toEqual(["SNAPSHOT\n"]);
+    expect(sent.map((data) => JSON.parse(String(data)))).toEqual([{
+      type: "maw-share-frame",
+      pane: "session:0",
+      data: "SNAPSHOT\n",
+      snapshot: true,
+      dimensions: { cols: 80, rows: 24 },
+    }]);
     const expiry = timers.find((timer) => timer.ms <= 50);
     expect(expiry).toBeDefined();
 

--- a/test/vendor-share-readonly.test.ts
+++ b/test/vendor-share-readonly.test.ts
@@ -22,6 +22,14 @@ function bytes(text: string): Uint8Array {
   return new TextEncoder().encode(text);
 }
 
+function text(data: WsMessage): string {
+  return typeof data === "string" ? data : new TextDecoder().decode(data);
+}
+
+function frame(data: WsMessage): any {
+  return JSON.parse(text(data));
+}
+
 describe("share readonly stream", () => {
   let killCalls: Array<Array<unknown>> = [];
   let pipeCalls: Array<Array<unknown>> = [];
@@ -60,6 +68,7 @@ describe("share readonly stream", () => {
       ws as unknown as any,
       {
         tmux: {
+          run: async () => "80 24",
           capture: async (target: string) => {
             captures.push(target);
             return "SNAPSHOT\n";
@@ -86,7 +95,10 @@ describe("share readonly stream", () => {
       } as any,
     );
 
-    expect(sent).toEqual(["SNAPSHOT\n", bytes("LIVE\n")] );
+    expect(sent.map(frame)).toEqual([
+      { type: "maw-share-frame", pane: "session:0", data: "SNAPSHOT\n", snapshot: true, dimensions: { cols: 80, rows: 24 } },
+      { type: "maw-share-frame", pane: "session:0", data: "LIVE\n" },
+    ]);
     expect(captures).toEqual(["session:0"]);
 
     handle.onMessage("ping");
@@ -120,6 +132,7 @@ describe("share readonly stream", () => {
 
     const deps = {
       tmux: {
+        run: async () => "80 24",
         capture: async () => `SNAPSHOT-${++captureCount}\n`,
         pipePane: async (...args: unknown[]) => {
           localPipeCalls.push(args);
@@ -137,14 +150,20 @@ describe("share readonly stream", () => {
 
     const first = await attach(share, { send: (data: WsMessage) => sentA.push(data) } as any, deps);
     liveHandlers[0]!(bytes("LIVE-OLD\n"));
-    expect(sentA).toEqual(["SNAPSHOT-1\n", bytes("LIVE-OLD\n")]);
+    expect(sentA.map(frame)).toEqual([
+      { type: "maw-share-frame", pane: "session:0", data: "SNAPSHOT-1\n", snapshot: true, dimensions: { cols: 80, rows: 24 } },
+      { type: "maw-share-frame", pane: "session:0", data: "LIVE-OLD\n" },
+    ]);
 
     childResolvers[0]?.();
     await first.close();
 
     const second = await attach(share, { send: (data: WsMessage) => sentB.push(data) } as any, deps);
     liveHandlers[1]!(bytes("LIVE-NEW\n"));
-    expect(sentB).toEqual(["SNAPSHOT-2\n", bytes("LIVE-NEW\n")]);
+    expect(sentB.map(frame)).toEqual([
+      { type: "maw-share-frame", pane: "session:0", data: "SNAPSHOT-2\n", snapshot: true, dimensions: { cols: 80, rows: 24 } },
+      { type: "maw-share-frame", pane: "session:0", data: "LIVE-NEW\n" },
+    ]);
 
     expect(captureCount).toBe(2);
     expect(liveHandlers).toHaveLength(2);
@@ -172,6 +191,7 @@ describe("share readonly stream", () => {
 
     const handle = await attach(share, { send: (data: WsMessage) => sent.push(data) } as any, {
       tmux: {
+        run: async (_cmd: string, _flag: string, target: string) => target.includes("0.0") ? "106 51" : "90 40",
         capture: async (target: string) => `SNAPSHOT ${target}\n`,
         pipePane: async (...args: unknown[]) => { localPipeCalls.push(args); },
       },
@@ -188,15 +208,15 @@ describe("share readonly stream", () => {
       join: (...parts: string[]) => parts.join("/"),
     } as any);
 
-    expect(sent.slice(0, 2).map((frame) => JSON.parse(String(frame)))).toEqual([
-      { type: "maw-share-frame", pane: "session:0.0", data: "SNAPSHOT session:0.0\n", snapshot: true },
-      { type: "maw-share-frame", pane: "session:0.1", data: "SNAPSHOT session:0.1\n", snapshot: true },
+    expect(sent.slice(0, 2).map(frame)).toEqual([
+      { type: "maw-share-frame", pane: "session:0.0", data: "SNAPSHOT session:0.0\n", snapshot: true, dimensions: { cols: 106, rows: 51 } },
+      { type: "maw-share-frame", pane: "session:0.1", data: "SNAPSHOT session:0.1\n", snapshot: true, dimensions: { cols: 90, rows: 40 } },
     ]);
     expect(localPipeCalls.filter((call) => call.length === 3).map((call) => call[0]).sort()).toEqual(["session:0.0", "session:0.1"]);
 
     liveHandlers.get("session:0.0")!(bytes("LIVE A\n"));
     liveHandlers.get("session:0.1")!(bytes("LIVE B\n"));
-    expect(sent.slice(2).map((frame) => JSON.parse(String(frame)))).toEqual([
+    expect(sent.slice(2).map(frame)).toEqual([
       { type: "maw-share-frame", pane: "session:0.0", data: "LIVE A\n" },
       { type: "maw-share-frame", pane: "session:0.1", data: "LIVE B\n" },
     ]);
@@ -208,4 +228,48 @@ describe("share readonly stream", () => {
     expect(localPipeCalls.filter((call) => call.length === 1).map((call) => call[0]).sort()).toEqual(["session:0.0", "session:0.1"]);
     expect(localKillCalls.map(([target, signal]) => `${target}:${signal}`).sort()).toEqual(["session:0.0:SIGTERM", "session:0.1:SIGTERM"]);
   });
+  test("source pane resize pushes dimension-only frames without resizing tmux", async () => {
+    const share: Share = {
+      target: "session:0",
+      panes: [],
+      readOnly: true,
+      tokenHash: "hash",
+      expiresAt: Date.now() + 1_000_000,
+      auth: "token",
+    };
+    const sent: Array<WsMessage> = [];
+    const timers: Array<() => void> = [];
+    const pipeCalls: Array<Array<unknown>> = [];
+    const resizeCalls: unknown[] = [];
+    let dims = "106 51";
+    let childResolve: (() => void) | null = null;
+
+    const handle = await attach(share, { send: (data: WsMessage) => sent.push(data) } as any, {
+      tmux: {
+        run: async () => dims,
+        capture: async () => "SNAPSHOT\n",
+        pipePane: async (...args: unknown[]) => { pipeCalls.push(args); },
+        resizePane: async (...args: unknown[]) => { resizeCalls.push(args); },
+      },
+      makeFifo: async () => undefined,
+      spawnPipeReader: async () => ({
+        kill: () => undefined,
+        exited: new Promise((resolve) => { childResolve = () => resolve(0); }),
+      }),
+      setInterval: ((fn: () => void) => { timers.push(fn); return fn as any; }) as any,
+      clearInterval: (() => undefined) as any,
+    } as any);
+
+    expect(frame(sent[0]!)).toEqual({ type: "maw-share-frame", pane: "session:0", data: "SNAPSHOT\n", snapshot: true, dimensions: { cols: 106, rows: 51 } });
+    dims = "106 44";
+    timers[0]!();
+    for (let i = 0; i < 10; i += 1) await Promise.resolve();
+
+    expect(frame(sent.at(-1)!)).toEqual({ type: "maw-share-frame", pane: "session:0", data: "", dimensions: { cols: 106, rows: 44 } });
+    expect(resizeCalls).toEqual([]);
+
+    childResolve?.();
+    await handle.close();
+  });
+
 });


### PR DESCRIPTION
Closes #2746

## Summary
- send per-pane tmux source dimensions with share snapshot frames and dimension-only resize metadata
- resize xterm.js to the source pane grid instead of FitAddon browser-fit sizing
- keep share read-only: browser resize scrolls/syncs viewer only, never resizes source tmux panes

## Verification
- timeout 120 bun test test/vendor-share-crypto.test.ts test/vendor-share-hardening.test.ts test/vendor-share-readonly.test.ts test/vendor-share-registry.test.ts test/vendor-share-token.test.ts
- timeout 120 bash scripts/test-isolated.sh test/isolated/plugin-share-standalone.test.ts
- timeout 120 bun scripts/check-plugin-coverage-gate.ts origin/alpha
- timeout 120 bun run build
- timeout 120 bun run test
- encrypted real WS smoke: first decrypted frame snapshot had dimensions 106x51 and sentinel content
- transient Chromium Playwright smoke: viewer rendered sentinel in .xterm-rows with pane data-cols/data-rows=106x51
