### PR TITLE
fix: honor enter flag in serve-control send (#2765)

### DIFF
--- a/src/vendor/mpr-plugins/serve-control/index.ts
+++ b/src/vendor/mpr-plugins/serve-control/index.ts
@@ -123,8 +123,10 @@ async function routeControl(req: Request): Promise<Response> {
   try {
     if (verb === "send") {
       const text = sanitizeLiteral(ctx.body.text);
+      const enter = ctx.body.enter === true;
       await tmux.sendKeysLiteral(ctx.target, text);
-      return json(200, { ok: true, target: ctx.target, bytes: byteLength(text) });
+      if (enter) await tmux.sendKeys(ctx.target, "Enter");
+      return json(200, { ok: true, target: ctx.target, bytes: byteLength(text), enter });
     }
     if (verb === "key") {
       const key = typeof ctx.body.key === "string" ? ctx.body.key : "";

--- a/test/isolated/plugin-serve-control-standalone.test.ts
+++ b/test/isolated/plugin-serve-control-standalone.test.ts
@@ -113,11 +113,18 @@ describe("serve-control standalone security gate (#2757)", () => {
 
     res = await handler(req(path, { slug: share.slug, text: `a\0b${"x".repeat(25_000)}` }, share.controlToken));
     expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ ok: true, enter: false });
     expect(tmuxCalls[0][0]).toBe("send");
     expect(tmuxCalls[0][1]).toBe("%1");
     const sent = tmuxCalls[0][2] as string;
     expect(sent.includes("\0")).toBe(false);
     expect(new TextEncoder().encode(sent).byteLength).toBeLessThanOrEqual(20_000);
+
+    tmuxCalls.length = 0;
+    res = await handler(req(path, { slug: share.slug, text: "echo hi", enter: true }, share.controlToken));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ ok: true, enter: true });
+    expect(tmuxCalls).toEqual([["send", "%1", "echo hi"], ["key", "%1", "Enter"]]);
   });
 
   test("key verb rejects off-allowlist keys before tmux", async () => {

--- a/test/vendor-serve-control-real-entry-smoke.test.ts
+++ b/test/vendor-serve-control-real-entry-smoke.test.ts
@@ -126,14 +126,30 @@ describe("serve-control real-entry smoke", () => {
       expect(badKey.status).toBe(400);
 
       const typed = ` ${sentinel}-typed `;
-      const send = await postControl(port, target, controlToken, { slug, text: typed });
+      const send = await postControl(port, target, controlToken, { slug, text: typed, enter: false });
       expect(send.status).toBe(200);
       const sendPayload = await send.json();
-      expect(sendPayload.ok).toBe(true);
+      expect(sendPayload).toMatchObject({ ok: true, enter: false });
 
       await Bun.sleep(300);
-      const capture = run(["tmux", "capture-pane", "-t", target, "-p", "-S", "-20"], { timeout: 5_000 }).stdout.toString();
+      let capture = run(["tmux", "capture-pane", "-t", target, "-p", "-S", "-20"], { timeout: 5_000 }).stdout.toString();
       expect(capture).toContain(typed.trim());
+
+      const cancelDraft = await postControl(port, target, controlToken, { slug, key: "C-c" }, "key");
+      expect(cancelDraft.status).toBe(200);
+
+      const output = `${sentinel}-executed`;
+      const execute = await postControl(port, target, controlToken, { slug, text: `printf '${output}\\n'`, enter: true });
+      expect(execute.status).toBe(200);
+      await expect(execute.json()).resolves.toMatchObject({ ok: true, enter: true });
+
+      const started = Date.now();
+      do {
+        capture = run(["tmux", "capture-pane", "-t", target, "-p", "-S", "-30"], { timeout: 5_000 }).stdout.toString();
+        if (capture.split("\n").some((line) => line.trim() === output)) break;
+        await Bun.sleep(100);
+      } while (Date.now() - started < 5_000);
+      expect(capture.split("\n").some((line) => line.trim() === output)).toBe(true);
     } finally {
       if (serve) {
         serve.kill();

--- a/test/vendor-share-control-viewer-real-entry-smoke.test.ts
+++ b/test/vendor-share-control-viewer-real-entry-smoke.test.ts
@@ -97,6 +97,17 @@ async function waitForCaptureContains(target: string, needle: string, timeoutMs 
   throw new Error(`timed out waiting for pane ${target} to contain ${JSON.stringify(needle)}\nLast capture:\n${capture}`);
 }
 
+async function waitForCaptureLine(target: string, expected: string, timeoutMs = 5_000): Promise<string> {
+  const started = Date.now();
+  let capture = "";
+  while (Date.now() - started < timeoutMs) {
+    capture = run(["tmux", "capture-pane", "-t", target, "-p", "-S", "-30"], { timeout: 5_000 }).stdout.toString();
+    if (capture.split("\n").some((line) => line.trim() === expected)) return capture;
+    await Bun.sleep(100);
+  }
+  throw new Error(`timed out waiting for pane ${target} to output line ${JSON.stringify(expected)}\nLast capture:\n${capture}`);
+}
+
 class FakeClassList {
   private values = new Set<string>();
   constructor(private readonly owner: FakeElement) {}
@@ -268,7 +279,8 @@ describe("share control viewer real-entry smoke (#2761)", () => {
       MAW_CONFIG_DIR: join(home, "config"),
       MAW_DISABLE_UPDATE_CHECK: "1",
     };
-    const typed = `MAW2761-viewer-typed-${process.pid}`;
+    const output = `MAW2765_VIEWER_EXECUTED_${process.pid}`;
+    const typed = `printf '${output}\\n'`;
     let serve: ReturnType<typeof Bun.spawn> | null = null;
 
     run(["tmux", "kill-session", "-t", session], { allowFailure: true, timeout: 2_000 });
@@ -291,6 +303,8 @@ describe("share control viewer real-entry smoke (#2761)", () => {
       await runViewerAgainstLiveBackend(viewer, url, target, typed);
       const capture = await waitForCaptureContains(target, typed);
       expect(capture).toContain(typed);
+      const executed = await waitForCaptureLine(target, output);
+      expect(executed.split("\n").some((line) => line.trim() === output)).toBe(true);
     } finally {
       if (serve) {
         serve.kill();


### PR DESCRIPTION
Closes #2765

## Summary
- Honor body.enter for serve-control send: literal text remains literal-only by default, and enter:true sends tmux Enter after the text.
- Keep enter:false/current literal-only behavior intact.
- Extend standalone and real-entry coverage so command execution output is asserted, not just typed bytes in the pane.

## Validation
- timeout 120 bash scripts/test-default-safe.sh test/vendor-serve-control-real-entry-smoke.test.ts test/vendor-share-control-viewer-real-entry-smoke.test.ts
- timeout 120 bash scripts/test-isolated.sh test/isolated/plugin-serve-control-standalone.test.ts
- timeout 120 bun run build