### PR TITLE
fix: prune unbounded federation maintenance maps

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -7,6 +7,32 @@ import { fleetDirForWrite, fleetDirsForRead, uniqueDirs } from "../core/fleet/pa
 
 // Rate limit: max 5 attempts per IP per minute
 const pinAttempts = new Map<string, { count: number; resetAt: number }>();
+export const MAX_PIN_ATTEMPTS_ENTRIES = 1_000;
+
+export function prunePinAttempts(
+  attempts: Map<string, { count: number; resetAt: number }> = pinAttempts,
+  now: number = Date.now(),
+  maxEntries: number = MAX_PIN_ATTEMPTS_ENTRIES,
+): number {
+  let pruned = 0;
+  for (const [key, entry] of attempts) {
+    if (now > entry.resetAt) {
+      attempts.delete(key);
+      pruned++;
+    }
+  }
+  if (attempts.size > maxEntries) {
+    const overflow = attempts.size - maxEntries;
+    const oldest = [...attempts.entries()]
+      .sort(([, a], [, b]) => a.resetAt - b.resetAt)
+      .slice(0, overflow);
+    for (const [key] of oldest) {
+      attempts.delete(key);
+      pruned++;
+    }
+  }
+  return pruned;
+}
 
 export interface ConfigApiDeps {
   readdirSync?: typeof readdirSync;

--- a/src/api/pair.ts
+++ b/src/api/pair.ts
@@ -16,7 +16,19 @@ import { getPeerKey } from "../lib/peer-key";
 import { signAutoPairProof, type AutoPairIdentity } from "../transports/scout-pair-proof";
 
 const DEFAULT_TTL_MS = 120_000;
+export const PAIR_RESULT_TTL_MS = DEFAULT_TTL_MS;
 const results = new Map<string, { consumedAt: number; remoteNode: string; remoteUrl: string }>();
+
+export function prunePairResults(now: number = Date.now(), ttlMs: number = PAIR_RESULT_TTL_MS): number {
+  let pruned = 0;
+  for (const [code, rec] of results) {
+    if (now - rec.consumedAt > ttlMs) {
+      results.delete(code);
+      pruned++;
+    }
+  }
+  return pruned;
+}
 
 export interface PairApiDeps {
   loadConfig: typeof loadConfig;
@@ -58,6 +70,10 @@ export function _resetResults(): void {
   results.clear();
   recentHellos.clear();
 }
+export function _injectResult(code: string, rec: { consumedAt: number; remoteNode: string; remoteUrl: string }): void {
+  results.set(normalize(code), rec);
+}
+export function _resultSize(): number { return results.size; }
 
 export function createPairApi(deps: PairApiDeps = {
   loadConfig,

--- a/src/lib/pair-codes.ts
+++ b/src/lib/pair-codes.ts
@@ -67,5 +67,17 @@ export function consume(code: string): LookupResult {
   return r;
 }
 
+export function prunePairCodes(now: number = Date.now()): number {
+  let pruned = 0;
+  for (const [code, entry] of store) {
+    if (entry.consumed || now > entry.expiresAt) {
+      store.delete(code);
+      pruned++;
+    }
+  }
+  return pruned;
+}
+
 export function _resetStore(): void { store.clear(); }
 export function _inject(entry: PairEntry): void { store.set(entry.code, entry); }
+export function _storeSize(): number { return store.size; }

--- a/src/transports/scout.ts
+++ b/src/transports/scout.ts
@@ -349,10 +349,27 @@ export class ScoutTransport implements Transport {
 
   private pruneStale(): void {
     const removed = this.state.pruneStale();
+    this.prunePairFailures();
     for (const node of removed) {
       console.log(`[scout] peer gone: ${node}`);
       this.emitPresence(node, "", "offline");
     }
+  }
+
+  private prunePairFailures(): number {
+    const active = new Set<string>();
+    for (const peer of this.state.discoveredPeers.values()) {
+      active.add(peer.node || peer.zid);
+      active.add(peer.zid);
+    }
+    let pruned = 0;
+    for (const key of this.pairFailures.keys()) {
+      if (!active.has(key)) {
+        this.pairFailures.delete(key);
+        pruned++;
+      }
+    }
+    return pruned;
   }
 
   private loadExistingPeers(): void {

--- a/src/vendor-plugins/serve-maintenance/index.ts
+++ b/src/vendor-plugins/serve-maintenance/index.ts
@@ -3,6 +3,9 @@ import { sweepOrphanPtySessions as defaultSweepOrphanPtySessions } from "../../c
 import { messageQueue as defaultMessageQueue } from "../../core/message-queue";
 import { requestReplyStore as defaultRequestReplyStore } from "../../core/request-reply";
 import { agentStatusStore as defaultAgentStatusStore } from "../../core/agent-status";
+import { prunePinAttempts as defaultPrunePinAttempts } from "../../api/config";
+import { prunePairCodes as defaultPrunePairCodes } from "../../lib/pair-codes";
+import { prunePairResults as defaultPrunePairResults } from "../../api/pair";
 
 type ServeLog = {
   info?: (...args: unknown[]) => void;
@@ -24,6 +27,9 @@ type ServeMaintenanceDeps = {
   messageQueue: Prunable;
   requestReplyStore: Prunable;
   agentStatusStore: Prunable;
+  prunePinAttempts: () => unknown;
+  prunePairCodes: () => unknown;
+  prunePairResults: () => unknown;
   setInterval: SetIntervalFn;
 };
 
@@ -33,6 +39,9 @@ const defaultDeps: ServeMaintenanceDeps = {
   messageQueue: defaultMessageQueue,
   requestReplyStore: defaultRequestReplyStore,
   agentStatusStore: defaultAgentStatusStore,
+  prunePinAttempts: defaultPrunePinAttempts,
+  prunePairCodes: defaultPrunePairCodes,
+  prunePairResults: defaultPrunePairResults,
   setInterval: (handler, timeout) => setInterval(handler, timeout) as TimerHandle,
 };
 
@@ -66,6 +75,9 @@ export function startServeMemoryMaintenance(
     try { d.messageQueue.prune(); } catch { /* best effort */ }
     try { d.requestReplyStore.prune(); } catch { /* best effort */ }
     try { d.agentStatusStore.prune(); } catch { /* best effort */ }
+    try { d.prunePinAttempts(); } catch { /* best effort */ }
+    try { d.prunePairCodes(); } catch { /* best effort */ }
+    try { d.prunePairResults(); } catch { /* best effort */ }
   }, 60_000);
   unrefTimer(timer);
   return timer;

--- a/src/vendor/mpr-plugins/pair/codes.ts
+++ b/src/vendor/mpr-plugins/pair/codes.ts
@@ -67,5 +67,17 @@ export function consume(code: string): LookupResult {
   return r;
 }
 
+export function prunePairCodes(now: number = Date.now()): number {
+  let pruned = 0;
+  for (const [code, entry] of store) {
+    if (entry.consumed || now > entry.expiresAt) {
+      store.delete(code);
+      pruned++;
+    }
+  }
+  return pruned;
+}
+
 export function _resetStore(): void { store.clear(); }
 export function _inject(entry: PairEntry): void { store.set(entry.code, entry); }
+export function _storeSize(): number { return store.size; }

--- a/test/federation-map-prune.test.ts
+++ b/test/federation-map-prune.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { prunePinAttempts } from "../src/api/config";
+import { _inject, _resetStore, _storeSize, lookup, prunePairCodes, type PairEntry } from "../src/lib/pair-codes";
+import { _injectResult, _resetResults, _resultSize, prunePairResults } from "../src/api/pair";
+import { ScoutTransport } from "../src/transports/scout";
+import { ScoutState } from "../src/transports/scout-state";
+import { makeHello } from "../src/transports/scout-protocol";
+import { startServeMemoryMaintenance } from "../src/vendor-plugins/serve-maintenance";
+
+describe("federation map pruning", () => {
+  beforeEach(() => {
+    _resetStore();
+    _resetResults();
+  });
+
+  test("prunePinAttempts evicts expired attempts and caps live cardinality", () => {
+    const attempts = new Map<string, { count: number; resetAt: number }>([
+      ["expired", { count: 5, resetAt: 900 }],
+      ["live-old", { count: 1, resetAt: 2_000 }],
+      ["live-new", { count: 1, resetAt: 3_000 }],
+    ]);
+
+    expect(prunePinAttempts(attempts, 1_000, 1)).toBe(2);
+    expect([...attempts.keys()]).toEqual(["live-new"]);
+  });
+
+  test("prunePairCodes evicts expired and consumed codes while keeping live codes", () => {
+    const entry = (code: string, expiresAt: number, consumed = false): PairEntry => ({
+      code,
+      expiresAt,
+      consumed,
+      createdAt: 1,
+    });
+    _inject(entry("ABCDEF", 900));
+    _inject(entry("GHJKLM", 2_000, true));
+    _inject(entry("NPQRST", 9_999_999_999_999));
+
+    expect(prunePairCodes(1_000)).toBe(2);
+    expect(_storeSize()).toBe(1);
+    expect(lookup("NPQRST").ok).toBe(true);
+    expect(lookup("ABCDEF")).toEqual({ ok: false, reason: "not_found" });
+  });
+
+  test("prunePairResults evicts stale status results and keeps fresh polling results", () => {
+    _injectResult("ABCDEF", { consumedAt: 1_000, remoteNode: "old", remoteUrl: "http://old" });
+    _injectResult("GHJKLM", { consumedAt: 4_500, remoteNode: "live", remoteUrl: "http://live" });
+
+    expect(prunePairResults(5_000, 2_000)).toBe(1);
+    expect(_resultSize()).toBe(1);
+  });
+
+  test("ScoutTransport stale sweep prunes pair failures for gone peers only", () => {
+    const transport: any = new ScoutTransport({ node: "local", port: 3456, autoPair: true });
+    transport.state = new ScoutState("zz-local");
+    transport.state.handleHello(makeHello({
+      zid: "z-live",
+      node: "live-node",
+      oracle: "live-oracle",
+      locators: ["http://live:3456"],
+      capabilities: ["pair"],
+      oracles: ["live-oracle"],
+    }), "10.0.0.2");
+    transport.state.handleHello(makeHello({
+      zid: "z-old",
+      node: "old-node",
+      oracle: "old-oracle",
+      locators: ["http://old:3456"],
+      capabilities: ["pair"],
+      oracles: ["old-oracle"],
+    }), "10.0.0.3");
+    transport.state.discoveredPeers.get("z-old")!.lastSeen = Date.now() - 31_000;
+    transport.pairFailures.set("live-node", { count: 1, cooldownUntil: Date.now() + 10_000, lastError: "live", cooldownLogged: false });
+    transport.pairFailures.set("old-node", { count: 1, cooldownUntil: Date.now() + 10_000, lastError: "old", cooldownLogged: false });
+
+    transport.pruneStale();
+
+    expect(transport.pairFailures.has("live-node")).toBe(true);
+    expect(transport.pairFailures.has("old-node")).toBe(false);
+  });
+
+  test("serve memory maintenance reuses the existing timer for federation pruners", () => {
+    const calls: string[] = [];
+    let handler: (() => void) | null = null;
+    startServeMemoryMaintenance({
+      messageQueue: { prune: () => calls.push("message") },
+      requestReplyStore: { prune: () => calls.push("request") },
+      agentStatusStore: { prune: () => calls.push("agent") },
+      prunePinAttempts: () => calls.push("pin") ,
+      prunePairCodes: () => calls.push("codes"),
+      prunePairResults: () => calls.push("results"),
+      setInterval: (fn) => { handler = fn; return { unref: () => calls.push("unref") }; },
+    });
+
+    handler?.();
+
+    expect(calls).toEqual(["unref", "message", "request", "agent", "pin", "codes", "results"]);
+  });
+});

--- a/test/isolated/plugin-pair-standalone.test.ts
+++ b/test/isolated/plugin-pair-standalone.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+import {
+  _inject,
+  _resetStore,
+  _storeSize,
+  consume,
+  lookup,
+  normalize,
+  prunePairCodes,
+  register,
+} from "../../src/vendor/mpr-plugins/pair/codes.ts?plugin-pair-standalone";
+
+const root = join(import.meta.dir, "../..");
+
+describe("pair plugin standalone boundary", () => {
+  test("declares the pair CLI surface", () => {
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/pair/plugin.json"), "utf8"));
+    expect(manifest).toMatchObject({
+      name: "pair",
+      entry: "./index.ts",
+      cli: {
+        command: "pair",
+        aliases: [],
+      },
+    });
+  });
+
+  test("boundary drift is explicit for the vendored pair plugin", () => {
+    expectStandalonePluginBoundary({
+      plugin: "pair",
+      requireSdk: false,
+      allowMawJs: ["maw-js/config"],
+      allowRelative: [
+        /^\.\.\/\.\.\/\.\.\/\.\.\/core\/xdg$/,
+      ],
+    });
+  });
+
+  test("pair code store exposes prune behavior through the plugin boundary", () => {
+    _resetStore();
+    const now = Date.now();
+    _inject({ code: "AAAAAA", createdAt: now - 10_000, expiresAt: now - 1, consumed: false });
+    _inject({ code: "BBBBBB", createdAt: now - 10_000, expiresAt: now + 60_000, consumed: true });
+    _inject({ code: "CCCCCC", createdAt: now, expiresAt: now + 60_000, consumed: false });
+
+    expect(prunePairCodes(now)).toBe(2);
+    expect(_storeSize()).toBe(1);
+    expect(lookup("CCC-CCC")).toEqual({
+      ok: true,
+      entry: { code: "CCCCCC", createdAt: now, expiresAt: now + 60_000, consumed: false },
+    });
+  });
+
+  test("normal code lifecycle still registers, normalizes, and consumes", () => {
+    _resetStore();
+    const entry = register("abc-def", 60_000);
+    expect(entry.code).toBe("ABCDEF");
+    expect(normalize("abc-def")).toBe("ABCDEF");
+    expect(consume("ABCDEF")).toMatchObject({ ok: true });
+    expect(lookup("ABCDEF")).toEqual({ ok: false, reason: "consumed" });
+  });
+});

--- a/test/isolated/plugin-serve-maintenance-standalone.test.ts
+++ b/test/isolated/plugin-serve-maintenance-standalone.test.ts
@@ -46,6 +46,9 @@ describe("serve-maintenance plugin standalone boundary", () => {
         /^\.\.\/\.\.\/core\/message-queue$/,
         /^\.\.\/\.\.\/core\/request-reply$/,
         /^\.\.\/\.\.\/core\/agent-status$/,
+        /^\.\.\/\.\.\/api\/config$/,
+        /^\.\.\/\.\.\/lib\/pair-codes$/,
+        /^\.\.\/\.\.\/api\/pair$/,
       ],
     });
   });
@@ -93,12 +96,15 @@ describe("serve-maintenance plugin standalone boundary", () => {
       messageQueue: { prune: () => { calls.push("message"); } },
       requestReplyStore: { prune: () => { calls.push("request"); throw new Error("ignore"); } },
       agentStatusStore: { prune: () => { calls.push("status"); } },
+      prunePinAttempts: () => { calls.push("pin"); },
+      prunePairCodes: () => { calls.push("codes"); throw new Error("ignore"); },
+      prunePairResults: () => { calls.push("results"); },
     });
 
     expect(timer.intervals).toEqual([60_000]);
     expect(timer.unrefCount).toBe(1);
     timer.handlers[0]();
-    expect(calls).toEqual(["message", "request", "status"]);
+    expect(calls).toEqual(["message", "request", "status", "pin", "codes", "results"]);
   });
 
   test("serve hook starts both maintenance timers", () => {


### PR DESCRIPTION
Closes #2779

Reuses existing maintenance sweeps to bound federation bookkeeping maps without changing live federation behavior:
- pinAttempts pruned/capped from serve-maintenance
- pair code/result stores pruned from serve-maintenance
- Scout pairFailures pruned during the existing stale-peer sweep

Verification:
- bun test test/federation-map-prune.test.ts
- bash scripts/test-isolated.sh test/isolated/plugin-serve-maintenance-standalone.test.ts
- bun run build
- bun run test

Note: full local bun run test:coverage currently hits unrelated alpha isolated failures in comm-send/team coverage files; the serve-maintenance boundary failure introduced by this change was fixed and passes targeted.