### PR TITLE
feat: add opt-in share viewer presence (#2773)

### DIFF
--- a/src/vendor/mpr-plugins/share-presence/index.ts
+++ b/src/vendor/mpr-plugins/share-presence/index.ts
@@ -1,0 +1,201 @@
+import { randomBytes } from "crypto";
+import type { ServeHookContext } from "../../../core/serve-route-registry";
+import type { ServeWsData, ServeWsRouteRegistrar, ServeWsSocket } from "../../../core/serve-ws-registry";
+import { getShare, verifyShare } from "../share/impl";
+
+const MAX_NAME_CHARS = 48;
+const MAX_VIEWERS_PER_SLUG = 256;
+
+export type ViewerInfo = { id: string; name: string; joinedAt: number };
+export type PresenceSnapshot = { type: "presence"; slug: string; count: number; viewers: ViewerInfo[] };
+
+type PresenceWsData = ServeWsData & {
+  shareSlug?: string;
+  shareToken?: string;
+  viewerName?: string;
+  shareError?: string;
+};
+
+type PresenceOpenState = {
+  slug: string;
+  viewerId: string | null;
+  closing: boolean;
+};
+
+type PresenceSocket = Pick<ServeWsSocket, "send">;
+
+type PresenceEntry = {
+  viewers: Map<string, ViewerInfo>;
+  sockets: Map<string, PresenceSocket>;
+};
+
+const registry = new Map<string, PresenceEntry>();
+const openStates = new Map<ServeWsSocket, PresenceOpenState>();
+
+type PresenceDeps = {
+  verifyShare: (slug: string, token: string) => Promise<boolean> | boolean;
+};
+
+let deps: PresenceDeps = { verifyShare };
+
+export function setPresenceDepsForTests(next: Partial<PresenceDeps>): () => void {
+  const previous = deps;
+  deps = { ...deps, ...next };
+  return () => { deps = previous; };
+}
+
+function makeViewerId(): string {
+  return `v_${randomBytes(9).toString("base64url")}`;
+}
+
+export function sanitizeViewerName(input: string | null | undefined): string {
+  const stripped = (input ?? "")
+    .replace(/[\0\x01-\x1F\x7F]/g, "")
+    .trim();
+  const chars = [...stripped].slice(0, MAX_NAME_CHARS).join("");
+  return chars || "anonymous";
+}
+
+function parseRoutePart(pathname: string, pattern: string): Record<string, string> | null {
+  const pathParts = pathname.split("/").filter(Boolean);
+  const patternParts = pattern.split("/").filter(Boolean);
+  if (pathParts.length !== patternParts.length) return null;
+  const params: Record<string, string> = {};
+  for (let i = 0; i < patternParts.length; i += 1) {
+    const part = patternParts[i];
+    const actual = pathParts[i];
+    if (actual === undefined) return null;
+    if (part.startsWith(":")) {
+      params[part.slice(1)] = decodeURIComponent(actual);
+      continue;
+    }
+    if (part !== actual) return null;
+  }
+  return params;
+}
+
+function parseShareToken(req: Request): string {
+  const url = new URL(req.url);
+  return url.searchParams.get("token") || url.searchParams.get("t") || url.searchParams.get("h") || "";
+}
+
+function snapshot(slug: string, entry: PresenceEntry): PresenceSnapshot {
+  return {
+    type: "presence",
+    slug,
+    count: entry.viewers.size,
+    viewers: [...entry.viewers.values()],
+  };
+}
+
+function sendSnapshot(slug: string, entry: PresenceEntry): void {
+  const payload = JSON.stringify(snapshot(slug, entry));
+  for (const socket of entry.sockets.values()) socket.send(payload);
+}
+
+export function joinPresence(slug: string, socket: PresenceSocket, name: string, now = Date.now()): ViewerInfo | { error: "too_many_viewers" } {
+  let entry = registry.get(slug);
+  if (!entry) {
+    entry = { viewers: new Map(), sockets: new Map() };
+    registry.set(slug, entry);
+  }
+  if (entry.viewers.size >= MAX_VIEWERS_PER_SLUG) return { error: "too_many_viewers" };
+  const viewer: ViewerInfo = { id: makeViewerId(), name: sanitizeViewerName(name), joinedAt: now };
+  entry.viewers.set(viewer.id, viewer);
+  entry.sockets.set(viewer.id, socket);
+  sendSnapshot(slug, entry);
+  return viewer;
+}
+
+export function leavePresence(slug: string, viewerId: string): void {
+  const entry = registry.get(slug);
+  if (!entry) return;
+  entry.viewers.delete(viewerId);
+  entry.sockets.delete(viewerId);
+  if (entry.viewers.size === 0) {
+    registry.delete(slug);
+    return;
+  }
+  sendSnapshot(slug, entry);
+}
+
+export function presenceSnapshot(slug: string): PresenceSnapshot | null {
+  const entry = registry.get(slug);
+  return entry ? snapshot(slug, entry) : null;
+}
+
+export function clearPresenceRegistryForTests(): void {
+  registry.clear();
+  openStates.clear();
+  deps = { verifyShare };
+}
+
+export function openPresenceStateCountForTests(): number {
+  return openStates.size;
+}
+
+function presenceWsRouteData(req: Request): PresenceWsData {
+  const url = new URL(req.url);
+  const params = parseRoutePart(url.pathname, "/ws/share/:slug/presence");
+  return {
+    target: null,
+    previewTargets: new Set(),
+    shareSlug: params?.slug,
+    shareToken: parseShareToken(req),
+    viewerName: url.searchParams.get("name") ?? undefined,
+    shareError: params?.slug ? undefined : "missing slug",
+  };
+}
+
+async function openPresenceWebSocket(ws: ServeWsSocket): Promise<void> {
+  const data = ws.data as PresenceWsData;
+  const slug = data.params?.slug || data.shareSlug || "";
+  if (data.shareError || !slug) {
+    ws.close(1008, data.shareError || "invalid share presence route");
+    return;
+  }
+  const share = getShare(slug);
+  if (!share) {
+    ws.close(1008, "invalid or expired share token");
+    return;
+  }
+  openStates.set(ws, { slug, viewerId: null, closing: false });
+  const verified = await deps.verifyShare(slug, data.shareToken ?? "");
+  const state = openStates.get(ws);
+  if (!state || state.closing) {
+    openStates.delete(ws);
+    return;
+  }
+  if (!verified) {
+    openStates.delete(ws);
+    ws.close(1008, "invalid or expired share token");
+    return;
+  }
+  if (share.presence !== true) {
+    openStates.delete(ws);
+    ws.close(1008, "share presence not enabled");
+    return;
+  }
+  const joined = joinPresence(slug, ws, data.viewerName ?? "");
+  if ("error" in joined) {
+    openStates.delete(ws);
+    ws.close(1013, "too many presence viewers");
+    return;
+  }
+  state.viewerId = joined.id;
+}
+
+export async function serve(ctx: ServeHookContext & { ws?: ServeWsRouteRegistrar }): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!ctx.ws) return { ok: false, error: "share-presence requires ctx.ws" };
+  ctx.ws.route("/ws/share/:slug/presence", presenceWsRouteData, {
+    open: (ws) => { void openPresenceWebSocket(ws); },
+    close: (ws) => {
+      const state = openStates.get(ws);
+      if (!state) return;
+      state.closing = true;
+      openStates.delete(ws);
+      if (state.viewerId) leavePresence(state.slug, state.viewerId);
+    },
+  });
+  return { ok: true };
+}

