### PR TITLE
fix: close share streams when websocket setup races disconnect (#2777)

### DIFF
--- a/src/vendor/mpr-plugins/share/index.ts
+++ b/src/vendor/mpr-plugins/share/index.ts
@@ -28,8 +28,24 @@ type ShareWsData = ServeWsData & {
 
 type ShareOpenState = {
   slug: string;
-  handle: ShareStreamHandle;
+  handle: ShareStreamHandle | null;
+  closing: boolean;
 };
+
+type ShareWsDeps = {
+  verifyShare: typeof verifyShare;
+  attach: typeof attach;
+};
+
+let shareWsDeps: ShareWsDeps = { verifyShare, attach };
+
+export function setShareWsDepsForTests(next: Partial<ShareWsDeps>): () => void {
+  const previous = shareWsDeps;
+  shareWsDeps = { ...shareWsDeps, ...next };
+  return () => {
+    shareWsDeps = previous;
+  };
+}
 
 type ShareMetadata = {
   target: string;
@@ -111,16 +127,51 @@ async function openShareWebSocket(
   }
 
   const share = getShare(slug);
-  if (!share || !(await verifyShare(slug, token))) {
+  if (!share) {
+    ws.close(1008, "invalid or expired share token");
+    return;
+  }
+
+  states.set(ws, { slug, handle: null, closing: false });
+
+  let verified: boolean;
+  try {
+    verified = await shareWsDeps.verifyShare(slug, token);
+  } catch (error: unknown) {
+    const state = states.get(ws);
+    states.delete(ws);
+    if (!state?.closing) {
+      ws.close(1011, error instanceof Error ? error.message : "share token verification failed");
+    }
+    return;
+  }
+
+  const verifiedState = states.get(ws);
+  if (!verifiedState || verifiedState.closing) {
+    states.delete(ws);
+    return;
+  }
+  if (!verified) {
+    states.delete(ws);
     ws.close(1008, "invalid or expired share token");
     return;
   }
 
   try {
-    const handle = await attach(share, ws);
-    states.set(ws, { slug, handle });
+    const handle = await shareWsDeps.attach(share, ws);
+    const attachedState = states.get(ws);
+    if (!attachedState || attachedState.closing) {
+      states.delete(ws);
+      await handle.close();
+      return;
+    }
+    attachedState.handle = handle;
   } catch (error: unknown) {
-    ws.close(1011, error instanceof Error ? error.message : "share stream failed");
+    const state = states.get(ws);
+    states.delete(ws);
+    if (!state?.closing) {
+      ws.close(1011, error instanceof Error ? error.message : "share stream failed");
+    }
   }
 }
 
@@ -266,14 +317,15 @@ export async function serve(ctx: ServeHookContext): Promise<{ ok: true } | { ok:
         ws.send("pong");
         return;
       }
-      if (!state) return;
+      if (!state?.handle) return;
       state.handle.onMessage(message);
     },
     close: (ws) => {
       const state = openStreams.get(ws);
       if (!state) return;
-      void state.handle.close();
+      state.closing = true;
       openStreams.delete(ws);
+      void state.handle?.close();
     },
   });
 

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -102,6 +102,10 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
 
     const index = readFileSync(join(root, "src/vendor/mpr-plugins/share/index.ts"), "utf8");
     expect(index).toContain("export async function serve");
+    expect(index).toContain("export function setShareWsDepsForTests");
+    expect(index).toContain("closing: false");
+    expect(index).toContain("await handle.close()");
+    expect(index).toContain("void state.handle?.close()");
     expect(index).toContain("export default async function handler");
     expect(index).toContain('"--control": Boolean');
     expect(index).toContain("controlToken");
@@ -159,6 +163,57 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
 
     const readonly = await shareImpl.createShare({ target: "%read", readOnly: true });
     expect(shareImpl.verifyShareControlToken(readonly.slug, "%read", created.controlToken!)).toMatchObject({ ok: false, reason: "share_read_only", status: 403 });
