### PR TITLE
fix: abort failed team fan-out member sends safely (#2753)

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -565,23 +565,35 @@ export async function cmdSend(
 
     // Fan-out sends individually. cmdSend calls process.exit on failure,
     // so we override it temporarily to keep iterating (#627 resilient fan-out).
+    // The override must still abort the nested cmdSend call; returning from
+    // process.exit lets fail paths continue through code that assumes `never`,
+    // which can leave subprocess/async work alive under isolated shard load.
+    class TeamMemberExitError extends Error {
+      readonly code: number;
+      constructor(code?: number) {
+        super("team member send exited");
+        this.name = "TeamMemberExitError";
+        this.code = code ?? 0;
+      }
+    }
     const origExit = process.exit;
     for (const member of members) {
       const routedMember = resolveTeamWorkspaceMemberTarget(teamName, member, sessions) ?? member;
-      let memberFailed = false;
       process.exit = ((code?: number) => {
-        memberFailed = true;
+        throw new TeamMemberExitError(code);
       }) as never;
       try {
         await cmdSend(routedMember, message, force, opts);
-        if (!memberFailed) delivered++;
-        else failed++;
+        delivered++;
       } catch (e: any) {
         failed++;
-        console.error(`  \x1b[31m✗\x1b[0m ${routedMember}: ${e?.message || "failed"}`);
+        if (!(e instanceof TeamMemberExitError)) {
+          console.error(`  \x1b[31m✗\x1b[0m ${routedMember}: ${e?.message || "failed"}`);
+        }
+      } finally {
+        process.exit = origExit;
       }
     }
-    process.exit = origExit;
 
     console.log(`\x1b[36m⚡\x1b[0m fan-out complete: ${delivered} delivered, ${failed} failed`);
     return;

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -244,6 +244,10 @@ let errs: string[];
 let logs: string[];
 let warns: string[];
 
+// These locate/manifest fallback cases exercise intentionally slow negative-path
+// waits; under isolated shard load the default 5s per-test cap flakes.
+const COMM_SEND_LOCATE_TIMEOUT_MS = 10_000;
+
 async function runCmd(fn: () => Promise<unknown>) {
   exitCode = undefined;
   errs = [];
@@ -795,7 +799,7 @@ describe("cmdSend — bare-name, wake, and safety gates", () => {
     expect(exitCode).toBe(1);
     expect(curlFetchCalls).toEqual([]);
     expect(errs.join("\n")).toContain("not found locally");
-  });
+  }, COMM_SEND_LOCATE_TIMEOUT_MS);
 
 
 
@@ -818,7 +822,7 @@ describe("cmdSend — bare-name, wake, and safety gates", () => {
     expect(receiverWrites[0].target).toBe("/tmp/renamed-oracle");
     expect(logs.join("\n")).toContain("renamed found at /tmp/renamed-oracle but no active session — written to inbox only");
     expect(warns.join("\n")).toContain("⚠ target node offline — message written to inbox only, will not be seen until node wakes");
-  });
+  }, COMM_SEND_LOCATE_TIMEOUT_MS);
 
   test("bare located repo resolves to active local session by cwd before inbox fallback (#2056)", async () => {
     listSessionsReturn = [{ name: "77-renamed", windows: [{ index: 0, name: "renamed-oracle", active: true, cwd: "/tmp/renamed-oracle" } as any] }];
@@ -830,7 +834,7 @@ describe("cmdSend — bare-name, wake, and safety gates", () => {
     expect(exitCode).toBeUndefined();
     expect(curlFetchCalls).toEqual([]);
     expect(sendKeysCalls).toEqual([{ target: "77-renamed:renamed-oracle", text: "[test-node:sender] hello" }]);
-  });
+  }, COMM_SEND_LOCATE_TIMEOUT_MS);
 
   test("bare manifest cross-node hit does not silently route to peer (#2056)", async () => {
     config.namedPeers = [{ name: "remote", url: "http://remote:3456" }];
@@ -844,7 +848,7 @@ describe("cmdSend — bare-name, wake, and safety gates", () => {
     expect(curlFetchCalls).toEqual([]);
     expect(warns.join("\n")).toContain("renamed found at /tmp/renamed-oracle but no active session — written to inbox only");
     expect(errs.join("\n")).toContain("found but no active session");
-  });
+  }, COMM_SEND_LOCATE_TIMEOUT_MS);
 
   test("bare peer aliases are allowed as explicit federation targets (#1940)", async () => {
     config.namedPeers = [{

--- a/test/isolated/comm-send-deep-branches-coverage.test.ts
+++ b/test/isolated/comm-send-deep-branches-coverage.test.ts
@@ -397,10 +397,11 @@ describe("comm-send deep isolated branches", () => {
   });
 
   test("team fan-out counts delivered, member exits, and thrown member failures", async () => {
-    oracleMembers = ["good", "exit", "thrower"];
-    oracleRegistry = { members: ["sender", "good", "exit", "thrower"] };
+    oracleMembers = ["good", "bad:target", "thrower"];
+    oracleRegistry = { members: ["sender", "good", "bad:target", "thrower"] };
     resolveTargetHandler = (query) => {
       if (query === "good") return { type: "local", target: "session:good.0" };
+      if (query === "bad:target") return { type: "error", detail: "forced member exit" };
       if (query === "thrower") throw new Error("fanout boom");
       return null;
     };
@@ -412,8 +413,31 @@ describe("comm-send deep isolated branches", () => {
     expect(sendKeysCalls).toEqual([{ target: "session:good.0", text: "[test-node:sender] fan out" }]);
     expect(logs.join("\n")).toContain("self 'sender' excluded");
     expect(logs.join("\n")).toContain("fan-out complete: 1 delivered, 2 failed");
-    expect(errs.join("\n")).toContain("bare target 'exit' not found locally");
+    expect(errs.join("\n")).toContain("forced member exit");
     expect(errs.join("\n")).toContain("thrower: fanout boom");
+  });
+
+  test("team fan-out aborts a member after process.exit without leaking delivery side effects", async () => {
+    oracleMembers = ["denied"];
+    oracleRegistry = { members: ["sender", "denied"] };
+    resolveTargetHandler = (query) => {
+      expect(query).toBe("denied");
+      return { type: "local", target: "session:denied.0" };
+    };
+    process.env.MAW_CONSENT = "1";
+    consentDecision = { allow: false, message: "consent denied for member", exitCode: 7 };
+
+    await runCmd(() => cmdSend("team:squad", "should not deliver"));
+
+    expect(exitCode).toBeUndefined();
+    expect(consentCalls).toHaveLength(1);
+    expect(sendKeysCalls).toEqual([]);
+    expect(defaultInboxCalls).toEqual([]);
+    expect(runHookCalls).toEqual([]);
+    expect(logMessageCalls).toEqual([]);
+    expect(emitFeedCalls).toEqual([]);
+    expect(logs.join("\n")).toContain("fan-out complete: 0 delivered, 1 failed");
+    expect(errs.join("\n")).toContain("consent denied for member");
   });
 
   test("ACL queue records pending peer sends before network delivery", async () => {


### PR DESCRIPTION
Closes #2753

## Summary
- Fix team fan-out process.exit override so nested failed `cmdSend` calls abort instead of continuing through fatal paths.
- Restore `process.exit` per member in `finally` and use a local sentinel Error class to avoid message-prefix collisions.
- Keep targeted 10s timeout on known slow #2056 locate negative-path tests, but root fix is the fan-out abort behavior.
- Add regression coverage that a member exit does not leak delivery side effects, and make the isolated member-exit branch deterministic/fast.

## Verification
- `timeout 120 bun test test/isolated/comm-send-deep-branches-coverage.test.ts`
- `timeout 120 bun test test/comm-send-cmdsend-coverage.test.ts`
- `MAW_SKIP_FLAKY=1 timeout 360 bash scripts/test-isolated.sh --shard 4/4` → 1126 pass, 0 fail; no new repo-local maw/bun serve orphan in before/after ps check
- `timeout 120 bun run build`

## Review
- codex-2675 adversarially reviewed the process.exit semantics and requested the per-member restore + sentinel Error hardening.
- codex-2 independently verified targeted deep-branches and isolated-4of4 shard green with no live orphan after run.