### PR TITLE
fix: require fleet HMAC for from-signed writes (#2776)

### DIFF
--- a/src/lib/elysia-auth.ts
+++ b/src/lib/elysia-auth.ts
@@ -292,12 +292,14 @@ export const federationAuth = new Elysia({ name: "federation-auth" })
     // pass-through so fresh single-node installs work unchanged.
     if (!token) return;
 
-    // #804 Step 4: when the request carries `x-maw-from`, the from-signing
-    // layer owns the `x-maw-signature` slot and is verified by
-    // `fromSigningAuth` (mounted alongside this plugin). Defer to it — the
-    // fleet HMAC layer would otherwise reject the from-sig as a malformed
-    // HMAC since it's keyed on `peerKey`, not `federationToken`.
-    if (request.headers.get("x-maw-from")) return;
+    // #2776 / Option A: `x-maw-from` is peer-continuity identity, not fleet
+    // admission. When a receiver has `federationToken` configured, every
+    // protected non-loopback federation write must still pass the shared-token
+    // HMAC below. Current v3 senders stack both signatures on separate slots:
+    //   - x-maw-signature    : fleet token HMAC
+    //   - x-maw-signature-v3 : per-peer from-signing HMAC
+    // Let `fromSigningAuth` run after this layer to verify/record peer
+    // continuity, but do not let a self-signed unknown peer skip token HMAC.
 
     // Check for HMAC signature
     const sig = request.headers.get("x-maw-signature");

--- a/test/isolated/elysia-auth-extra-coverage.test.ts
+++ b/test/isolated/elysia-auth-extra-coverage.test.ts
@@ -56,6 +56,13 @@ function fromAuthApp(): Elysia {
     .get("/sessions", () => ({ ok: true, route: "sessions" }));
 }
 
+function fullAuthSendApp(): Elysia {
+  return new Elysia({ prefix: "/api" })
+    .use(federationAuth)
+    .use(fromSigningAuth)
+    .post("/send", () => ({ ok: true, route: "send" }));
+}
+
 function fullAuthPaneKeysApp(): Elysia {
   return new Elysia({ prefix: "/api" })
     .use(federationAuth)
@@ -192,10 +199,23 @@ describe("federationAuth — HMAC success and error branches", () => {
     expect(await res.json()).toMatchObject({ ok: true, route: "download" });
   });
 
-  test("x-maw-from lets HMAC layer defer instead of rejecting the from-signature slot", async () => {
+  test("#2776: x-maw-from no longer skips token HMAC when federationToken is configured", async () => {
     const res = await hmacApp().handle(new Request("http://localhost/api/send", {
       method: "POST",
-      headers: { "x-maw-from": "oracle:peer-node", "x-maw-signature": "not-a-fleet-hmac" },
+      headers: fromSignatureHeaders({ body: "{}" }),
+      body: "{}",
+    }));
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "federation auth required", reason: "missing_signature" });
+  });
+
+  test("no federationToken configured keeps single-node passthrough even with x-maw-from", async () => {
+    configState = { node: "local" };
+
+    const res = await hmacApp().handle(new Request("http://localhost/api/send", {
+      method: "POST",
+      headers: fromSignatureHeaders({ body: "{}" }),
       body: "{}",
     }));
 
@@ -249,16 +269,68 @@ describe("fromSigningAuth — per-peer continuity branches", () => {
     expect(await res.json()).toMatchObject({ ok: true, route: "send" });
   });
 
-  test("/api/pane-keys accepts current v3 from-signing headers even with fleet-HMAC signature noise (#1859)", async () => {
+  test("#2776 proof: self-signed unknown peer without fleet token is rejected before protected action", async () => {
+    const body = JSON.stringify({ hello: "attacker" });
+    const res = await fullAuthSendApp().handle(new Request("http://localhost/api/send", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...fromSignatureHeaders({ body, secret: "attacker-owned-key" }),
+      },
+      body,
+    }));
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "federation auth required", reason: "missing_signature" });
+  });
+
+  test("#2776 legit fleet member with token HMAC plus uncached v3 from-signature passes TOFU bootstrap", async () => {
+    const body = JSON.stringify({ hello: "legit-tofu" });
+    const timestamp = Math.floor(Date.now() / 1000);
+    const res = await fullAuthSendApp().handle(new Request("http://localhost/api/send", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...signedHeaders("POST", "/api/send", timestamp),
+        ...fromSignatureHeaders({ body, timestamp }),
+      },
+      body,
+    }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, route: "send" });
+  });
+
+  test("#2776 cached peer with unsigned from-address remains refused by O6 row 3", async () => {
+    peersState = { peer: { node: "peer-node", pubkey: PEER_SECRET } };
+    const res = await fromAuthApp().handle(new Request("http://localhost/api/send", {
+      method: "POST",
+      headers: {
+        "x-maw-from": "oracle:peer-node",
+      },
+      body: "{}",
+    }));
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({
+      error: "from-signing failed",
+      kind: "refuse-unsigned",
+      reason: "cache-no-sig",
+      from: "oracle:peer-node",
+    });
+  });
+
+  test("/api/pane-keys accepts current v3 from-signing headers stacked with fleet-HMAC (#1859, #2776)", async () => {
     peersState = { peer: { node: "peer-node", pubkey: PEER_SECRET } };
     const body = JSON.stringify({ target: "origin_discord:0", text: "test", enter: true });
+    const timestamp = Math.floor(Date.now() / 1000);
 
     const res = await fullAuthPaneKeysApp().handle(new Request("http://localhost/api/pane-keys", {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "x-maw-signature": "0".repeat(64),
-        ...fromSignatureHeaders({ path: "/api/pane-keys", body }),
+        ...signedHeaders("POST", "/api/pane-keys", timestamp),
+        ...fromSignatureHeaders({ path: "/api/pane-keys", body, timestamp }),
       },
       body,
     }));


### PR DESCRIPTION
Closes #2776

## Summary
- Require the shared `federationToken` HMAC for protected non-loopback federation writes even when `x-maw-from` is present.
- Keep loopback bypass and receiver-without-token single-node passthrough unchanged.
- Preserve v3 identity continuity as a second layer by stacking `X-Maw-Signature` (fleet token) with `X-Maw-Signature-V3` (from-signing).

## Design note
Option A reinforces the current federation model: every federation peer must share `federationToken` for fleet admission. This intentionally closes token-less v3-only federation for protected writes. If we want identity-only federation later, that should be a separate explicit design, not an accidental bypass.

## Tests
- `timeout 90 bash scripts/test-isolated.sh test/isolated/elysia-auth-extra-coverage.test.ts`
- `timeout 120 bash scripts/test-isolated.sh test/isolated/from-signing-verify.test.ts test/isolated/from-signing-outgoing.test.ts test/isolated/elysia-auth-global-scope.test.ts test/isolated/elysia-auth-extra-coverage.test.ts`
- `timeout 300 bun run test`
- Coverage-equivalent gate: `test-default-safe` + `test-isolated --timeout=10000 --coverage` + mock smoke + plugin coverage + merge/gap/badge
- `timeout 180 bun run build`

Note: unmodified `bun run test:coverage` still uses Bun's default 5s per-test timeout and repeatedly flakes on existing comm-send coverage tests; rerunning those files passes, and the coverage-equivalent run above is green with `--timeout=10000`.
