### PR TITLE
fix: apply serve CORS to plugin control routes (#2769)

### DIFF
--- a/src/core/serve-cors.ts
+++ b/src/core/serve-cors.ts
@@ -3,7 +3,7 @@ export function corsHeaders(req: Request): Record<string, string> {
   return {
     "Access-Control-Allow-Origin": origin,
     "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Federation-Token, X-From-Signature",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Federation-Token, X-From-Signature, x-maw-control-signature, x-maw-control-token, x-maw-share-write-token",
     "Access-Control-Allow-Private-Network": "true",
   };
 }
@@ -11,4 +11,12 @@ export function corsHeaders(req: Request): Record<string, string> {
 export function handleCorsOptions(req: Request): Response | undefined {
   if (req.method !== "OPTIONS") return undefined;
   return new Response(null, { status: 204, headers: corsHeaders(req) });
+}
+
+export function addCorsHeaders(req: Request, res: Response): Response {
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers: { ...Object.fromEntries(res.headers.entries()), ...corsHeaders(req) },
+  });
 }

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -22,7 +22,7 @@ import { sendKeys } from "./transport/ssh";
 import { getRuntimeVersionLabel } from "./runtime/build-info";
 import { ServeRouteRegistry } from "./serve-route-registry";
 import { ServeWsRegistry } from "./serve-ws-registry";
-import { corsHeaders, handleCorsOptions } from "./serve-cors";
+import { addCorsHeaders, handleCorsOptions } from "./serve-cors";
 import { createViews } from "../vendor/mpr-plugins/serve-views/index.ts";
 import { serve as registerServeWs } from "../vendor/mpr-plugins/serve-ws/index.ts";
 export { createViews };
@@ -432,6 +432,8 @@ export async function startBunGatewayServer(
       return response;
     };
 
+    const addCors = (r: Response) => addCorsHeaders(req, r);
+
     // CORS preflight for all routes
     const corsPreflight = handleCorsOptions(req);
     if (corsPreflight) return logAccess(corsPreflight);
@@ -448,24 +450,16 @@ export async function startBunGatewayServer(
         const authOrLegacyRoute = await api.handle(req.clone());
         if (authOrLegacyRoute.status !== 404) return logAccess(authOrLegacyRoute);
         const servedByPlugin = await serveRoutes.handle(req);
-        return logAccess(servedByPlugin ?? authOrLegacyRoute);
+        return logAccess(servedByPlugin ? addCors(servedByPlugin) : authOrLegacyRoute);
       }
       const servedByPlugin = await serveRoutes.handle(req);
-      if (servedByPlugin) return logAccess(servedByPlugin);
+      if (servedByPlugin) return logAccess(addCors(servedByPlugin));
       return logAccess(await api.handle(req));
     }
     const servedByPlugin = await serveRoutes.handle(req);
-    if (servedByPlugin) return logAccess(servedByPlugin);
+    if (servedByPlugin) return logAccess(addCors(servedByPlugin));
 
     // Plugin-registered fallbacks handle views + static — clone response with CORS headers
-    const addCors = (r: Response) => {
-      const h = corsHeaders(req);
-      return new Response(r.body, {
-        status: r.status,
-        statusText: r.statusText,
-        headers: { ...Object.fromEntries(r.headers.entries()), ...h },
-      });
-    };
     const res = serveRoutes.handleFallback(req, { server });
     if (res instanceof Promise) return logAccess(addCors(await res));
     return logAccess(addCors(res as Response));

--- a/test/isolated/serve-cors.test.ts
+++ b/test/isolated/serve-cors.test.ts
@@ -1,14 +1,25 @@
 import { describe, expect, test } from "bun:test";
-import { corsHeaders, handleCorsOptions } from "../../src/core/serve-cors";
+import { addCorsHeaders, corsHeaders, handleCorsOptions } from "../../src/core/serve-cors";
+
+const CONTROL_HEADERS = [
+  "x-maw-control-signature",
+  "x-maw-control-token",
+  "x-maw-share-write-token",
+];
 
 describe("serve CORS middleware", () => {
-  test("corsHeaders mirrors request origin and permits serve API headers", () => {
-    expect(corsHeaders(new Request("http://local/api", { headers: { origin: "http://example.test" } }))).toEqual({
+  test("corsHeaders mirrors request origin and permits serve API/control headers", () => {
+    const headers = corsHeaders(new Request("http://local/api", { headers: { origin: "http://example.test" } }));
+
+    expect(headers).toEqual({
       "Access-Control-Allow-Origin": "http://example.test",
       "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Federation-Token, X-From-Signature",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Federation-Token, X-From-Signature, x-maw-control-signature, x-maw-control-token, x-maw-share-write-token",
       "Access-Control-Allow-Private-Network": "true",
     });
+    for (const header of CONTROL_HEADERS) {
+      expect(headers["Access-Control-Allow-Headers"].toLowerCase()).toContain(header);
+    }
   });
 
   test("corsHeaders falls back to wildcard origin when no Origin header is present", () => {
@@ -16,15 +27,38 @@ describe("serve CORS middleware", () => {
   });
 
   test("handleCorsOptions returns a 204 preflight response only for OPTIONS requests", () => {
-    const preflight = handleCorsOptions(new Request("http://local/ws", {
+    const preflight = handleCorsOptions(new Request("http://local/api/control/%251/send", {
       method: "OPTIONS",
-      headers: { origin: "http://preflight.test" },
+      headers: {
+        origin: "http://preflight.test",
+        "access-control-request-method": "POST",
+        "access-control-request-headers": "content-type,x-maw-control-token,x-maw-control-signature,x-maw-share-write-token",
+      },
     }));
 
     expect(preflight).toBeInstanceOf(Response);
     expect(preflight?.status).toBe(204);
     expect(preflight?.headers.get("Access-Control-Allow-Origin")).toBe("http://preflight.test");
     expect(preflight?.headers.get("Access-Control-Allow-Private-Network")).toBe("true");
+    const allowed = preflight?.headers.get("Access-Control-Allow-Headers")?.toLowerCase() ?? "";
+    for (const header of CONTROL_HEADERS) expect(allowed).toContain(header);
     expect(handleCorsOptions(new Request("http://local/ws"))).toBeUndefined();
+  });
+
+  test("plugin control responses can be cloned with CORS headers", async () => {
+    const request = new Request("http://local/api/control/%251/send", {
+      method: "POST",
+      headers: { origin: "http://viewer.test" },
+    });
+    const response = addCorsHeaders(request, new Response(JSON.stringify({ ok: true }), {
+      status: 202,
+      headers: { "content-type": "application/json", "x-plugin-route": "serve-control" },
+    }));
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("http://viewer.test");
+    expect(response.headers.get("Access-Control-Allow-Headers")?.toLowerCase()).toContain("x-maw-control-token");
+    expect(response.headers.get("x-plugin-route")).toBe("serve-control");
+    expect(await response.json()).toEqual({ ok: true });
   });
 });


### PR DESCRIPTION
Closes #2769

## Summary
- add maw control/share write headers to serve CORS preflight allow-list
- wrap serveRoutes.handle plugin responses with the same CORS clone used by fallback responses
- add CORS regressions for /api/control preflight and plugin control POST responses

## Verification
- timeout 120 bun test test/isolated/serve-cors.test.ts
- timeout 120 bun run build
- timeout 120 bun run test