+  });
+
+
+  test("websocket close before attach resolves tears down the late stream handle", async () => {
+    let resolveAttach: ((handle: any) => void) | null = null;
+    let handleCloseCalls = 0;
+    const restore = sharePlugin.setShareWsDepsForTests({
+      attach: async () => new Promise((resolve) => {
+        resolveAttach = resolve;
+      }),
+    });
+
+    try {
+      const { httpRoutes, wsRoutes } = await makeServeHarness();
+      const createRoute = httpRoutes.find((entry) => entry.method === "POST" && entry.path === "/api/share")!;
+      const createRes = await createRoute.handler(new Request("http://local/api/share", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ target: "%race", ttl: 60 }),
+      }));
+      expect(createRes.status).toBe(200);
+      const created = await createRes.json() as { slug: string; token: string };
+      const route = wsRoutes.find((entry) => entry.path === "/ws/share/:slug")!;
+      const sent: string[] = [];
+      const closes: Array<[number, string | undefined]> = [];
+      const ws = {
+        data: { params: { slug: created.slug }, shareSlug: created.slug, shareToken: created.token },
+        send: (data: string) => sent.push(data),
+        close: (code: number, reason?: string) => closes.push([code, reason]),
+      };
+
+      (route.handlers.open as (ws: any) => void)(ws);
+      for (let i = 0; i < 10 && !resolveAttach; i += 1) await Promise.resolve();
+      expect(resolveAttach).toBeFunction();
+
+      (route.handlers.close as (ws: any) => void)(ws);
+      resolveAttach!({
+        onMessage: () => undefined,
+        close: async () => {
+          handleCloseCalls += 1;
+        },
+      });
+      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+
+      expect(handleCloseCalls).toBe(1);
+      expect(closes).toEqual([]);
+      (route.handlers.message as (ws: any, message: unknown) => void)(ws, "ping");
+      expect(sent).toEqual([]);
+    } finally {
+      restore();
+    }
   });
 
   test("stream default deps preserve real Tmux prototype methods", () => {

--- a/test/vendor-share-readonly.test.ts
+++ b/test/vendor-share-readonly.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { __resetShareStreamBusesForTests, __resolveShareStreamDepsForTests, attach } from "../src/vendor/mpr-plugins/share/stream";
-import type { Share } from "../src/vendor/mpr-plugins/share/impl";
+import { serve, setShareWsDepsForTests } from "../src/vendor/mpr-plugins/share/index";
+import { clearShareRegistry, createShare, type Share } from "../src/vendor/mpr-plugins/share/impl";
+import { __resetShareStreamBusesForTests, __resolveShareStreamDepsForTests, attach, type ShareStreamHandle } from "../src/vendor/mpr-plugins/share/stream";
 
 type WsMessage = string | Uint8Array;
 type FakeWs = {
@@ -36,12 +37,81 @@ describe("share readonly stream", () => {
   let captures: string[] = [];
   let sendKeysCalls: number = 0;
 
+  let restoreShareWsDeps: (() => void) | null = null;
+
   beforeEach(() => {
+    restoreShareWsDeps?.();
+    restoreShareWsDeps = null;
+    clearShareRegistry();
     __resetShareStreamBusesForTests();
     killCalls = [];
     pipeCalls = [];
     captures = [];
     sendKeysCalls = 0;
+  });
+
+  afterEach(() => {
+    restoreShareWsDeps?.();
+    restoreShareWsDeps = null;
+    clearShareRegistry();
+  });
+
+
+  test("websocket close before attach resolves closes late stream handle", async () => {
+    const share = await createShare({ target: "session:0", ttl: 60 });
+    let resolveAttach: ((handle: ShareStreamHandle) => void) | null = null;
+    let handleCloseCalls = 0;
+    const lateHandle: ShareStreamHandle = {
+      onMessage: () => undefined,
+      close: async () => {
+        handleCloseCalls += 1;
+      },
+    };
+
+    restoreShareWsDeps = setShareWsDepsForTests({
+      attach: async () => new Promise<ShareStreamHandle>((resolve) => {
+        resolveAttach = resolve;
+      }),
+    });
+
+    let handlers: {
+      open: (ws: any) => void;
+      message: (ws: any, message: unknown) => void;
+      close: (ws: any) => void;
+    } | null = null;
+
+    await serve({
+      http: {
+        route: () => undefined,
+      },
+      ws: {
+        route: (_path: string, _data: unknown, next: typeof handlers) => {
+          handlers = next;
+        },
+      },
+    } as any);
+
+    const sent: string[] = [];
+    const closes: Array<[number, string | undefined]> = [];
+    const ws = {
+      data: { params: { slug: share.slug }, shareSlug: share.slug, shareToken: share.token },
+      send: (data: string) => sent.push(data),
+      close: (code: number, reason?: string) => closes.push([code, reason]),
+    };
+
+    handlers!.open(ws);
+    for (let i = 0; i < 10 && !resolveAttach; i += 1) await Promise.resolve();
+    expect(resolveAttach).toBeFunction();
+    handlers!.close(ws);
+
+    resolveAttach!(lateHandle);
+    for (let i = 0; i < 5; i += 1) await Promise.resolve();
+
+    expect(handleCloseCalls).toBe(1);
+    expect(closes).toEqual([]);
+
+    handlers!.message(ws, "ping");
+    expect(sent).toEqual([]);
   });
 
   test("default stream deps preserve real Tmux prototype methods", () => {


### PR DESCRIPTION
Closes #2777

## Summary
- register share websocket placeholder state before async token validation/attach
- mark sockets closing on close and close any late stream handle immediately
- add unit + standalone boundary regression for close-before-attach-resolves

## Verification
- timeout 120 bun test test/vendor-share-readonly.test.ts test/vendor-share-real-entry-smoke.test.ts test/isolated/plugin-share-standalone.test.ts
- timeout 120 bun run build
- timeout 120 bun scripts/check-plugin-coverage-gate.ts origin/alpha
- timeout 650 bun run test (rerun green; first run hit unrelated #2056 comm-send 10s timeout)