### PR TITLE
fix: make share control viewer match serve-control contract (#2761)

### DIFF
--- a/src/vendor/mpr-plugins/share/viewer.html
+++ b/src/vendor/mpr-plugins/share/viewer.html
@@ -239,7 +239,7 @@
         const wsProof = e2eKey ? await sha256Hex(e2eKey) : token;
         const wsUrl = () => `${wsProto}://${location.host}/ws/share/${encodeURIComponent(slug)}?${e2eKey ? "h" : "t"}=${encodeURIComponent(wsProof)}`;
         let shareMetadata = { control: false, writeToken: "", panes: [], target: "" };
-        let controlWriteToken = params.get("w") || params.get("writeToken") || "";
+        let controlWriteToken = params.get("c") || params.get("w") || params.get("writeToken") || "";
 
         const metadataUrl = () => `/api/share/${encodeURIComponent(slug)}?${e2eKey ? "h" : "t"}=${encodeURIComponent(wsProof)}`;
 
@@ -358,18 +358,40 @@
           return shareMetadata.panes[0] || shareMetadata.target || id;
         };
 
-        const controlHeaders = () => ({
+        const hmacSha256Hex = async (secret, message) => {
+          const key = await crypto.subtle.importKey(
+            "raw",
+            new TextEncoder().encode(secret),
+            { name: "HMAC", hash: "SHA-256" },
+            false,
+            ["sign"],
+          );
+          const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(message));
+          return Array.from(new Uint8Array(signature), (byte) => byte.toString(16).padStart(2, "0")).join("");
+        };
+
+        const controlHeaders = (signature) => ({
           "content-type": "application/json",
           "authorization": `Bearer ${controlWriteToken}`,
+          "x-maw-control-token": controlWriteToken,
+          "x-maw-control-signature": signature,
           "x-maw-share-write-token": controlWriteToken,
         });
 
+        const signControlRequest = async (method, path, rawBody) => {
+          const bodyHash = await sha256Hex(rawBody);
+          return hmacSha256Hex(controlWriteToken, `${method.toUpperCase()}\n${path}\n${bodyHash}`);
+        };
+
         const postControl = async (target, action, body = {}) => {
           if (!controlsEnabled()) throw new Error("share control is not enabled");
-          const response = await fetch(`/api/control/${encodeURIComponent(target)}/${action}`, {
+          const path = `/api/control/${encodeURIComponent(target)}/${action}`;
+          const rawBody = JSON.stringify({ slug, ...body });
+          const signature = await signControlRequest("POST", path, rawBody);
+          const response = await fetch(path, {
             method: "POST",
-            headers: controlHeaders(),
-            body: JSON.stringify(body),
+            headers: controlHeaders(signature),
+            body: rawBody,
           });
           if (!response.ok) {
             const detail = await response.text().catch(() => "");

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -129,7 +129,12 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(viewer).toContain("await loadShareMetadata();");
     expect(viewer).toContain("metadata?.control === true");
     expect(viewer).toContain("metadata?.writeToken");
+    expect(viewer).toContain("params.get(\"c\")");
+    expect(viewer).toContain("x-maw-control-token");
+    expect(viewer).toContain("x-maw-control-signature");
     expect(viewer).toContain("x-maw-share-write-token");
+    expect(viewer).toContain("JSON.stringify({ slug, ...body })");
+    expect(viewer).toContain("signControlRequest(\"POST\", path, rawBody)");
     expect(viewer).toContain("/api/control/${encodeURIComponent(target)}/${action}");
     expect(viewer).toContain('postControl(controlTargetForPane(pane.id), "send", { text, enter })');
     expect(viewer).toContain('postControl(controlTargetForPane(pane.id), "key", { key })');

--- a/test/vendor-share-control-viewer-real-entry-smoke.test.ts
+++ b/test/vendor-share-control-viewer-real-entry-smoke.test.ts
@@ -1,0 +1,306 @@
+// @maw-test-isolate
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "node:net";
+
+type SpawnSyncResult = ReturnType<typeof Bun.spawnSync>;
+type Listener = (event?: any) => void;
+
+function run(cmd: string[], options: { cwd?: string; env?: Record<string, string | undefined>; timeout?: number; allowFailure?: boolean } = {}): SpawnSyncResult {
+  const result = Bun.spawnSync({
+    cmd,
+    cwd: options.cwd,
+    env: options.env,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: options.timeout ?? 10_000,
+  });
+  if (!options.allowFailure && !result.success) {
+    throw new Error(`${cmd.join(" ")} failed (${result.exitCode})\nSTDOUT:\n${result.stdout.toString()}\nSTDERR:\n${result.stderr.toString()}`);
+  }
+  return result;
+}
+
+function commandAvailable(cmd: string[]): boolean {
+  return run(cmd, { allowFailure: true, timeout: 2_000 }).success;
+}
+
+async function freePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("failed to allocate tcp port")));
+        return;
+      }
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForHttp(url: string, timeoutMs = 10_000): Promise<void> {
+  const started = Date.now();
+  let last = "no attempt";
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      last = `${response.status}`;
+      if (response.status < 500) return;
+    } catch (error) {
+      last = error instanceof Error ? error.message : String(error);
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(`timed out waiting for ${url}; last=${last}`);
+}
+
+async function waitForNoListener(port: number, timeoutMs = 5_000): Promise<void> {
+  if (!commandAvailable(["bash", "-lc", "command -v lsof >/dev/null"])) return;
+  const started = Date.now();
+  let last = "";
+  while (Date.now() - started < timeoutMs) {
+    const result = run(["lsof", "-nP", `-iTCP:${port}`, "-sTCP:LISTEN"], { allowFailure: true, timeout: 2_000 });
+    last = result.stdout.toString() + result.stderr.toString();
+    if (!result.success || last.trim() === "") return;
+    await Bun.sleep(100);
+  }
+  throw new Error(`listener leak on port ${port}:\n${last}`);
+}
+
+function parseControlShareUrl(output: string, port: number): { slug: string; readToken: string; controlToken: string; url: URL } {
+  const raw = output.match(/https?:\/\/\S+/)?.[0];
+  if (!raw) throw new Error(`share URL missing from output:\n${output}`);
+  const url = new URL(raw);
+  url.hostname = "127.0.0.1";
+  url.port = String(port);
+  const slug = url.pathname.split("/").filter(Boolean).at(-1);
+  const params = new URLSearchParams(url.hash.slice(1));
+  const readToken = params.get("t") || "";
+  const controlToken = params.get("c") || "";
+  if (!slug || !readToken || !controlToken) throw new Error(`control share URL missing slug/read/control token: ${url.toString()}`);
+  return { slug, readToken, controlToken, url };
+}
+
+async function waitForCaptureContains(target: string, needle: string, timeoutMs = 5_000): Promise<string> {
+  const started = Date.now();
+  let capture = "";
+  while (Date.now() - started < timeoutMs) {
+    capture = run(["tmux", "capture-pane", "-t", target, "-p", "-S", "-20"], { timeout: 5_000 }).stdout.toString();
+    if (capture.includes(needle)) return capture;
+    await Bun.sleep(100);
+  }
+  throw new Error(`timed out waiting for pane ${target} to contain ${JSON.stringify(needle)}\nLast capture:\n${capture}`);
+}
+
+class FakeClassList {
+  private values = new Set<string>();
+  constructor(private readonly owner: FakeElement) {}
+  add(...tokens: string[]) { for (const token of tokens) this.values.add(token); this.sync(); }
+  remove(...tokens: string[]) { for (const token of tokens) this.values.delete(token); this.sync(); }
+  toggle(token: string, force?: boolean) {
+    const next = force ?? !this.values.has(token);
+    if (next) this.values.add(token); else this.values.delete(token);
+    this.sync();
+    return next;
+  }
+  contains(token: string) { return this.values.has(token); }
+  private sync() { this.owner.className = [...this.values].join(" "); }
+}
+
+class FakeElement {
+  children: FakeElement[] = [];
+  classList = new FakeClassList(this);
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  listeners = new Map<string, Listener[]>();
+  textContent = "";
+  className = "";
+  type = "";
+  rows = 0;
+  placeholder = "";
+  value = "";
+  disabled = false;
+  constructor(public readonly tagName: string) {}
+  appendChild(child: FakeElement) { this.children.push(child); return child; }
+  append(...children: FakeElement[]) { for (const child of children) this.appendChild(child); }
+  addEventListener(type: string, listener: Listener) {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  }
+  dispatch(type: string, event: Record<string, unknown> = {}) {
+    for (const listener of this.listeners.get(type) ?? []) listener({ preventDefault() {}, ...event });
+  }
+  focus() {}
+}
+
+class FakeDocument {
+  elements: FakeElement[] = [];
+  private byId = new Map<string, FakeElement>();
+  constructor(ids: string[]) {
+    for (const id of ids) {
+      const element = this.createElement("div");
+      this.byId.set(id, element);
+    }
+  }
+  createElement(tag: string) {
+    const element = new FakeElement(tag.toLowerCase());
+    this.elements.push(element);
+    return element;
+  }
+  getElementById(id: string) {
+    const existing = this.byId.get(id);
+    if (existing) return existing;
+    const element = this.createElement("div");
+    this.byId.set(id, element);
+    return element;
+  }
+  findByClass(name: string) {
+    return this.elements.find((element) => element.className.split(/\s+/).includes(name));
+  }
+}
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  listeners = new Map<string, Listener[]>();
+  binaryType = "";
+  constructor(public readonly url: string) {
+    FakeWebSocket.instances.push(this);
+    queueMicrotask(() => this.emit("open", {}));
+  }
+  addEventListener(type: string, listener: Listener) {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  }
+  emit(type: string, event: Record<string, unknown>) {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+  close() { this.emit("close", { code: 1000, reason: "test" }); }
+}
+
+async function runViewerAgainstLiveBackend(viewerHtml: string, shareUrl: URL, paneTarget: string, typed: string): Promise<void> {
+  const script = viewerHtml.match(/<script>([\s\S]*)<\/script>/)?.[1];
+  if (!script) throw new Error("viewer module script not found");
+
+  const previous = {
+    window: globalThis.window,
+    document: globalThis.document,
+    location: globalThis.location,
+    WebSocket: globalThis.WebSocket,
+    ResizeObserver: globalThis.ResizeObserver,
+    requestAnimationFrame: globalThis.requestAnimationFrame,
+    alert: globalThis.alert,
+    confirm: globalThis.confirm,
+    fetch: globalThis.fetch,
+  } as Record<string, unknown>;
+  const document = new FakeDocument(["fallback", "toolbar", "tabs", "tile-toggle", "terms"]);
+  const alerts: string[] = [];
+  try {
+    Object.assign(globalThis, {
+      document,
+      location: shareUrl,
+      WebSocket: FakeWebSocket,
+      ResizeObserver: class ResizeObserver { observe() {} disconnect() {} },
+      requestAnimationFrame: (fn: () => void) => { queueMicrotask(fn); return 1; },
+      alert: (message: string) => { alerts.push(String(message)); },
+      confirm: () => true,
+      fetch: (input: RequestInfo | URL, init?: RequestInit) => {
+        const resolved = typeof input === "string" && input.startsWith("/") ? new URL(input, shareUrl.origin).toString() : input;
+        return (previous.fetch as typeof fetch)(resolved as RequestInfo | URL, init);
+      },
+    });
+    (globalThis as any).window = {
+      Terminal: undefined,
+      addEventListener() {},
+      visualViewport: undefined,
+      alert: (message: string) => { alerts.push(String(message)); },
+      confirm: () => true,
+    };
+
+    (0, eval)(script);
+    await Bun.sleep(300);
+    const ws = FakeWebSocket.instances.at(-1);
+    if (!ws) throw new Error("viewer did not create websocket");
+    ws.emit("message", {
+      data: JSON.stringify({ type: "maw-share-frame", pane: paneTarget, data: "", snapshot: true, dimensions: { cols: 80, rows: 24 } }),
+    });
+    await Bun.sleep(100);
+
+    const input = document.findByClass("pane-control-input");
+    const form = document.findByClass("pane-controls");
+    if (!input || !form) throw new Error("viewer did not render control form for #c token");
+    input.value = typed;
+    input.dispatch("input");
+    form.dispatch("submit");
+    await Bun.sleep(500);
+    if (alerts.length > 0) throw new Error(`viewer control alert: ${alerts.join(" | ")}`);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete (globalThis as any)[key];
+      else (globalThis as any)[key] = value;
+    }
+    FakeWebSocket.instances.length = 0;
+  }
+}
+
+describe("share control viewer real-entry smoke (#2761)", () => {
+  test("real viewer control form signs live serve-control requests and writes to tmux", async () => {
+    if (!commandAvailable(["tmux", "-V"])) {
+      console.warn("SKIP share control viewer real-entry smoke: tmux binary is unavailable");
+      return;
+    }
+
+    const repo = join(import.meta.dir, "..");
+    const session = `maw-share-control-2761-${process.pid}`;
+    let target = "";
+    const port = await freePort();
+    const home = mkdtempSync(join(tmpdir(), "maw-share-control-2761-"));
+    const env = {
+      ...process.env,
+      MAW_HOME: home,
+      MAW_STATE_DIR: join(home, "state"),
+      MAW_CONFIG_DIR: join(home, "config"),
+      MAW_DISABLE_UPDATE_CHECK: "1",
+    };
+    const typed = `MAW2761-viewer-typed-${process.pid}`;
+    let serve: ReturnType<typeof Bun.spawn> | null = null;
+
+    run(["tmux", "kill-session", "-t", session], { allowFailure: true, timeout: 2_000 });
+    try {
+      run(["tmux", "new-session", "-d", "-x", "106", "-y", "51", "-s", session, "--", "bash", "-lc", "exec bash --noprofile --norc"], { timeout: 5_000 });
+      await Bun.sleep(300);
+      target = run(["tmux", "list-panes", "-t", session, "-F", "#{pane_id}"], { timeout: 5_000 }).stdout.toString().trim().split("\n")[0] ?? "";
+      if (!target.startsWith("%")) throw new Error(`failed to resolve real smoke pane id for ${session}: ${target || "empty"}`);
+
+      serve = Bun.spawn({ cmd: ["bun", "src/cli.ts", "serve", String(port), "--force-takeover", "-q"], cwd: repo, env, stdout: "pipe", stderr: "pipe" });
+      await waitForHttp(`http://127.0.0.1:${port}/api/identity`);
+
+      const shareOut = run(["bun", "src/cli.ts", "share", target, "--control", "--ttl", "120", "--port", String(port)], { cwd: repo, env, timeout: 10_000 }).stdout.toString();
+      const { url } = parseControlShareUrl(shareOut, port);
+      const viewer = await fetch(url).then((response) => response.text());
+      expect(viewer).toContain('params.get("c")');
+      expect(viewer).toContain("x-maw-control-signature");
+      expect(viewer).toContain("JSON.stringify({ slug, ...body })");
+
+      await runViewerAgainstLiveBackend(viewer, url, target, typed);
+      const capture = await waitForCaptureContains(target, typed);
+      expect(capture).toContain(typed);
+    } finally {
+      if (serve) {
+        serve.kill();
+        await serve.exited.catch(() => undefined);
+      }
+      run(["tmux", "kill-session", "-t", session], { allowFailure: true, timeout: 2_000 });
+      await waitForNoListener(port);
+      const sessionCheck = run(["tmux", "has-session", "-t", session], { allowFailure: true, timeout: 2_000 });
+      expect(sessionCheck.success).toBe(false);
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/test/vendor-share-hardening.test.ts
+++ b/test/vendor-share-hardening.test.ts
@@ -60,7 +60,12 @@ describe("share hardening", () => {
     expect(viewer).toContain("const tileToggle = document.getElementById(\"tile-toggle\")");
     expect(viewer).toContain("await loadShareMetadata();");
     expect(viewer).toContain("metadata?.control === true");
+    expect(viewer).toContain("params.get(\"c\")");
+    expect(viewer).toContain("x-maw-control-token");
+    expect(viewer).toContain("x-maw-control-signature");
     expect(viewer).toContain("x-maw-share-write-token");
+    expect(viewer).toContain("JSON.stringify({ slug, ...body })");
+    expect(viewer).toContain("signControlRequest(\"POST\", path, rawBody)");
     expect(viewer).toContain("/api/control/${encodeURIComponent(target)}/${action}");
     expect(viewer).toContain('postControl(controlTargetForPane(pane.id), "send", { text, enter })');
     expect(viewer).toContain('postControl(controlTargetForPane(pane.id), "key", { key })');


### PR DESCRIPTION
Closes #2761

Fixes the viewer ↔ serve-control contract mismatch found by live browser testing:
- reads the CLI control token from the real fragment param #c
- includes slug in every control POST body
- signs each raw control body with Web Crypto HMAC-SHA256 as METHOD\nPATH\nsha256(rawBody)
- keeps serve-control fail-safe behavior unchanged

Adds a real-entry regression test that starts real maw serve + real tmux, fetches live viewer.html through /share/:slug, simulates the viewer control form with the real #c URL, and asserts the pane receives typed text through live serve-control.

Validation:
- timeout 120 bash scripts/test-default-safe.sh test/vendor-share-control-viewer-real-entry-smoke.test.ts
- timeout 120 bun test test/vendor-share-hardening.test.ts
- timeout 120 bash scripts/test-isolated.sh test/isolated/plugin-share-standalone.test.ts test/isolated/plugin-serve-control-standalone.test.ts
- timeout 120 bun run build

Note: attempted timeout 240 bun run test; it still fails in pre-existing comm-send-cmdsend coverage timeouts/assertions (the #2737-class baseline), unrelated to share control.