--- a/src/vendor/mpr-plugins/share-presence/plugin.json
+++ b/src/vendor/mpr-plugins/share-presence/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "share-presence",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Opt-in read-only web-viewer presence for maw share.",
+  "tier": "extra",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "policy": "fail-fast"
+    }
+  },
+  "weight": 12,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/src/vendor/mpr-plugins/share/impl.ts
+++ b/src/vendor/mpr-plugins/share/impl.ts
@@ -26,6 +26,7 @@ export interface Share {
   encryptionKeyHash?: string;
   encryptionFrameCounter?: bigint;
   control?: ShareControl;
+  presence?: boolean;
 }
 
 export interface CreateShareOptions {
@@ -36,6 +37,7 @@ export interface CreateShareOptions {
   auth?: ShareAuthKind;
   encrypted?: boolean;
   control?: boolean;
+  presence?: boolean;
 }
 
 export interface CreateShareResult {
@@ -239,6 +241,7 @@ export async function createShare(opts: CreateShareOptions): Promise<CreateShare
     auth,
     encrypted,
     encryptionFrameCounter: 0n,
+    ...(opts.presence === true ? { presence: true } : {}),
   };
   const token = await authHandler.mint(share, slug);
   share.tokenHash = hashToken(token);

--- a/src/vendor/mpr-plugins/share/index.ts
+++ b/src/vendor/mpr-plugins/share/index.ts
@@ -14,7 +14,7 @@ export const command = {
   description: "Share a live read-only tmux session/pane in a browser via a temporary link.",
 };
 
-const SHARE_USAGE = "usage: maw share <session-or-pane> [additional-pane ...] [--read-only] [--control] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]";
+const SHARE_USAGE = "usage: maw share <session-or-pane> [additional-pane ...] [--read-only] [--control] [--presence] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]";
 const DEFAULT_TTL_SECONDS = 3600;
 const DEFAULT_READ_ONLY = true;
 
@@ -38,6 +38,7 @@ type ShareMetadata = {
   expiresAt: number;
   auth: string;
   control?: boolean;
+  presence?: boolean;
 };
 
 type CreateShareRequest = {
@@ -48,6 +49,7 @@ type CreateShareRequest = {
   auth?: unknown;
   encrypted?: unknown;
   control?: unknown;
+  presence?: unknown;
 };
 
 const viewerHtml = (() => {
@@ -157,6 +159,7 @@ async function routeCreateShare(req: Request): Promise<Response> {
       auth: resolveAuthFlag(body.auth),
       encrypted: body.encrypted === true || body.auth === "encrypted",
       control: body.control === true,
+      presence: body.presence === true,
     });
     const payload = {
       slug: created.slug,
@@ -219,6 +222,7 @@ async function routeShareMetadata(req: Request): Promise<Response> {
     expiresAt: share.expiresAt,
     auth: share.auth,
     ...(share.control ? { control: true } : {}),
+    ...(share.presence ? { presence: true } : {}),
   };
 
   return new Response(JSON.stringify(payload), {
@@ -371,6 +375,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       "--auth": String,
       "--encrypt": Boolean,
       "--control": Boolean,
+      "--presence": Boolean,
     }, 0);
 
     const targets = flags._;
@@ -391,6 +396,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     const hit = hits[0]!.hit!;
 
     const control = flags["--control"] === true;
+    const presence = flags["--presence"] === true;
     const readOnly = control ? false : (flags["--read-only"] === undefined ? DEFAULT_READ_ONLY : Boolean(flags["--read-only"]));
     const ttl = typeof flags["--ttl"] === "number" && Number.isFinite(flags["--ttl"]) ? flags["--ttl"] : DEFAULT_TTL_SECONDS;
     const encrypted = flags["--encrypt"] === true || flags["--auth"] === "encrypted";
@@ -403,6 +409,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       ttl,
       auth,
       ...(control ? { control: true } : {}),
+      ...(presence ? { presence: true } : {}),
     };
     if (encrypted) request.encrypted = true;
 

--- a/src/vendor/mpr-plugins/share/plugin.json
+++ b/src/vendor/mpr-plugins/share/plugin.json
@@ -6,14 +6,15 @@
   "description": "Share a tmux session/pane as a read-only web stream.",
   "cli": {
     "command": "share",
-    "help": "maw share <session-or-pane> [--read-only] [--control] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]",
+    "help": "maw share <session-or-pane> [--read-only] [--control] [--presence] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]",
     "flags": {
       "--read-only": "boolean",
       "--ttl": "number",
       "--port": "number",
       "--auth": "string",
       "--encrypt": "boolean",
-      "--control": "boolean"
+      "--control": "boolean",
+      "--presence": "boolean"
     }
   },
   "weight": 10,

--- a/test/isolated/plugin-share-presence-standalone.test.ts
+++ b/test/isolated/plugin-share-presence-standalone.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+const root = join(import.meta.dir, "../..");
+
+describe("share-presence standalone boundary (#2773)", () => {
+  test("manifest keeps share-presence opt-in, serve-only, and out of default-active", () => {
+    expectStandalonePluginBoundary({
+      plugin: "share-presence",
+      requireSdk: false,
+      allowRelative: [
+        "../../../core/serve-route-registry",
+        "../../../core/serve-ws-registry",
+        "../share/impl",
+      ],
+    });
+
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/share-presence/plugin.json"), "utf8"));
+    expect(manifest.name).toBe("share-presence");
+    expect(manifest.tier).toBe("extra");
+    expect(manifest.hooks.serve.handler).toBe("serve");
+    expect(manifest.cli).toBeUndefined();
+    const defaults = readFileSync(join(root, "src/plugin/default-active.ts"), "utf8");
+    expect(defaults).not.toContain('"share-presence"');
+  });
+
+  test("source is pure presence bookkeeping without tmux or write verbs", () => {
+    const source = readFileSync(join(root, "src/vendor/mpr-plugins/share-presence/index.ts"), "utf8");
+    expect(source.toLowerCase()).not.toContain("tmux");
+    expect(source).not.toContain("sendKeys");
+    expect(source).not.toContain("killPane");
+    expect(source).not.toContain("resizePane");
+    expect(source).toContain('ctx.ws.route("/ws/share/:slug/presence"');
+    expect(source).toContain("verifyShare(slug");
+    expect(source).toContain("share.presence !== true");
+  });
+});

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -99,11 +99,14 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(manifest.cli.command).toBe("share");
     expect(manifest.hooks.serve.handler).toBe("serve");
     expect(manifest.cli.flags["--control"]).toBe("boolean");
+    expect(manifest.cli.flags["--presence"]).toBe("boolean");
 
     const index = readFileSync(join(root, "src/vendor/mpr-plugins/share/index.ts"), "utf8");
     expect(index).toContain("export async function serve");
     expect(index).toContain("export default async function handler");
     expect(index).toContain('"--control": Boolean');
+    expect(index).toContain('"--presence": Boolean');
+    expect(index).toContain("presence: body.presence === true");
     expect(index).toContain("controlToken");
 
     const stream = readFileSync(join(root, "src/vendor/mpr-plugins/share/stream.ts"), "utf8");
@@ -216,6 +219,42 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
         readOnly: true,
         auth: "token",
       });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+
+  test("share --presence posts daemon flag and exposes read-only metadata", async () => {
+    const { httpRoutes } = await makeServeHarness();
+    const createRoute = httpRoutes.find((route) => route.method === "POST" && route.path === "/api/share")!;
+    const metadataRoute = httpRoutes.find((route) => route.method === "GET" && route.path === "/api/share/:slug")!;
+    const originalFetch = globalThis.fetch;
+    const postedBodies: unknown[] = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      postedBodies.push(await req.clone().json());
+      return createRoute.handler(req);
+    }) as typeof fetch;
+
+    try {
+      const result = await shareHandler({
+        source: "cli",
+        args: ["neo:1", "--presence", "--ttl", "42", "--port", "4567"],
+      } as any);
+
+      expect(result.ok).toBe(true);
+      expect(postedBodies).toEqual([{ target: "neo:1:resolved", readOnly: true, ttl: 42, auth: "token", presence: true }]);
+      const { slug, token } = parseShareOutput(result.output);
+      const share = shareRuntimeImpl.getShare(slug)!;
+      expect(share.presence).toBe(true);
+      expect(share.readOnly).toBe(true);
+      expect(share.control).toBeUndefined();
+
+      const metadata = await metadataRoute.handler(new Request(`http://127.0.0.1:4567/api/share/${slug}?token=${encodeURIComponent(token)}`));
+      expect(metadata.status).toBe(200);
+      await expect(metadata.json()).resolves.toMatchObject({ presence: true, readOnly: true });
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/test/vendor-share-presence-real-entry-smoke.test.ts
+++ b/test/vendor-share-presence-real-entry-smoke.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "node:net";
+
+type SpawnSyncResult = ReturnType<typeof Bun.spawnSync>;
+type PresenceMessage = { type: "presence"; slug: string; count: number; viewers: Array<{ id: string; name: string; joinedAt: number }> };
+
+function run(cmd: string[], options: { cwd?: string; env?: Record<string, string | undefined>; timeout?: number; allowFailure?: boolean } = {}): SpawnSyncResult {
+  const result = Bun.spawnSync({ cmd, cwd: options.cwd, env: options.env, stdout: "pipe", stderr: "pipe", timeout: options.timeout ?? 10_000 });
+  if (!options.allowFailure && !result.success) {
+    throw new Error(`${cmd.join(" ")} failed (${result.exitCode})\nSTDOUT:\n${result.stdout.toString()}\nSTDERR:\n${result.stderr.toString()}`);
+  }
+  return result;
+}
+
+function commandAvailable(cmd: string[]): boolean {
+  return run(cmd, { allowFailure: true, timeout: 2_000 }).success;
+}
+
+async function freePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") return server.close(() => reject(new Error("failed to allocate tcp port")));
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForHttp(url: string, timeoutMs = 10_000): Promise<void> {
+  const started = Date.now();
+  let last = "no attempt";
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      last = `${response.status}`;
+      if (response.status < 500) return;
+    } catch (error) {
+      last = error instanceof Error ? error.message : String(error);
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(`timed out waiting for ${url}; last=${last}`);
+}
+
+async function waitForShareApi(port: number, timeoutMs = 10_000): Promise<void> {
+  const started = Date.now();
+  let last = "no attempt";
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/api/share`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      last = `${response.status}`;
+      if (response.status === 400) return;
+    } catch (error) {
+      last = error instanceof Error ? error.message : String(error);
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(`timed out waiting for share API on ${port}; last=${last}`);
+}
+
+async function waitForNoListener(port: number, timeoutMs = 5_000): Promise<void> {
+  if (!commandAvailable(["bash", "-lc", "command -v lsof >/dev/null"])) return;
+  const started = Date.now();
+  let last = "";
+  while (Date.now() - started < timeoutMs) {
+    const result = run(["lsof", "-nP", `-iTCP:${port}`, "-sTCP:LISTEN"], { allowFailure: true, timeout: 2_000 });
+    last = result.stdout.toString() + result.stderr.toString();
+    if (!result.success || last.trim() === "") return;
+    await Bun.sleep(100);
+  }
+  throw new Error(`listener leak on port ${port}:\n${last}`);
+}
+
+function parseShareUrl(output: string, port: number): { slug: string; token: string } {
+  const raw = output.match(/https?:\/\/\S+/)?.[0];
+  if (!raw) throw new Error(`share URL missing from output:\n${output}`);
+  const url = new URL(raw);
+  url.hostname = "127.0.0.1";
+  url.port = String(port);
+  const slug = url.pathname.split("/").filter(Boolean).at(-1);
+  const token = url.hash.match(/[?#&]t=([^&]+)/)?.[1];
+  if (!slug || token === undefined) throw new Error(`share URL missing slug or token fragment: ${url.toString()}`);
+  return { slug, token: decodeURIComponent(token) };
+}
+
+function openPresence(url: string): { ws: WebSocket; next: () => Promise<PresenceMessage>; close: () => Promise<CloseEvent> } {
+  const queue: PresenceMessage[] = [];
+  const waiters: Array<(message: PresenceMessage) => void> = [];
+  let closeEvent: CloseEvent | null = null;
+  let closeResolve: ((event: CloseEvent) => void) | null = null;
+  const closed = new Promise<CloseEvent>((resolve) => { closeResolve = resolve; });
+  const ws = new WebSocket(url);
+  ws.onmessage = (event) => {
+    const message = JSON.parse(String(event.data)) as PresenceMessage;
+    const waiter = waiters.shift();
+    if (waiter) waiter(message);
+    else queue.push(message);
+  };
+  ws.onclose = (event) => {
+    closeEvent = event;
+    closeResolve?.(event);
+  };
+  ws.onerror = () => {
+    if (!closeEvent) {
+      closeEvent = new CloseEvent("close", { code: 1006, reason: "websocket error" });
+      closeResolve?.(closeEvent);
+    }
+  };
+  return {
+    ws,
+    next: () => new Promise((resolve, reject) => {
+      const queued = queue.shift();
+      if (queued) return resolve(queued);
+      const timer = setTimeout(() => reject(new Error(`timed out waiting for presence message from ${url}`)), 10_000);
+      waiters.push((message) => {
+        clearTimeout(timer);
+        resolve(message);
+      });
+    }),
+    close: async () => {
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) ws.close(1000, "smoke done");
+      return await closed;
+    },
+  };
+}
+
+async function waitForClose(url: string): Promise<CloseEvent> {
+  return await new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      try { ws.close(); } catch { /* ignore */ }
+      reject(new Error(`timed out waiting for websocket close from ${url}`));
+    }, 10_000);
+    ws.onclose = (event) => {
+      clearTimeout(timer);
+      resolve(event);
+    };
+    ws.onerror = () => {
+      // Bun will still emit close for failed handshakes; leave close handler authoritative.
+    };
+  });
+}
+
+describe("share-presence real-entry smoke", () => {
+  test("maw share --presence broadcasts web viewer join and leave through real serve websocket", async () => {
+    if (!commandAvailable(["tmux", "-V"])) {
+      console.warn("SKIP share-presence real-entry smoke: tmux binary is unavailable");
+      return;
+    }
+
+    const repo = join(import.meta.dir, "..");
+    const session = `maw-presence-2773-${process.pid}`;
+    let target = "";
+    const port = await freePort();
+    const home = mkdtempSync(join(tmpdir(), "maw-presence-2773-"));
+    const env = {
+      ...process.env,
+      MAW_HOME: home,
+      MAW_STATE_DIR: join(home, "state"),
+      MAW_CONFIG_DIR: join(home, "config"),
+      MAW_DISABLE_UPDATE_CHECK: "1",
+    };
+    let serve: ReturnType<typeof Bun.spawn> | null = null;
+    let alice: ReturnType<typeof openPresence> | null = null;
+    let bob: ReturnType<typeof openPresence> | null = null;
+
+    run(["tmux", "kill-session", "-t", session], { allowFailure: true, timeout: 2_000 });
+    try {
+      run(["tmux", "new-session", "-d", "-x", "80", "-y", "24", "-s", session, "--", "bash", "-lc", "printf 'presence ready\\n'; sleep 120"], { timeout: 5_000 });
+      await Bun.sleep(300);
+      target = run(["tmux", "list-panes", "-t", session, "-F", "#{pane_id}"], { timeout: 5_000 }).stdout.toString().trim().split("\n")[0] ?? "";
+      if (!target.startsWith("%")) throw new Error(`failed to resolve real smoke pane id for ${session}: ${target || "empty"}`);
+
+      serve = Bun.spawn({ cmd: ["bun", "src/cli.ts", "serve", String(port), "--force-takeover", "-q"], cwd: repo, env, stdout: "pipe", stderr: "pipe" });
+      await waitForHttp(`http://127.0.0.1:${port}/api/identity`);
+      await waitForShareApi(port);
+
+      const shareOut = run(["bun", "src/cli.ts", "share", target, "--presence", "--ttl", "120", "--port", String(port)], { cwd: repo, env, timeout: 10_000 }).stdout.toString();
+      const { slug, token } = parseShareUrl(shareOut, port);
+      const metadata = await fetch(`http://127.0.0.1:${port}/api/share/${encodeURIComponent(slug)}?t=${encodeURIComponent(token)}`);
+      expect(metadata.status).toBe(200);
+      await expect(metadata.json()).resolves.toMatchObject({ presence: true, readOnly: true });
+
+      alice = openPresence(`ws://127.0.0.1:${port}/ws/share/${encodeURIComponent(slug)}/presence?t=${encodeURIComponent(token)}&name=Alice%00%0A`);
+      const one = await alice.next();
+      expect(one).toMatchObject({ type: "presence", slug, count: 1 });
+      expect(one.viewers).toHaveLength(1);
+      expect(one.viewers[0].name).toBe("Alice");
+      expect(one.viewers[0].id).toMatch(/^v_/);
+
+      bob = openPresence(`ws://127.0.0.1:${port}/ws/share/${encodeURIComponent(slug)}/presence?t=${encodeURIComponent(token)}&name=${encodeURIComponent("Bob".repeat(30))}`);
+      const aliceSeesTwo = await alice.next();
+      const bobSeesTwo = await bob.next();
+      for (const message of [aliceSeesTwo, bobSeesTwo]) {
+        expect(message.count).toBe(2);
+        expect(message.viewers.map((viewer) => viewer.name)).toEqual(["Alice", "Bob".repeat(16).slice(0, 48)]);
+        expect(new Set(message.viewers.map((viewer) => viewer.id)).size).toBe(2);
+      }
+
+      await bob.close();
+      bob = null;
+      const aliceSeesLeave = await alice.next();
+      expect(aliceSeesLeave.count).toBe(1);
+      expect(aliceSeesLeave.viewers.map((viewer) => viewer.name)).toEqual(["Alice"]);
+
+      const plainShareOut = run(["bun", "src/cli.ts", "share", target, "--ttl", "120", "--port", String(port)], { cwd: repo, env, timeout: 10_000 }).stdout.toString();
+      const plain = parseShareUrl(plainShareOut, port);
+      const closed = await waitForClose(`ws://127.0.0.1:${port}/ws/share/${encodeURIComponent(plain.slug)}/presence?t=${encodeURIComponent(plain.token)}&name=blocked`);
+      expect(closed.code).toBe(1008);
+    } finally {
+      if (bob) await bob.close().catch(() => undefined);
+      if (alice) await alice.close().catch(() => undefined);
+      if (serve) {
+        serve.kill();
+        await serve.exited.catch(() => undefined);
+      }
+      run(["tmux", "kill-session", "-t", session], { allowFailure: true, timeout: 2_000 });
+      await waitForNoListener(port);
+      const sessionCheck = run(["tmux", "has-session", "-t", session], { allowFailure: true, timeout: 2_000 });
+      expect(sessionCheck.success).toBe(false);
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/test/vendor-share-presence-unit.test.ts
+++ b/test/vendor-share-presence-unit.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  clearPresenceRegistryForTests,
+  joinPresence,
+  leavePresence,
+  openPresenceStateCountForTests,
+  presenceSnapshot,
+  sanitizeViewerName,
+  serve,
+  setPresenceDepsForTests,
+} from "../src/vendor/mpr-plugins/share-presence/index";
+import { createShare, clearShareRegistry } from "../src/vendor/mpr-plugins/share/impl";
+
+function socket() {
+  const sent: string[] = [];
+  return { sent, ws: { send: (payload: string) => { sent.push(payload); } } };
+}
+
+function last(sent: string[]) {
+  return JSON.parse(sent.at(-1) ?? "{}");
+}
+
+describe("share-presence registry", () => {
+  beforeEach(() => {
+    clearPresenceRegistryForTests();
+    clearShareRegistry();
+  });
+
+  test("sanitizes display names with control stripping, cap, and anonymous default", () => {
+    expect(sanitizeViewerName("\0 Nat\n Viewer\t ")).toBe("Nat Viewer");
+    expect(sanitizeViewerName("\x01\x7F")).toBe("anonymous");
+    expect([...sanitizeViewerName("x".repeat(80))]).toHaveLength(48);
+  });
+
+  test("assigns server viewer ids and broadcasts join/leave snapshots", () => {
+    const a = socket();
+    const b = socket();
+    const first = joinPresence("slug-a", a.ws, "nat", 1000);
+    expect("error" in first).toBe(false);
+    if ("error" in first) throw new Error("unexpected join error");
+    expect(first).toMatchObject({ name: "nat", joinedAt: 1000 });
+    expect(first.id).toMatch(/^v_/);
+    expect(last(a.sent)).toMatchObject({ type: "presence", slug: "slug-a", count: 1 });
+
+    const second = joinPresence("slug-a", b.ws, "noah", 2000);
+    expect("error" in second).toBe(false);
+    if ("error" in second) throw new Error("unexpected join error");
+    expect(second.id).toMatch(/^v_/);
+    expect(second.id).not.toBe(first.id);
+    expect(last(a.sent)).toMatchObject({ count: 2 });
+    expect(last(b.sent)).toMatchObject({ count: 2 });
+    expect(presenceSnapshot("slug-a")?.viewers.map((viewer) => viewer.name)).toEqual(["nat", "noah"]);
+
+    leavePresence("slug-a", second.id);
+    expect(last(a.sent)).toMatchObject({ count: 1, viewers: [{ id: first.id, name: "nat", joinedAt: 1000 }] });
+    leavePresence("slug-a", first.id);
+    expect(presenceSnapshot("slug-a")).toBeNull();
+  });
+
+  test("share-presence plugin remains read-only and tmux-free", () => {
+    const source = readFileSync(join(import.meta.dir, "../src/vendor/mpr-plugins/share-presence/index.ts"), "utf8");
+    expect(source.toLowerCase()).not.toContain("tmux");
+    expect(source).not.toContain("sendKeys");
+    expect(source).not.toContain("killPane");
+    expect(source).not.toContain("resizePane");
+  });
+
+  test("closing while token validation is pending leaves no presence state or viewer", async () => {
+    const created = await createShare({ target: "%1", auth: "token", ttl: 60, presence: true });
+    let resolveVerify: ((ok: boolean) => void) | null = null;
+    setPresenceDepsForTests({
+      verifyShare: () => new Promise<boolean>((resolve) => { resolveVerify = resolve; }),
+    });
+
+    let handlers: { open: (ws: any) => void; close: (ws: any) => void } | null = null;
+    await serve({
+      ws: {
+        route: (_pattern: string, _data: unknown, next: typeof handlers) => { handlers = next; },
+      },
+    } as any);
+    if (!handlers) throw new Error("presence ws handlers were not registered");
+
+    const sent: string[] = [];
+    const closed: Array<{ code: number; reason: string }> = [];
+    const ws = {
+      data: {
+        params: { slug: created.slug },
+        shareSlug: created.slug,
+        shareToken: created.token,
+        viewerName: "race",
+      },
+      send: (payload: string) => { sent.push(payload); },
+      close: (code: number, reason: string) => { closed.push({ code, reason }); },
+    };
+
+    handlers.open(ws);
+    expect(openPresenceStateCountForTests()).toBe(1);
+    handlers.close(ws);
+    expect(openPresenceStateCountForTests()).toBe(0);
+    expect(presenceSnapshot(created.slug)).toBeNull();
+
+    resolveVerify?.(true);
+    await Bun.sleep(0);
+
+    expect(openPresenceStateCountForTests()).toBe(0);
+    expect(presenceSnapshot(created.slug)).toBeNull();
+    expect(sent).toEqual([]);
+    expect(closed).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #2773
Part of #2752

## Summary
- add opt-in share-presence serve plugin for read-only viewer join/leave bookkeeping
- wire maw share --presence to mint presence-enabled metadata
- add unit, standalone boundary, and real-entry smoke coverage

## Verification
- 5x timeout 120 bun test test/vendor-share-control-viewer-real-entry-smoke.test.ts
- 5x timeout 120 bun test test/vendor-share-presence-real-entry-smoke.test.ts
- timeout 120 bun test test/vendor-share-presence-unit.test.ts test/vendor-share-presence-real-entry-smoke.test.ts test/isolated/plugin-share-presence-standalone.test.ts test/isolated/plugin-share-standalone.test.ts
- timeout 120 bun run build
- timeout 120 bun scripts/check-plugin-coverage-gate.ts origin/alpha
- timeout 650 bun run test

## Notes
- tsc skipped: repo intentionally has no tsconfig.json
