### PR TITLE
fix: fail loud on corrupt trust stores (#2788)

### DIFF
--- a/src/commands/shared/scope-acl.ts
+++ b/src/commands/shared/scope-acl.ts
@@ -169,9 +169,9 @@ export function loadAllScopes(): TScope[] {
  * the file. Mirrors the relationship between `loadAllScopes()` (this
  * module) and `cmdList()` (the scope plugin).
  *
- * Returns `[]` when the file is missing, malformed, or unreadable —
- * forgiving semantics so an operator who's never written a trust entry
- * still gets a working ACL evaluator. The on-disk shape carries an
+ * Returns `[]` when the file is missing, malformed, or unreadable. Missing
+ * stays quiet for fresh installs; malformed/unreadable files are warned and
+ * quarantined by `loadTrustStore()`. The on-disk shape carries an
  * `addedAt` field that this function strips before returning, so the
  * result is assignable to `TrustList` (which only requires
  * `sender` / `target`). TypeScript's structural typing accepts the

--- a/src/core/consent/store.ts
+++ b/src/core/consent/store.ts
@@ -88,18 +88,41 @@ export interface PendingRequest {
 
 function emptyTrust(): TrustFile { return { version: 1, trust: {} }; }
 
+function corruptTrustPath(path: string, attempt = 0): string {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const candidate = `${path}.corrupt-${stamp}${attempt ? `-${attempt}` : ""}`;
+  return existsSync(candidate) ? corruptTrustPath(path, attempt + 1) : candidate;
+}
+
+function quarantineCorruptTrust(path: string, reason: string): void {
+  const dest = corruptTrustPath(path);
+  try {
+    renameSync(path, dest);
+    console.warn(`[consent-trust] trust store at ${path} is corrupt/unreadable (${reason}); moved aside to ${dest}; starting with empty trust`);
+  } catch (error) {
+    const moveReason = error instanceof Error ? error.message : String(error);
+    console.warn(`[consent-trust] trust store at ${path} is corrupt/unreadable (${reason}); failed to move aside (${moveReason}); starting with empty trust`);
+  }
+}
+
 export function loadTrust(): TrustFile {
   const path = readableTrustPath();
   if (!path) return emptyTrust();
   try {
     const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<TrustFile>;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return emptyTrust();
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      quarantineCorruptTrust(path, "invalid shape: expected object");
+      return emptyTrust();
+    }
     const trust = (parsed as { trust?: unknown }).trust;
     if (trust !== undefined && (typeof trust !== "object" || trust === null || Array.isArray(trust))) {
+      quarantineCorruptTrust(path, "invalid shape: expected trust object");
       return emptyTrust();
     }
     return { version: 1, trust: (trust ?? {}) as Record<string, TrustEntry> };
-  } catch {
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    quarantineCorruptTrust(path, reason);
     return emptyTrust();
   }
 }

--- a/src/lib/trust-store.ts
+++ b/src/lib/trust-store.ts
@@ -12,8 +12,9 @@
  * vendored copy is the canonical location for the helper logic; the plugin
  * (if it survives at all) becomes a thin CLI dispatcher.
  *
- * Forgiving load semantics — missing file, corrupt JSON, or wrong shape
- * all fall back to `[]` rather than throwing. Atomic writes via tmp +
+ * Fail-loud load semantics — missing file falls back to `[]`, but corrupt
+ * JSON or wrong shape is warned and moved aside before returning `[]`.
+ * Atomic writes via tmp +
  * rename(2). No file lock — Phase 1 / Phase 2 trust adds are operator-driven
  * and racing writers aren't a realistic workload.
  */
@@ -51,18 +52,40 @@ function readableTrustPath(): string | null {
   return null;
 }
 
+function corruptTrustPath(path: string, attempt = 0): string {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const candidate = `${path}.corrupt-${stamp}${attempt ? `-${attempt}` : ""}`;
+  return existsSync(candidate) ? corruptTrustPath(path, attempt + 1) : candidate;
+}
+
+function quarantineCorruptTrust(path: string, reason: string): void {
+  const dest = corruptTrustPath(path);
+  try {
+    renameSync(path, dest);
+    console.warn(`[trust-store] trust store at ${path} is corrupt/unreadable (${reason}); moved aside to ${dest}; starting with empty trust`);
+  } catch (error) {
+    const moveReason = error instanceof Error ? error.message : String(error);
+    console.warn(`[trust-store] trust store at ${path} is corrupt/unreadable (${reason}); failed to move aside (${moveReason}); starting with empty trust`);
+  }
+}
+
 export function loadTrust(): TrustListOnDisk {
   const path = readableTrustPath();
   if (!path) return [];
   let raw: string;
   try {
     raw = readFileSync(path, "utf-8");
-  } catch {
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    quarantineCorruptTrust(path, reason);
     return [];
   }
   try {
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
+    if (!Array.isArray(parsed)) {
+      quarantineCorruptTrust(path, "invalid shape: expected array");
+      return [];
+    }
     return parsed.filter(
       (e: any): e is TrustEntryOnDisk =>
         e &&
@@ -70,7 +93,9 @@ export function loadTrust(): TrustListOnDisk {
         typeof e.target === "string" &&
         typeof e.addedAt === "string",
     );
-  } catch {
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    quarantineCorruptTrust(path, reason);
     return [];
   }
 }

--- a/test/core/consent/consent.test.ts
+++ b/test/core/consent/consent.test.ts
@@ -5,7 +5,7 @@
  * so the suite never touches the real ~/.maw/{trust,consent-pending}.
  */
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from "fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -113,21 +113,60 @@ describe("trust store", () => {
     expect(trustKey("a", "b", "hey")).toBe("a→b:hey");
   });
 
-  it("survives missing file (fresh install)", () => {
-    expect(listTrust()).toEqual([]);
+  it("survives missing file (fresh install) without warning", () => {
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = ((...args: unknown[]) => { warnings.push(args.map(String).join(" ")); }) as typeof console.warn;
+    try {
+      expect(listTrust()).toEqual([]);
+      expect(warnings).toEqual([]);
+    } finally {
+      console.warn = origWarn;
+    }
   });
 
-  it("survives corrupt file (bad JSON)", async () => {
-    writeFileSync(process.env.CONSENT_TRUST_FILE!, "{not json");
-    expect(listTrust()).toEqual([]);
-    // Should still accept new writes after a corrupt read
-    recordTrust({ from: "x", to: "y", action: "hey", approvedAt: "z", approvedBy: "human", requestId: null });
-    expect(isTrusted("x", "y", "hey")).toBe(true);
+  it("warns, preserves, and recovers from corrupt file (bad JSON)", async () => {
+    const path = process.env.CONSENT_TRUST_FILE!;
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = ((...args: unknown[]) => { warnings.push(args.map(String).join(" ")); }) as typeof console.warn;
+    try {
+      writeFileSync(path, "{not json");
+      expect(listTrust()).toEqual([]);
+      expect(existsSync(path)).toBe(false);
+      const corrupt = readdirSync(workdir).filter(f => f.startsWith("trust.json.corrupt-"));
+      expect(corrupt).toHaveLength(1);
+      expect(readFileSync(join(workdir, corrupt[0]!), "utf-8")).toBe("{not json");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("corrupt/unreadable");
+      expect(warnings[0]).toContain("moved aside");
+      // Should still accept new writes after a corrupt read, without overwriting the corrupt copy.
+      recordTrust({ from: "x", to: "y", action: "hey", approvedAt: "z", approvedBy: "human", requestId: null });
+      expect(isTrusted("x", "y", "hey")).toBe(true);
+      expect(readFileSync(join(workdir, corrupt[0]!), "utf-8")).toBe("{not json");
+    } finally {
+      console.warn = origWarn;
+    }
   });
 
-  it("survives wrong-shape file (peers:[] instead of peers:{})", async () => {
-    writeFileSync(process.env.CONSENT_TRUST_FILE!, JSON.stringify({ version: 1, trust: [] }));
-    expect(listTrust()).toEqual([]);
+  it("warns and preserves wrong-shape file (peers:[] instead of peers:{})", async () => {
+    const path = process.env.CONSENT_TRUST_FILE!;
+    const body = JSON.stringify({ version: 1, trust: [] });
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = ((...args: unknown[]) => { warnings.push(args.map(String).join(" ")); }) as typeof console.warn;
+    try {
+      writeFileSync(path, body);
+      expect(listTrust()).toEqual([]);
+      expect(existsSync(path)).toBe(false);
+      const corrupt = readdirSync(workdir).filter(f => f.startsWith("trust.json.corrupt-"));
+      expect(corrupt).toHaveLength(1);
+      expect(readFileSync(join(workdir, corrupt[0]!), "utf-8")).toBe(body);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("invalid shape");
+    } finally {
+      console.warn = origWarn;
+    }
   });
 
   it("reads legacy config trust and migrates the next write to state", () => {

--- a/test/isolated/consent-plugin-coverage.test.ts
+++ b/test/isolated/consent-plugin-coverage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -118,9 +118,24 @@ describe("vendor consent plugin index coverage", () => {
     expect(unknown.error).toContain("unknown subcommand: wat");
     expect(unknown.error).toContain("maw consent list-trust");
 
-    process.env.CONSENT_TRUST_FILE = dir;
-    const caught = await handler(cli(["trust", "peer"]));
-    expect(caught.ok).toBe(false);
-    expect(caught.error).toBeString();
+    const badTrustPath = join(dir, "trust-as-dir");
+    mkdirSync(badTrustPath);
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => warnings.push(String(message));
+    try {
+      process.env.CONSENT_TRUST_FILE = badTrustPath;
+      const recovered = await handler(cli(["trust", "peer"]));
+      expect(recovered).toEqual({ ok: true, output: "✅ trust written: local-node → peer:hey" });
+    } finally {
+      console.warn = originalWarn;
+    }
+    const corruptCopies = readdirSync(dir).filter((entry) => entry.startsWith("trust-as-dir.corrupt-"));
+    expect(corruptCopies).toHaveLength(1);
+    expect(existsSync(join(dir, corruptCopies[0]))).toBe(true);
+    expect(JSON.parse(readFileSync(badTrustPath, "utf-8")).trust["local-node→peer:hey"]).toMatchObject({ from: "local-node", to: "peer", action: "hey" });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("corrupt/unreadable");
+    expect(warnings[0]).toContain("moved aside");
   });
 });

--- a/test/isolated/scope-acl-coverage.test.ts
+++ b/test/isolated/scope-acl-coverage.test.ts
@@ -69,21 +69,31 @@ describe("scope ACL coverage", () => {
     ]);
   });
 
-  test("loadTrustFromDisk strips timestamps and forgives missing, malformed, and wrong-shaped trust files", () => {
-    expect(loadTrustFromDisk()).toEqual([]);
+  test("loadTrustFromDisk strips timestamps and warns/quarantines malformed trust files", () => {
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = ((...args: unknown[]) => { warnings.push(args.map(String).join(" ")); }) as typeof console.warn;
+    try {
+      expect(loadTrustFromDisk()).toEqual([]);
+      expect(warnings).toEqual([]);
 
-    writeTrust("{");
-    expect(loadTrustFromDisk()).toEqual([]);
+      writeTrust("{");
+      expect(loadTrustFromDisk()).toEqual([]);
 
-    writeTrust({ sender: "not", target: "array" });
-    expect(loadTrustFromDisk()).toEqual([]);
+      writeTrust({ sender: "not", target: "array" });
+      expect(loadTrustFromDisk()).toEqual([]);
 
-    writeTrust([
-      { sender: "alpha", target: "beta", addedAt: "2026-05-18T00:00:00Z" },
-      { sender: "missing", target: "timestamp" },
-      { sender: 7, target: "bad", addedAt: "now" },
-    ]);
-    expect(loadTrustFromDisk()).toEqual([{ sender: "alpha", target: "beta" }]);
+      writeTrust([
+        { sender: "alpha", target: "beta", addedAt: "2026-05-18T00:00:00Z" },
+        { sender: "missing", target: "timestamp" },
+        { sender: 7, target: "bad", addedAt: "now" },
+      ]);
+      expect(loadTrustFromDisk()).toEqual([{ sender: "alpha", target: "beta" }]);
+      expect(warnings).toHaveLength(2);
+      expect(warnings.every(w => w.includes("moved aside"))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+    }
   });
 
   test("evaluateAclFromDisk composes scope and trust loaders with queue fallback", () => {

--- a/test/lib-trust-scope.test.ts
+++ b/test/lib-trust-scope.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { scopePath, scopesDir } from "../src/lib/scope-paths";
@@ -79,27 +79,64 @@ describe("trust store helpers", () => {
     expect(trustPath()).toBe(join(tempRoot, "state-root", "trust.json"));
   });
 
-  test("loadTrust is forgiving for missing files, wrong shape, and corrupt JSON", () => {
+  test("loadTrust is quiet for missing files", () => {
+    process.env.MAW_CONFIG_DIR = join(tempRoot, "config");
+    process.env.MAW_STATE_DIR = join(tempRoot, "state");
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = ((...args: unknown[]) => { warnings.push(args.map(String).join(" ")); }) as typeof console.warn;
+    try {
+      expect(loadTrust()).toEqual([]);
+      expect(warnings).toEqual([]);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
+  test("loadTrust warns and preserves wrong-shape or corrupt JSON", () => {
     process.env.MAW_CONFIG_DIR = join(tempRoot, "config");
     process.env.MAW_STATE_DIR = join(tempRoot, "state");
     mkdirSync(process.env.MAW_STATE_DIR, { recursive: true });
     const path = trustPath();
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = ((...args: unknown[]) => { warnings.push(args.map(String).join(" ")); }) as typeof console.warn;
+    try {
+      writeFileSync(path, JSON.stringify({ sender: "a" }));
+      expect(loadTrust()).toEqual([]);
+      expect(existsSync(path)).toBe(false);
+      let corrupt = readdirSync(process.env.MAW_STATE_DIR).filter(f => f.startsWith("trust.json.corrupt-"));
+      expect(corrupt).toHaveLength(1);
+      expect(readFileSync(join(process.env.MAW_STATE_DIR, corrupt[0]!), "utf-8")).toBe(JSON.stringify({ sender: "a" }));
 
-    expect(loadTrust()).toEqual([]);
-
-    writeFileSync(path, JSON.stringify({ sender: "a" }));
-    expect(loadTrust()).toEqual([]);
-
-    writeFileSync(path, "not-json");
-    expect(loadTrust()).toEqual([]);
+      writeFileSync(path, "not-json");
+      expect(loadTrust()).toEqual([]);
+      corrupt = readdirSync(process.env.MAW_STATE_DIR).filter(f => f.startsWith("trust.json.corrupt-"));
+      expect(corrupt).toHaveLength(2);
+      expect(corrupt.some(f => readFileSync(join(process.env.MAW_STATE_DIR!, f), "utf-8") === "not-json")).toBe(true);
+      expect(warnings).toHaveLength(2);
+      expect(warnings.every(w => w.includes("trust store") && w.includes("moved aside"))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+    }
   });
 
-  test("loadTrust returns [] when the trust path exists but cannot be read as a file", () => {
+  test("loadTrust warns and preserves unreadable trust path", () => {
     process.env.MAW_CONFIG_DIR = join(tempRoot, "config");
     process.env.MAW_STATE_DIR = join(tempRoot, "state");
     mkdirSync(trustPath(), { recursive: true });
-
-    expect(loadTrust()).toEqual([]);
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = ((...args: unknown[]) => { warnings.push(args.map(String).join(" ")); }) as typeof console.warn;
+    try {
+      expect(loadTrust()).toEqual([]);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("corrupt/unreadable");
+      expect(existsSync(trustPath())).toBe(false);
+      expect(readdirSync(process.env.MAW_STATE_DIR).some(f => f.startsWith("trust.json.corrupt-"))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+    }
   });
 
   test("loadTrust filters invalid entries and keeps valid entries", () => {


### PR DESCRIPTION
Closes #2788

## Summary
- keep missing trust-store files quiet for fresh installs
- warn loudly and move corrupt/unreadable/wrong-shaped trust stores to `.corrupt-<timestamp>` before returning empty trust
- cover consent trust and shared scope trust loaders, including plugin recovery behavior

## Design note
This keeps absent-file bootstrap behavior but stops parse/read failures from silently fail-opening to empty trust. Corrupt contents are preserved; nothing is deleted.

## Tests
- `bun test test/isolated/consent-plugin-coverage.test.ts test/core/consent/consent.test.ts test/lib-trust-scope.test.ts test/isolated/scope-acl-coverage.test.ts`
- `bun run test`
- `bun run test:coverage`
- `bun run build`