### PR TITLE
feat: secure opt-in serve-control backend (#2757)

### DIFF
--- a/src/lib/elysia-auth.ts
+++ b/src/lib/elysia-auth.ts
@@ -32,6 +32,10 @@ const PROTECTED = new Set([
   "/worktrees/cleanup",
   "/_engine/register",
   "/_engine/unregister",
+  "/control/send",
+  "/control/key",
+  "/control/kill",
+  "/control/resize",
 ]);
 
 /** POST-only protected (GET is public for UI, POST needs auth) */
@@ -45,6 +49,7 @@ const PROTECTED_POST = new Set([
 
 export function isProtected(path: string, method: string): boolean {
   if (PROTECTED.has(path)) return true;
+  if (path.startsWith("/control/")) return true;
   if (PROTECTED_POST.has(path) && method === "POST") return true;
   // Protect plugin invocation — POST /plugins/:name is a control operation
   if (method === "POST" && path.startsWith("/plugins/")) return true;

--- a/src/vendor/mpr-plugins/serve-control/index.ts
+++ b/src/vendor/mpr-plugins/serve-control/index.ts
@@ -1,0 +1,160 @@
+import { createHash, createHmac, timingSafeEqual } from "crypto";
+import { loadConfig } from "maw-js/config";
+import type { ServeHookContext } from "../../../core/serve-route-registry";
+import { Tmux } from "../../../core/transport/tmux-class";
+import { verifyShareControlToken } from "../share/impl";
+
+const MAX_SEND_BYTES = 20_000;
+const ALLOWED_KEYS = new Set(["Up", "Down", "Left", "Right", "Escape", "Enter", "C-c"]);
+const CONTROL_WARNING = "[serve-control] RCE-equivalent pane control routes registered; verbs require share --control write token and scoped target allowlist";
+
+type ControlBody = Record<string, unknown>;
+type RouteParams = { target?: string; verb?: string };
+type ControlRequest = {
+  slug: string;
+  target: string;
+  token: string;
+  body: ControlBody;
+  rawBody: string;
+};
+
+function json(status: number, payload: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" },
+  });
+}
+
+function parseRoute(pathname: string): RouteParams | null {
+  const parts = pathname.split("/").filter(Boolean);
+  if (parts.length !== 4 || parts[0] !== "api" || parts[1] !== "control") return null;
+  return { target: decodeURIComponent(parts[2] ?? ""), verb: parts[3] };
+}
+
+function byteLength(text: string): number {
+  return new TextEncoder().encode(text).byteLength;
+}
+
+function sanitizeLiteral(input: unknown): string {
+  const text = typeof input === "string" ? input : String(input ?? "");
+  const stripped = text.replace(/\0/g, "");
+  const bytes = new TextEncoder().encode(stripped);
+  if (bytes.byteLength <= MAX_SEND_BYTES) return stripped;
+  return new TextDecoder().decode(bytes.slice(0, MAX_SEND_BYTES));
+}
+
+function sha256Hex(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function safeEqualHex(a: string, b: string): boolean {
+  if (!/^[a-f0-9]+$/i.test(a) || !/^[a-f0-9]+$/i.test(b)) return false;
+  const left = Buffer.from(a, "hex");
+  const right = Buffer.from(b, "hex");
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
+export function signControlAction(token: string, method: string, path: string, rawBody: string): string {
+  const bodyHash = sha256Hex(rawBody);
+  return createHmac("sha256", token).update(`${method.toUpperCase()}\n${path}\n${bodyHash}`).digest("hex");
+}
+
+async function readJsonBody(req: Request): Promise<{ body: ControlBody; rawBody: string } | Response> {
+  const rawBody = await req.text();
+  if (!rawBody.trim()) return { body: {}, rawBody };
+  try {
+    const parsed = JSON.parse(rawBody);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return json(400, { error: "control_body_must_be_object" });
+    return { body: parsed as ControlBody, rawBody };
+  } catch {
+    return json(400, { error: "control_body_invalid_json" });
+  }
+}
+
+function extractToken(req: Request): string {
+  const auth = req.headers.get("authorization") || "";
+  if (auth.toLowerCase().startsWith("bearer ")) return auth.slice(7).trim();
+  return req.headers.get("x-maw-control-token") || "";
+}
+
+function remoteControlAllowed(req: Request): Response | null {
+  if (!req.headers.get("x-maw-signature")) return null;
+  const cfg = loadConfig() as ReturnType<typeof loadConfig> & { control?: { allowRemote?: boolean } };
+  if (cfg.control?.allowRemote === true) return null;
+  return json(403, { error: "control_remote_disabled" });
+}
+
+async function authorize(req: Request): Promise<ControlRequest | Response> {
+  if (req.method !== "POST") return json(405, { error: "method_not_allowed" });
+  const remoteBlocked = remoteControlAllowed(req);
+  if (remoteBlocked) return remoteBlocked;
+  const params = parseRoute(new URL(req.url).pathname);
+  const target = params?.target ?? "";
+  if (!target) return json(400, { error: "target_required" });
+  const bodyRead = await readJsonBody(req);
+  if (bodyRead instanceof Response) return bodyRead;
+  const { body, rawBody } = bodyRead;
+  const slug = typeof body.slug === "string" ? body.slug : "";
+  if (!slug) return json(400, { error: "share_slug_required" });
+  const token = extractToken(req);
+  const verified = verifyShareControlToken(slug, target, token);
+  if (!verified.ok) return json(verified.status, { error: verified.reason });
+
+  const signature = req.headers.get("x-maw-control-signature") || "";
+  if (!signature) return json(401, { error: "control_signature_required" });
+  const expected = signControlAction(token, req.method, new URL(req.url).pathname, rawBody);
+  if (!safeEqualHex(signature, expected)) return json(401, { error: "invalid_control_signature" });
+  return { slug, target, token, body, rawBody };
+}
+
+function tmuxFromBody(body: ControlBody): Tmux {
+  const host = typeof body.host === "string" && body.host.trim() ? body.host : undefined;
+  return new Tmux(host);
+}
+
+async function routeControl(req: Request): Promise<Response> {
+  const params = parseRoute(new URL(req.url).pathname);
+  const verb = params?.verb;
+  if (!verb) return json(404, { error: "not_found" });
+  const ctx = await authorize(req);
+  if (ctx instanceof Response) return ctx;
+  const tmux = tmuxFromBody(ctx.body);
+  try {
+    if (verb === "send") {
+      const text = sanitizeLiteral(ctx.body.text);
+      await tmux.sendKeysLiteral(ctx.target, text);
+      return json(200, { ok: true, target: ctx.target, bytes: byteLength(text) });
+    }
+    if (verb === "key") {
+      const key = typeof ctx.body.key === "string" ? ctx.body.key : "";
+      if (!ALLOWED_KEYS.has(key)) return json(400, { error: "key_not_allowed" });
+      await tmux.sendKeys(ctx.target, key);
+      return json(200, { ok: true, target: ctx.target, key });
+    }
+    if (verb === "kill") {
+      await tmux.killPane(ctx.target);
+      return json(200, { ok: true, target: ctx.target });
+    }
+    if (verb === "resize") {
+      const cols = Math.max(1, Math.min(1000, Math.floor(Number(ctx.body.cols))));
+      const rows = Math.max(1, Math.min(1000, Math.floor(Number(ctx.body.rows))));
+      if (!Number.isFinite(cols) || !Number.isFinite(rows)) return json(400, { error: "invalid_dimensions" });
+      await tmux.resizePane(ctx.target, cols, rows);
+      return json(200, { ok: true, target: ctx.target, cols, rows });
+    }
+    return json(404, { error: "unknown_control_verb" });
+  } catch (error) {
+    return json(500, { error: "control_tmux_failed", detail: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+export async function serve(ctx: ServeHookContext): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!ctx.http) return { ok: false, error: "serve-control requires ctx.http" };
+  (ctx as { log?: { warn?: (...args: unknown[]) => void } }).log?.warn?.(CONTROL_WARNING);
+  ctx.http.route("POST", "/api/control/:target/send", routeControl);
+  ctx.http.route("POST", "/api/control/:target/key", routeControl);
+  ctx.http.route("POST", "/api/control/:target/kill", routeControl);
+  ctx.http.route("POST", "/api/control/:target/resize", routeControl);
+  return { ok: true };
+}

--- a/src/vendor/mpr-plugins/serve-control/plugin.json
+++ b/src/vendor/mpr-plugins/serve-control/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "serve-control",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Opt-in, write-token-gated pane control routes for maw share.",
+  "tier": "extra",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "policy": "fail-fast"
+    }
+  },
+  "weight": 11,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/src/vendor/mpr-plugins/share/impl.ts
+++ b/src/vendor/mpr-plugins/share/impl.ts
@@ -3,6 +3,11 @@ import { deriveShareKey, hashShareSecret, mintShareSecret, type ShareEncryptionK
 
 type ShareAuthKind = "token" | "federation" | "none" | "encrypted";
 
+export interface ShareControl {
+  tokenHash: string;
+  allowedTargets: string[];
+}
+
 export interface Share {
   target: string;
   panes: string[];
@@ -20,6 +25,7 @@ export interface Share {
   encryptionKey?: ShareEncryptionKey;
   encryptionKeyHash?: string;
   encryptionFrameCounter?: bigint;
+  control?: ShareControl;
 }
 
 export interface CreateShareOptions {
@@ -29,6 +35,7 @@ export interface CreateShareOptions {
   ttl?: number;
   auth?: ShareAuthKind;
   encrypted?: boolean;
+  control?: boolean;
 }
 
 export interface CreateShareResult {
@@ -36,6 +43,7 @@ export interface CreateShareResult {
   token: string;
   url: string;
   encrypted?: boolean;
+  controlToken?: string;
 }
 
 export interface ShareAuth {
@@ -70,6 +78,15 @@ function presentedMatchesTokenHash(share: Share, presented: string): boolean {
     return hashesMatch(share.tokenHash, presented.toLowerCase());
   }
   return hashesMatch(share.tokenHash, hashToken(presented));
+}
+
+
+function uniqueTargets(targets: string[]): string[] {
+  return [...new Set(targets.map((target) => target.trim()).filter(Boolean))];
+}
+
+function controlTargetsFor(target: string, panes: string[]): string[] {
+  return uniqueTargets(panes.length > 0 ? panes : [target]);
 }
 
 function makeSlug(): string {
@@ -209,6 +226,7 @@ export async function createShare(opts: CreateShareOptions): Promise<CreateShare
   const auth: ShareAuthKind = opts.auth ?? (opts.encrypted ? "encrypted" : "token");
   const encrypted = opts.encrypted === true || auth === "encrypted";
   const expiresAt = Date.now() + ensureTTL(opts.ttl);
+  if (opts.control === true && readOnly) throw new Error("share control requires readOnly=false");
 
   const authHandler = await resolveAuth(auth);
   const slug = makeSlug();
@@ -228,6 +246,13 @@ export async function createShare(opts: CreateShareOptions): Promise<CreateShare
     share.encryptionKey = deriveShareKey(token);
     share.encryptionKeyHash = hashShareSecret(token);
   }
+  const controlToken = opts.control === true ? randomBytes(32).toString("base64url") : undefined;
+  if (controlToken) {
+    share.control = {
+      tokenHash: hashToken(controlToken),
+      allowedTargets: controlTargetsFor(target, panes),
+    };
+  }
 
   shareRegistry.set(slug, share);
   ensureSweepTimer();
@@ -237,6 +262,7 @@ export async function createShare(opts: CreateShareOptions): Promise<CreateShare
     token,
     url: `/share/${slug}#${encrypted ? "k" : "t"}=${token}`,
     encrypted,
+    ...(controlToken ? { controlToken } : {}),
   };
 }
 
@@ -272,4 +298,16 @@ export function sweepExpiredShares(): number {
 export function clearShareRegistry(): void {
   shareRegistry.clear();
   stopShareSweepTimer();
+}
+
+
+export function verifyShareControlToken(slug: string, target: string, presented: string): { ok: true; share: Share } | { ok: false; reason: string; status: number } {
+  const share = getShare(slug);
+  if (!share) return { ok: false, reason: "invalid_share", status: 404 };
+  if (share.readOnly) return { ok: false, reason: "share_read_only", status: 403 };
+  if (!share.control) return { ok: false, reason: "control_not_enabled", status: 403 };
+  if (!share.control.allowedTargets.includes(target)) return { ok: false, reason: "target_not_allowed", status: 403 };
+  if (!presented) return { ok: false, reason: "control_token_required", status: 401 };
+  if (!hashesMatch(share.control.tokenHash, hashToken(presented))) return { ok: false, reason: "invalid_control_token", status: 401 };
+  return { ok: true, share };
 }

--- a/src/vendor/mpr-plugins/share/index.ts
+++ b/src/vendor/mpr-plugins/share/index.ts
@@ -14,7 +14,7 @@ export const command = {
   description: "Share a live read-only tmux session/pane in a browser via a temporary link.",
 };
 
-const SHARE_USAGE = "usage: maw share <session-or-pane> [additional-pane ...] [--read-only] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]";
+const SHARE_USAGE = "usage: maw share <session-or-pane> [additional-pane ...] [--read-only] [--control] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]";
 const DEFAULT_TTL_SECONDS = 3600;
 const DEFAULT_READ_ONLY = true;
 
@@ -37,6 +37,7 @@ type ShareMetadata = {
   readOnly: boolean;
   expiresAt: number;
   auth: string;
+  control?: boolean;
 };
 
 type CreateShareRequest = {
@@ -46,6 +47,7 @@ type CreateShareRequest = {
   ttl?: unknown;
   auth?: unknown;
   encrypted?: unknown;
+  control?: unknown;
 };
 
 const viewerHtml = (() => {
@@ -154,12 +156,14 @@ async function routeCreateShare(req: Request): Promise<Response> {
       ttl: typeof body.ttl === "number" && Number.isFinite(body.ttl) ? body.ttl : DEFAULT_TTL_SECONDS,
       auth: resolveAuthFlag(body.auth),
       encrypted: body.encrypted === true || body.auth === "encrypted",
+      control: body.control === true,
     });
     const payload = {
       slug: created.slug,
       token: created.token,
       encrypted: created.encrypted === true,
       url: shareUrlForRequest(req, created.slug, created.token, created.encrypted === true),
+      ...(created.controlToken ? { controlToken: created.controlToken } : {}),
     };
     return new Response(JSON.stringify(payload), {
       headers: { "content-type": "application/json; charset=utf-8" },
@@ -214,6 +218,7 @@ async function routeShareMetadata(req: Request): Promise<Response> {
     readOnly: share.readOnly,
     expiresAt: share.expiresAt,
     auth: share.auth,
+    ...(share.control ? { control: true } : {}),
   };
 
   return new Response(JSON.stringify(payload), {
@@ -316,12 +321,13 @@ export function displayOrigin(flags: Record<string, unknown>): string {
   return displayOriginForHost(host, port);
 }
 
-function displayShareUrl(origin: string, share: { slug: string; token: string; encrypted?: boolean }): string {
+function displayShareUrl(origin: string, share: { slug: string; token: string; encrypted?: boolean; controlToken?: string }): string {
   const param = share.encrypted === true ? "k" : "t";
-  return `${origin}/share/${share.slug}#${param}=${share.token}`;
+  const control = share.controlToken ? `&c=${encodeURIComponent(share.controlToken)}` : "";
+  return `${origin}/share/${share.slug}#${param}=${share.token}${control}`;
 }
 
-export async function createShareViaDaemon(origin: string, body: CreateShareRequest): Promise<{ slug: string; token: string; encrypted?: boolean }> {
+export async function createShareViaDaemon(origin: string, body: CreateShareRequest): Promise<{ slug: string; token: string; encrypted?: boolean; controlToken?: string }> {
   const endpoint = `${origin}/api/share`;
   let res: Response;
   try {
@@ -364,6 +370,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       "--port": Number,
       "--auth": String,
       "--encrypt": Boolean,
+      "--control": Boolean,
     }, 0);
 
     const targets = flags._;
@@ -383,7 +390,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     const resolvedTargets = hits.map((entry) => entry.hit!.resolved);
     const hit = hits[0]!.hit!;
 
-    const readOnly = flags["--read-only"] === undefined ? DEFAULT_READ_ONLY : Boolean(flags["--read-only"]);
+    const control = flags["--control"] === true;
+    const readOnly = control ? false : (flags["--read-only"] === undefined ? DEFAULT_READ_ONLY : Boolean(flags["--read-only"]));
     const ttl = typeof flags["--ttl"] === "number" && Number.isFinite(flags["--ttl"]) ? flags["--ttl"] : DEFAULT_TTL_SECONDS;
     const encrypted = flags["--encrypt"] === true || flags["--auth"] === "encrypted";
     const auth = encrypted && flags["--auth"] === undefined ? "encrypted" : resolveAuthFlag(flags["--auth"]);
@@ -394,12 +402,14 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       readOnly,
       ttl,
       auth,
+      ...(control ? { control: true } : {}),
     };
     if (encrypted) request.encrypted = true;
 
     const share = await createShareViaDaemon(daemonLoopbackOrigin(flags), request);
     const url = displayShareUrl(displayOrigin(flags), share);
 
+    if (control) console.warn("⚠ maw share --control enables RCE-equivalent pane writes for this share; keep the URL fragment private.");
     console.log(`🔗 ${url}`);
     return { ok: true, output: url };
   } catch (error: any) {

--- a/src/vendor/mpr-plugins/share/plugin.json
+++ b/src/vendor/mpr-plugins/share/plugin.json
@@ -6,13 +6,14 @@
   "description": "Share a tmux session/pane as a read-only web stream.",
   "cli": {
     "command": "share",
-    "help": "maw share <session-or-pane> [--read-only] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]",
+    "help": "maw share <session-or-pane> [--read-only] [--control] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]",
     "flags": {
       "--read-only": "boolean",
       "--ttl": "number",
       "--port": "number",
       "--auth": "string",
-      "--encrypt": "boolean"
+      "--encrypt": "boolean",
+      "--control": "boolean"
     }
   },
   "weight": 10,

--- a/test/isolated/plugin-serve-control-standalone.test.ts
+++ b/test/isolated/plugin-serve-control-standalone.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+const root = join(import.meta.dir, "../..");
+const tmuxCalls: Array<[string, ...unknown[]]> = [];
+
+mock.module("maw-js/config", () => ({
+  D: { hmacWindowSeconds: 300 },
+  loadConfig: () => ({ host: "local" }),
+}));
+mock.module(import.meta.resolve("../../src/core/transport/tmux-class.ts"), () => ({
+  Tmux: class Tmux {
+    async sendKeysLiteral(target: string, text: string) { tmuxCalls.push(["send", target, text]); }
+    async sendKeys(target: string, key: string) { tmuxCalls.push(["key", target, key]); }
+    async killPane(target: string) { tmuxCalls.push(["kill", target]); }
+    async resizePane(target: string, cols: number, rows: number) { tmuxCalls.push(["resize", target, cols, rows]); }
+  },
+}));
+
+const shareImpl = await import("../../src/vendor/mpr-plugins/share/impl.ts");
+const controlPlugin = await import("../../src/vendor/mpr-plugins/serve-control/index.ts?serve-control-standalone");
+const auth = await import("../../src/lib/elysia-auth.ts?serve-control-standalone");
+
+beforeEach(() => {
+  tmuxCalls.length = 0;
+  shareImpl.clearShareRegistry();
+});
+
+async function routeHarness() {
+  const routes: Array<{ method: string; path: string; handler: (req: Request) => Response | Promise<Response> }> = [];
+  const result = await controlPlugin.serve({
+    http: {
+      route(method: string, path: string, handler: (req: Request) => Response | Promise<Response>) {
+        routes.push({ method, path, handler });
+      },
+    },
+  } as any);
+  expect(result.ok).toBe(true);
+  const route = routes.find((entry) => entry.path === "/api/control/:target/send")!;
+  expect(route).toBeTruthy();
+  return { routes, handler: route.handler };
+}
+
+function req(path: string, body: Record<string, unknown>, token?: string, signature = true): Request {
+  const raw = JSON.stringify(body);
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token) {
+    headers["x-maw-control-token"] = token;
+    if (signature) headers["x-maw-control-signature"] = controlPlugin.signControlAction(token, "POST", path, raw);
+  }
+  return new Request(`http://127.0.0.1:3457${path}`, { method: "POST", headers, body: raw });
+}
+
+async function json(res: Response): Promise<any> {
+  return await res.json();
+}
+
+describe("serve-control standalone security gate (#2757)", () => {
+  test("standalone boundary and manifest keep serve-control opt-in and out of default-active", () => {
+    expectStandalonePluginBoundary({
+      plugin: "serve-control",
+      requireSdk: false,
+      allowMawJs: ["maw-js/config"],
+      allowRelative: [
+        "../../../core/serve-route-registry",
+        "../../../core/transport/tmux-class",
+        "../share/impl",
+      ],
+    });
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/serve-control/plugin.json"), "utf8"));
+    expect(manifest.name).toBe("serve-control");
+    expect(manifest.hooks.serve.handler).toBe("serve");
+    expect(manifest.tier).toBe("extra");
+    const defaults = readFileSync(join(root, "src/plugin/default-active.ts"), "utf8");
+    expect(defaults).not.toContain('"serve-control"');
+  });
+
+  test("elysia auth marks every /api/control/* route protected before plugin dispatch", () => {
+    expect(auth.isProtected("/control/%25p/send", "POST")).toBe(true);
+    expect(auth.isProtected("/control/%25p/key", "POST")).toBe(true);
+    expect(auth.isProtected("/control/%25p/kill", "POST")).toBe(true);
+    expect(auth.isProtected("/control/%25p/resize", "POST")).toBe(true);
+  });
+
+  test("send requires separate write token, signature, scoped target, and readOnly=false", async () => {
+    const { handler } = await routeHarness();
+    const share = await shareImpl.createShare({ target: "%1", readOnly: false, control: true });
+    expect(share.controlToken).toBeTruthy();
+    const path = "/api/control/%251/send";
+
+    let res = await handler(req(path, { slug: share.slug, text: "hi" }));
+    expect(res.status).toBe(401);
+    expect((await json(res)).error).toBe("control_token_required");
+
+    res = await handler(req(path, { slug: share.slug, text: "hi" }, share.controlToken, false));
+    expect(res.status).toBe(401);
+    expect((await json(res)).error).toBe("control_signature_required");
+
+    res = await handler(req(path, { slug: share.slug, text: "hi" }, `${share.controlToken}x`));
+    expect(res.status).toBe(401);
+    expect((await json(res)).error).toBe("invalid_control_token");
+
+    res = await handler(req("/api/control/%252/send", { slug: share.slug, text: "hi" }, share.controlToken));
+    expect(res.status).toBe(403);
+    expect((await json(res)).error).toBe("target_not_allowed");
+
+    const readonly = await shareImpl.createShare({ target: "%3", readOnly: true });
+    res = await handler(req("/api/control/%253/send", { slug: readonly.slug, text: "hi" }, share.controlToken));
+    expect(res.status).toBe(403);
+    expect((await json(res)).error).toBe("share_read_only");
+
+    res = await handler(req(path, { slug: share.slug, text: `a\0b${"x".repeat(25_000)}` }, share.controlToken));
+    expect(res.status).toBe(200);
+    expect(tmuxCalls[0][0]).toBe("send");
+    expect(tmuxCalls[0][1]).toBe("%1");
+    const sent = tmuxCalls[0][2] as string;
+    expect(sent.includes("\0")).toBe(false);
+    expect(new TextEncoder().encode(sent).byteLength).toBeLessThanOrEqual(20_000);
+  });
+
+  test("key verb rejects off-allowlist keys before tmux", async () => {
+    const { routes } = await routeHarness();
+    const keyRoute = routes.find((entry) => entry.path === "/api/control/:target/key")!;
+    const share = await shareImpl.createShare({ target: "%1", readOnly: false, control: true });
+    const path = "/api/control/%251/key";
+    const res = await keyRoute.handler(req(path, { slug: share.slug, key: "Space" }, share.controlToken));
+    expect(res.status).toBe(400);
+    expect((await json(res)).error).toBe("key_not_allowed");
+    expect(tmuxCalls).toEqual([]);
+  });
+});

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -98,10 +98,13 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(manifest.name).toBe("share");
     expect(manifest.cli.command).toBe("share");
     expect(manifest.hooks.serve.handler).toBe("serve");
+    expect(manifest.cli.flags["--control"]).toBe("boolean");
 
     const index = readFileSync(join(root, "src/vendor/mpr-plugins/share/index.ts"), "utf8");
     expect(index).toContain("export async function serve");
     expect(index).toContain("export default async function handler");
+    expect(index).toContain('"--control": Boolean');
+    expect(index).toContain("controlToken");
 
     const stream = readFileSync(join(root, "src/vendor/mpr-plugins/share/stream.ts"), "utf8");
     expect(stream).toContain('cmd: ["cat", path]');
@@ -123,6 +126,23 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(viewer).toContain("new ResizeObserver(syncAllDimensions)");
     expect(viewer).toContain("const parseWireFrame = (plain) =>");
     expect(viewer).toContain("const tileToggle = document.getElementById(\"tile-toggle\")");
+  });
+
+
+
+  test("share --control mints a separate write token and marks metadata without exposing it through read token", async () => {
+    const created = await shareImpl.createShare({ target: "%control", readOnly: false, control: true });
+    expect(created.controlToken).toBeTruthy();
+    expect(created.controlToken).not.toBe(created.token);
+    const share = shareImpl.getShare(created.slug)!;
+    expect(share.readOnly).toBe(false);
+    expect(share.control?.allowedTargets).toEqual(["%control"]);
+    expect(share.control?.tokenHash).not.toBe(share.tokenHash);
+    expect(shareImpl.verifyShareControlToken(created.slug, "%control", created.controlToken!)).toEqual({ ok: true, share });
+    expect(shareImpl.verifyShareControlToken(created.slug, "%other", created.controlToken!)).toMatchObject({ ok: false, reason: "target_not_allowed", status: 403 });
+
+    const readonly = await shareImpl.createShare({ target: "%read", readOnly: true });
+    expect(shareImpl.verifyShareControlToken(readonly.slug, "%read", created.controlToken!)).toMatchObject({ ok: false, reason: "share_read_only", status: 403 });
   });
 
   test("stream default deps preserve real Tmux prototype methods", () => {

--- a/test/vendor-serve-control-real-entry-smoke.test.ts
+++ b/test/vendor-serve-control-real-entry-smoke.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "node:net";
+import { signControlAction } from "../src/vendor/mpr-plugins/serve-control/index";
+
+type SpawnSyncResult = ReturnType<typeof Bun.spawnSync>;
+
+function run(cmd: string[], options: { cwd?: string; env?: Record<string, string | undefined>; timeout?: number; allowFailure?: boolean } = {}): SpawnSyncResult {
+  const result = Bun.spawnSync({ cmd, cwd: options.cwd, env: options.env, stdout: "pipe", stderr: "pipe", timeout: options.timeout ?? 10_000 });
+  if (!options.allowFailure && !result.success) {
+    throw new Error(`${cmd.join(" ")} failed (${result.exitCode})\nSTDOUT:\n${result.stdout.toString()}\nSTDERR:\n${result.stderr.toString()}`);
+  }
+  return result;
+}
+
+function commandAvailable(cmd: string[]): boolean {
+  return run(cmd, { allowFailure: true, timeout: 2_000 }).success;
+}
+
+async function freePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") return server.close(() => reject(new Error("failed to allocate tcp port")));
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForHttp(url: string, timeoutMs = 10_000): Promise<void> {
+  const started = Date.now();
+  let last = "no attempt";
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      last = `${response.status}`;
+      if (response.status < 500) return;
+    } catch (error) {
+      last = error instanceof Error ? error.message : String(error);
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(`timed out waiting for ${url}; last=${last}`);
+}
+
+async function waitForNoListener(port: number, timeoutMs = 5_000): Promise<void> {
+  if (!commandAvailable(["bash", "-lc", "command -v lsof >/dev/null"])) return;
+  const started = Date.now();
+  let last = "";
+  while (Date.now() - started < timeoutMs) {
+    const result = run(["lsof", "-nP", `-iTCP:${port}`, "-sTCP:LISTEN"], { allowFailure: true, timeout: 2_000 });
+    last = result.stdout.toString() + result.stderr.toString();
+    if (!result.success || last.trim() === "") return;
+    await Bun.sleep(100);
+  }
+  throw new Error(`listener leak on port ${port}:\n${last}`);
+}
+
+function parseControlShareUrl(output: string, port: number): { slug: string; controlToken: string } {
+  const raw = output.match(/https?:\/\/\S+/)?.[0];
+  if (!raw) throw new Error(`share URL missing from output:\n${output}`);
+  const url = new URL(raw);
+  url.hostname = "127.0.0.1";
+  url.port = String(port);
+  const slug = url.pathname.split("/").filter(Boolean).at(-1);
+  const controlToken = url.hash.match(/[?#&]c=([^&]+)/)?.[1];
+  if (!slug || !controlToken) throw new Error(`control share URL missing slug or control token fragment: ${url.toString()}`);
+  return { slug, controlToken: decodeURIComponent(controlToken) };
+}
+
+async function postControl(port: number, target: string, token: string | undefined, body: Record<string, unknown>, verb = "send"): Promise<Response> {
+  const path = `/api/control/${encodeURIComponent(target)}/${verb}`;
+  const raw = JSON.stringify(body);
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token) {
+    headers["x-maw-control-token"] = token;
+    headers["x-maw-control-signature"] = signControlAction(token, "POST", path, raw);
+  }
+  return await fetch(`http://127.0.0.1:${port}${path}`, { method: "POST", headers, body: raw });
+}
+
+describe("serve-control real-entry smoke", () => {
+  test("maw share --control gates real pane writes with scoped write token", async () => {
+    if (!commandAvailable(["tmux", "-V"])) {
+      console.warn("SKIP serve-control real-entry smoke: tmux binary is unavailable");
+      return;
+    }
+
+    const repo = join(import.meta.dir, "..");
+    const session = `maw-control-2757-${process.pid}`;
+    let target = "";
+    const port = await freePort();
+    const home = mkdtempSync(join(tmpdir(), "maw-control-2757-"));
+    const env = {
+      ...process.env,
+      MAW_HOME: home,
+      MAW_STATE_DIR: join(home, "state"),
+      MAW_CONFIG_DIR: join(home, "config"),
+      MAW_DISABLE_UPDATE_CHECK: "1",
+    };
+    const sentinel = `MAW2757-control-${process.pid}`;
+    let serve: ReturnType<typeof Bun.spawn> | null = null;
+
+    run(["tmux", "kill-session", "-t", session], { allowFailure: true, timeout: 2_000 });
+    try {
+      run(["tmux", "new-session", "-d", "-x", "106", "-y", "51", "-s", session, "--", "bash", "-lc", `printf 'ready ${sentinel}\\n'; exec bash --noprofile --norc`], { timeout: 5_000 });
+      await Bun.sleep(300);
+      target = run(["tmux", "list-panes", "-t", session, "-F", "#{pane_id}"], { timeout: 5_000 }).stdout.toString().trim().split("\n")[0] ?? "";
+      if (!target.startsWith("%")) throw new Error(`failed to resolve real smoke pane id for ${session}: ${target || "empty"}`);
+
+      serve = Bun.spawn({ cmd: ["bun", "src/cli.ts", "serve", String(port), "--force-takeover", "-q"], cwd: repo, env, stdout: "pipe", stderr: "pipe" });
+      await waitForHttp(`http://127.0.0.1:${port}/api/identity`);
+
+      const shareOut = run(["bun", "src/cli.ts", "share", target, "--control", "--encrypt", "--ttl", "120", "--port", String(port)], { cwd: repo, env, timeout: 10_000 }).stdout.toString();
+      const { slug, controlToken } = parseControlShareUrl(shareOut, port);
+
+      const noToken = await postControl(port, target, undefined, { slug, text: "blocked" });
+      expect(noToken.status).toBe(401);
+
+      const badKey = await postControl(port, target, controlToken, { slug, key: "Space" }, "key");
+      expect(badKey.status).toBe(400);
+
+      const typed = ` ${sentinel}-typed `;
+      const send = await postControl(port, target, controlToken, { slug, text: typed });
+      expect(send.status).toBe(200);
+      const sendPayload = await send.json();
+      expect(sendPayload.ok).toBe(true);
+
+      await Bun.sleep(300);
+      const capture = run(["tmux", "capture-pane", "-t", target, "-p", "-S", "-20"], { timeout: 5_000 }).stdout.toString();
+      expect(capture).toContain(typed.trim());
+    } finally {
+      if (serve) {
+        serve.kill();
+        await serve.exited.catch(() => undefined);
+      }
+      run(["tmux", "kill-session", "-t", session], { allowFailure: true, timeout: 2_000 });
+      await waitForNoListener(port);
+      const sessionCheck = run(["tmux", "has-session", "-t", session], { allowFailure: true, timeout: 2_000 });
+      expect(sessionCheck.success).toBe(false);
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
Closes #2757
Closes #2756

## Summary
- add opt-in serve-control plugin for share-scoped send/key/kill/resize
- mint separate signed write tokens for maw share --control and keep read tokens read-only
- protect /api/control/*, enforce allowlist/readOnly/input/key/remote gates
- add standalone gate coverage plus real serve+tmux control smoke

## Verify
- timeout 120 bun run test
- timeout 120 bash scripts/test-isolated.sh test/isolated/plugin-share-standalone.test.ts test/isolated/plugin-serve-control-standalone.test.ts
- timeout 120 bun test test/vendor-serve-control-real-entry-smoke.test.ts
- timeout 120 bun scripts/check-plugin-coverage-gate.ts origin/alpha
- timeout 120 bun run build