### PR TITLE
fix: mount serve plugin routes before readiness (#2774)

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -500,6 +500,27 @@ export async function startBunGatewayServer(
   };
   const wsConfig = { ...wsHandlers, idleTimeout: cfgTimeout("wsIdleSec"), sendPings: true };
 
+  log.debug(`[serve:debug] running serve lifecycle hooks`);
+  await runServeLifecycleHooks({
+    port,
+    httpUrl: HTTP_URL,
+    wsUrl: WS_URL,
+    hostname,
+    http: serveRoutes,
+    ws: serveWs,
+    engine,
+    log,
+    plugins: serveLifecyclePlugins,
+    reloadPlugins: serveLifecycleReloadPlugins,
+    profile: {
+      views: profileFlag(profile, "views"),
+      apiRouters: profile.apiRouters,
+    },
+  }, undefined, {
+    info: (message) => log.info(message),
+    warn: (message) => log.warn(message),
+  });
+
   let server: ReturnType<typeof Bun.serve>;
   try {
     server = Bun.serve({ port, hostname, fetch: fetchHandler, websocket: wsConfig });
@@ -514,32 +535,6 @@ export async function startBunGatewayServer(
 
   const bindNote = reason ? ` (${reason})` : "";
   log.info(`maw ${VERSION} serve → ${HTTP_URL} (${WS_URL}) [${hostname}]${bindNote}`);
-
-  log.debug(`[serve:debug] running serve lifecycle hooks`);
-  try {
-    await runServeLifecycleHooks({
-      port,
-      httpUrl: HTTP_URL,
-      wsUrl: WS_URL,
-      hostname,
-      http: serveRoutes,
-      ws: serveWs,
-      engine,
-      log,
-      plugins: serveLifecyclePlugins,
-      reloadPlugins: serveLifecycleReloadPlugins,
-      profile: {
-        views: profileFlag(profile, "views"),
-        apiRouters: profile.apiRouters,
-      },
-    }, undefined, {
-      info: (message) => log.info(message),
-      warn: (message) => log.warn(message),
-    });
-  } catch (err) {
-    try { server.stop(true); } catch { /* best effort */ }
-    throw err;
-  }
 
   const routeSnapshot = collectServeRouteSnapshot({ http: serveRoutes, ws: serveWs });
   (server as unknown as Record<symbol, ServeRouteSnapshotEntry[]>)[SERVE_ROUTE_SNAPSHOT_SYMBOL] = routeSnapshot;

--- a/test/vendor-daily-ops-real-entry-smoke.test.ts
+++ b/test/vendor-daily-ops-real-entry-smoke.test.ts
@@ -32,6 +32,7 @@ function writeSmokeConfig(home: string): void {
     host: "local",
     commands: { default: "claude", codex: "codex" },
     defaultEngine: "codex",
+    engines: { codex: { cmd: "codex", label: "Codex CLI" } },
     agents: {},
     namedPeers: [],
   }, null, 2) + "\n");

--- a/test/vendor-serve-control-real-entry-smoke.test.ts
+++ b/test/vendor-serve-control-real-entry-smoke.test.ts
@@ -84,6 +84,44 @@ async function postControl(port: number, target: string, token: string | undefin
   return await fetch(`http://127.0.0.1:${port}${path}`, { method: "POST", headers, body: raw });
 }
 
+async function waitForPaneTarget(target: string, timeoutMs = 5_000): Promise<void> {
+  const started = Date.now();
+  let last = "";
+  while (Date.now() - started < timeoutMs) {
+    const result = run(["tmux", "display-message", "-p", "-t", target, "#{pane_id}"], { allowFailure: true, timeout: 2_000 });
+    last = result.stdout.toString() + result.stderr.toString();
+    if (result.success && last.trim() === target) return;
+    await Bun.sleep(50);
+  }
+  throw new Error(`timed out waiting for tmux pane target ${target}; last=${JSON.stringify(last)}`);
+}
+
+async function waitForCaptureContains(target: string, needle: string, timeoutMs = 5_000): Promise<string> {
+  const started = Date.now();
+  let capture = "";
+  while (Date.now() - started < timeoutMs) {
+    const result = run(["tmux", "capture-pane", "-t", target, "-p", "-S", "-30"], { allowFailure: true, timeout: 2_000 });
+    capture = result.stdout.toString() + result.stderr.toString();
+    if (result.success && capture.includes(needle)) return capture;
+    await Bun.sleep(50);
+  }
+  throw new Error(`timed out waiting for pane ${target} to contain ${JSON.stringify(needle)}\nLast capture:\n${capture}`);
+}
+
+async function expectJsonStatus(response: Response, expected: number, context: string): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  let parsed: Record<string, unknown> = {};
+  try {
+    parsed = text ? JSON.parse(text) as Record<string, unknown> : {};
+  } catch {
+    parsed = { raw: text };
+  }
+  if (response.status !== expected) {
+    throw new Error(`${context}: expected HTTP ${expected}, got ${response.status}; body=${text || "<empty>"}`);
+  }
+  return parsed;
+}
+
 describe("serve-control real-entry smoke", () => {
   test("maw share --control gates real pane writes with scoped write token", async () => {
     if (!commandAvailable(["tmux", "-V"])) {
@@ -109,9 +147,10 @@ describe("serve-control real-entry smoke", () => {
     run(["tmux", "kill-session", "-t", session], { allowFailure: true, timeout: 2_000 });
     try {
       run(["tmux", "new-session", "-d", "-x", "106", "-y", "51", "-s", session, "--", "bash", "-lc", `printf 'ready ${sentinel}\\n'; exec bash --noprofile --norc`], { timeout: 5_000 });
-      await Bun.sleep(300);
       target = run(["tmux", "list-panes", "-t", session, "-F", "#{pane_id}"], { timeout: 5_000 }).stdout.toString().trim().split("\n")[0] ?? "";
       if (!target.startsWith("%")) throw new Error(`failed to resolve real smoke pane id for ${session}: ${target || "empty"}`);
+      await waitForPaneTarget(target);
+      await waitForCaptureContains(target, `ready ${sentinel}`);
 
       serve = Bun.spawn({ cmd: ["bun", "src/cli.ts", "serve", String(port), "--force-takeover", "-q"], cwd: repo, env, stdout: "pipe", stderr: "pipe" });
       await waitForHttp(`http://127.0.0.1:${port}/api/identity`);
@@ -120,35 +159,31 @@ describe("serve-control real-entry smoke", () => {
       const { slug, controlToken } = parseControlShareUrl(shareOut, port);
 
       const noToken = await postControl(port, target, undefined, { slug, text: "blocked" });
-      expect(noToken.status).toBe(401);
+      await expectJsonStatus(noToken, 401, "no-token control send");
 
       const badKey = await postControl(port, target, controlToken, { slug, key: "Space" }, "key");
-      expect(badKey.status).toBe(400);
+      await expectJsonStatus(badKey, 400, "disallowed control key");
 
       const typed = ` ${sentinel}-typed `;
+      await waitForPaneTarget(target);
       const send = await postControl(port, target, controlToken, { slug, text: typed, enter: false });
-      expect(send.status).toBe(200);
-      const sendPayload = await send.json();
+      const sendPayload = await expectJsonStatus(send, 200, "control send literal");
       expect(sendPayload).toMatchObject({ ok: true, enter: false });
 
-      await Bun.sleep(300);
-      let capture = run(["tmux", "capture-pane", "-t", target, "-p", "-S", "-20"], { timeout: 5_000 }).stdout.toString();
+      let capture = await waitForCaptureContains(target, typed.trim());
       expect(capture).toContain(typed.trim());
 
+      await waitForPaneTarget(target);
       const cancelDraft = await postControl(port, target, controlToken, { slug, key: "C-c" }, "key");
-      expect(cancelDraft.status).toBe(200);
+      await expectJsonStatus(cancelDraft, 200, "control cancel draft");
+      await waitForPaneTarget(target);
 
       const output = `${sentinel}-executed`;
       const execute = await postControl(port, target, controlToken, { slug, text: `printf '${output}\\n'`, enter: true });
-      expect(execute.status).toBe(200);
-      await expect(execute.json()).resolves.toMatchObject({ ok: true, enter: true });
+      const executePayload = await expectJsonStatus(execute, 200, "control send enter");
+      expect(executePayload).toMatchObject({ ok: true, enter: true });
 
-      const started = Date.now();
-      do {
-        capture = run(["tmux", "capture-pane", "-t", target, "-p", "-S", "-30"], { timeout: 5_000 }).stdout.toString();
-        if (capture.split("\n").some((line) => line.trim() === output)) break;
-        await Bun.sleep(100);
-      } while (Date.now() - started < 5_000);
+      capture = await waitForCaptureContains(target, output);
       expect(capture.split("\n").some((line) => line.trim() === output)).toBe(true);
     } finally {
       if (serve) {

--- a/test/vendor-serve-hook-order-real-entry-smoke.test.ts
+++ b/test/vendor-serve-hook-order-real-entry-smoke.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "node:net";
+
+type SpawnSyncResult = ReturnType<typeof Bun.spawnSync>;
+
+function run(cmd: string[], options: { cwd?: string; env?: Record<string, string | undefined>; timeout?: number; allowFailure?: boolean } = {}): SpawnSyncResult {
+  const result = Bun.spawnSync({
+    cmd,
+    cwd: options.cwd,
+    env: options.env,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: options.timeout ?? 10_000,
+  });
+  if (!options.allowFailure && !result.success) {
+    throw new Error(`${cmd.join(" ")} failed (${result.exitCode})\nSTDOUT:\n${result.stdout.toString()}\nSTDERR:\n${result.stderr.toString()}`);
+  }
+  return result;
+}
+
+function commandAvailable(cmd: string[]): boolean {
+  return run(cmd, { allowFailure: true, timeout: 2_000 }).success;
+}
+
+async function freePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("failed to allocate tcp port")));
+        return;
+      }
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForHttp(url: string, timeoutMs = 10_000): Promise<void> {
+  const started = Date.now();
+  let last = "no attempt";
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      last = `${response.status}`;
+      if (response.status < 500) return;
+    } catch (error) {
+      last = error instanceof Error ? error.message : String(error);
+    }
+    await Bun.sleep(25);
+  }
+  throw new Error(`timed out waiting for ${url}; last=${last}`);
+}
+
+async function waitForNoListener(port: number, timeoutMs = 5_000): Promise<void> {
+  if (!commandAvailable(["bash", "-lc", "command -v lsof >/dev/null"])) return;
+  const started = Date.now();
+  let last = "";
+  while (Date.now() - started < timeoutMs) {
+    const result = run(["lsof", "-nP", `-iTCP:${port}`, "-sTCP:LISTEN"], { allowFailure: true, timeout: 2_000 });
+    last = result.stdout.toString() + result.stderr.toString();
+    if (!result.success || last.trim() === "") return;
+    await Bun.sleep(50);
+  }
+  throw new Error(`listener leak on port ${port}:\n${last}`);
+}
+
+function installSlowServeHook(pluginDir: string): void {
+  const dir = join(pluginDir, "zz-slow-serve-hook");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "plugin.json"), JSON.stringify({
+    name: "zz-slow-serve-hook",
+    version: "1.0.0",
+    entry: "./index.ts",
+    sdk: "^1.0.0",
+    tier: "core",
+    weight: 1,
+    schemaVersion: 1,
+    hooks: { serve: { script: "./index.ts", handler: "serve", policy: "fail-fast" } },
+  }));
+  writeFileSync(join(dir, "index.ts"), `
+    export async function serve(ctx) {
+      await Bun.sleep(500);
+      ctx.http.route("GET", "/api/slow-hook-ready", () => Response.json({ ok: true }));
+      return { ok: true };
+    }
+  `);
+}
+
+async function postInvalidShare(port: number): Promise<Response> {
+  return await fetch(`http://127.0.0.1:${port}/api/share`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({}),
+  });
+}
+
+describe("serve hook mount order real-entry smoke (#2774)", () => {
+  test("core readiness never opens before plugin routes such as /api/share are mounted", async () => {
+    const repo = join(import.meta.dir, "..");
+    const root = mkdtempSync(join(tmpdir(), "maw-serve-order-2774-"));
+    const pluginDir = join(root, "plugins");
+    const port = await freePort();
+    const env = {
+      ...process.env,
+      MAW_HOME: join(root, "home"),
+      MAW_STATE_DIR: join(root, "state"),
+      MAW_CONFIG_DIR: join(root, "config"),
+      MAW_PLUGINS_DIR: pluginDir,
+      MAW_DISABLE_UPDATE_CHECK: "1",
+    };
+    let serve: ReturnType<typeof Bun.spawn> | null = null;
+
+    installSlowServeHook(pluginDir);
+    try {
+      serve = Bun.spawn({
+        cmd: ["bun", "src/cli.ts", "serve", String(port), "--force-takeover", "-q"],
+        cwd: repo,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      await waitForHttp(`http://127.0.0.1:${port}/api/identity`);
+      for (let i = 0; i < 8; i += 1) {
+        const response = await postInvalidShare(port);
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: "target_required" });
+      }
+    } finally {
+      if (serve) {
+        serve.kill();
+        await serve.exited.catch(() => undefined);
+      }
+      await waitForNoListener(port);
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/test/vendor-share-control-viewer-real-entry-smoke.test.ts
+++ b/test/vendor-share-control-viewer-real-entry-smoke.test.ts
@@ -285,10 +285,11 @@ describe("share control viewer real-entry smoke (#2761)", () => {
 
     run(["tmux", "kill-session", "-t", session], { allowFailure: true, timeout: 2_000 });
     try {
-      run(["tmux", "new-session", "-d", "-x", "106", "-y", "51", "-s", session, "--", "bash", "-lc", "exec bash --noprofile --norc"], { timeout: 5_000 });
-      await Bun.sleep(300);
+      const ready = `MAW2765_READY_${process.pid}`;
+      run(["tmux", "new-session", "-d", "-x", "106", "-y", "51", "-s", session, "--", "bash", "-lc", `printf '${ready}\n'; exec bash --noprofile --norc`], { timeout: 5_000 });
       target = run(["tmux", "list-panes", "-t", session, "-F", "#{pane_id}"], { timeout: 5_000 }).stdout.toString().trim().split("\n")[0] ?? "";
       if (!target.startsWith("%")) throw new Error(`failed to resolve real smoke pane id for ${session}: ${target || "empty"}`);
+      await waitForCaptureContains(target, ready);
 
       serve = Bun.spawn({ cmd: ["bun", "src/cli.ts", "serve", String(port), "--force-takeover", "-q"], cwd: repo, env, stdout: "pipe", stderr: "pipe" });
       await waitForHttp(`http://127.0.0.1:${port}/api/identity`);

--- a/test/vendor-share-real-entry-smoke.test.ts
+++ b/test/vendor-share-real-entry-smoke.test.ts
@@ -80,6 +80,18 @@ async function waitForNoListener(port: number, timeoutMs = 5_000): Promise<void>
   throw new Error(`listener leak on port ${port}:\n${last}`);
 }
 
+async function waitForTmuxCaptureContains(target: string, expected: string, timeoutMs = 5_000): Promise<void> {
+  const started = Date.now();
+  let last = "";
+  while (Date.now() - started < timeoutMs) {
+    const result = run(["tmux", "capture-pane", "-p", "-t", target], { allowFailure: true, timeout: 2_000 });
+    last = result.stdout.toString() + result.stderr.toString();
+    if (result.success && last.includes(expected)) return;
+    await Bun.sleep(50);
+  }
+  throw new Error(`timed out waiting for tmux capture to contain ${JSON.stringify(expected)}; last=${JSON.stringify(last)}`);
+}
+
 function parseShareUrl(output: string, port: number): { slug: string; secret: string } {
   const raw = output.match(/https?:\/\/\S+/)?.[0];
   if (!raw) throw new Error(`share URL missing from output:\n${output}`);
@@ -175,6 +187,7 @@ describe("share real-entry smoke", () => {
       await Bun.sleep(300);
       target = run(["tmux", "list-panes", "-t", session, "-F", "#{pane_id}"], { timeout: 5_000 }).stdout.toString().trim().split("\n")[0] ?? "";
       if (!target.startsWith("%")) throw new Error(`failed to resolve real smoke pane id for ${session}: ${target || "empty"}`);
+      await waitForTmuxCaptureContains(target, sentinel);
 
       serve = Bun.spawn({
         cmd: ["bun", "src/cli.ts", "serve", String(port), "--force-takeover", "-q"],


### PR DESCRIPTION
Closes #2774

## Summary
- run serve lifecycle hooks before Bun.serve binds so plugin routes are mounted before core readiness can pass
- preserve fail-fast startup on hook errors and keep address-in-use handling around Bun.serve
- add a real-entry slow-hook smoke proving /api/share is never 404 immediately after /api/identity readiness

## Verification
- timeout 120 bun test test/vendor-serve-hook-order-real-entry-smoke.test.ts test/vendor-share-control-viewer-real-entry-smoke.test.ts
- timeout 650 bun run test
- timeout 120 bun run build
- timeout 120 bun scripts/check-plugin-coverage-gate.ts origin/alpha

## Notes
- tsc skipped: repo intentionally has no tsconfig / no tsc gate.
- local test:isolated currently hits unrelated comm-send isolated timeouts/failures in this environment (comm-send-edge-coverage, comm-send-fourteenth-pass-coverage); this PR does not touch comm-send.