### PR TITLE
fix: notify live inbox receivers from CLI queue paths (#2789)

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -15,12 +15,14 @@ import { Tmux } from "../core/transport/tmux";
 import { pushFeedEvent } from "./feed";
 import { buildMessageLifecycleFeedEvent, type MessageLifecycleInput } from "../lib/message-events";
 import { defaultReceiverInboxWriter, type ReceiverInboxResult, type ReceiverInboxWriter } from "../commands/shared/receiver-inbox";
+import { notifyLiveInboxReceiver } from "../commands/shared/live-inbox-notify";
+export { formatInboxNotification, resolveLiveInboxNotificationTarget } from "../commands/shared/live-inbox-notify";
 import { checkBusyGuard, queueForDispatch } from "../core/agent-status-guard";
 import type { Session } from "../core/transport/ssh";
 
 type Config = ReturnType<typeof loadConfig>;
 type IdleCheck = Awaited<ReturnType<typeof checkPaneIdle>>;
-type TmuxLike = Pick<Tmux, "sendKeysLiteral" | "sendKeys" | "listPanes" | "capture">;
+type TmuxLike = Pick<Tmux, "sendKeysLiteral" | "sendKeys" | "listPanes" | "capture" | "run">;
 
 type AutoWakeDecision = Awaited<ReturnType<typeof defaultShouldAutoWake>>;
 type AutoWakeOpts = Parameters<typeof defaultShouldAutoWake>[1];
@@ -136,46 +138,6 @@ export function sessionTargetExists(sessions: Session[], target: string): boolea
   if (!session) return false;
   if (!windowName) return true;
   return session.windows.some(w => String(w.index) === windowName || w.name === windowName);
-}
-
-function normalizeInboxTargetName(value: string | undefined): string {
-  return (value ?? "")
-    .trim()
-    .replace(/\.[0-9]+$/, "")
-    .replace(/^\d+-/, "")
-    .replace(/-oracle$/i, "")
-    .toLowerCase();
-}
-
-function windowTarget(session: Session, window: Session["windows"][number] | undefined): string {
-  if (!window) return session.name;
-  return `${session.name}:${window.name || window.index}`;
-}
-
-function receiverNamedWindow(session: Session, wanted: string): Session["windows"][number] | undefined {
-  return session.windows.find((window) => normalizeInboxTargetName(window.name) === wanted);
-}
-
-/** @internal exported for tests. Resolve an inbox oracle to a live tmux target. */
-export function resolveLiveInboxNotificationTarget(oracle: string, sessions: Session[]): string | null {
-  const wanted = normalizeInboxTargetName(oracle);
-  if (!wanted) return null;
-
-  for (const session of sessions) {
-    const namedWindow = receiverNamedWindow(session, wanted);
-    if (namedWindow) return windowTarget(session, namedWindow);
-
-    if (normalizeInboxTargetName(session.name) === wanted) {
-      return windowTarget(session, session.windows.find(w => w.active) ?? session.windows[0]);
-    }
-  }
-
-  return null;
-}
-
-/** @internal exported for tests. */
-export function formatInboxNotification(inbox: Extract<ReceiverInboxResult, { ok: true }>, from: string): string {
-  return `📬 maw inbox: new message from ${from} in ψ/inbox/${inbox.filename}. Run \`maw inbox\` to read.`;
 }
 
 export function emitMessageLifecycle(input: MessageLifecycleInput, deps: SessionsApiDeps = {}) {
@@ -412,20 +374,32 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
           receipt: queuedReceipt(reason),
         };
       };
-      const notifyLiveInboxReceiver = async (inbox: ReceiverInboxResult) => {
-        if (!inbox.ok) return;
-        try {
-          const liveTarget = resolveLiveInboxNotificationTarget(inbox.oracle, await d.listSessions());
-          if (liveTarget) await d.sendKeys(liveTarget, formatInboxNotification(inbox, messageFrom));
-        } catch {
-          // Inbox persistence is the durable path. Live notification is only a
-          // best-effort nudge for already-running receiver sessions (#2057).
+      const notifyQueuedInboxReceiver = async (inbox: ReceiverInboxResult, tmuxTarget: string, reason: string) => {
+        const notify = await notifyLiveInboxReceiver(inbox, messageFrom, {
+          listSessions: d.listSessions,
+          tmux: d.createTmux(),
+        });
+        if (notify.status !== "sent") {
+          const detail = notify.reason || "unknown notify failure";
+          console.warn(`warn: inbox pane notify skipped for ${inbox.ok ? inbox.oracle : tmuxTarget}: ${detail}`);
+          emitLifecycle({
+            direction: "inbound",
+            state: "queued",
+            channel: "api-send",
+            route: "inbox-notify",
+            from: messageFrom,
+            to: inbox.ok ? `${config.node ?? "local"}:${inbox.oracle}` : messageTo,
+            target: notify.target || tmuxTarget,
+            text: message,
+            lastLine: `${reason}; notify skipped: ${detail}`,
+            signed: messageSigned,
+          });
         }
       };
       const queueOrFail = async (tmuxTarget: string, reason: string, status = 502) => {
         const inbox = await writeInboundInbox(tmuxTarget);
-        if (inbox?.ok) await notifyLiveInboxReceiver(inbox);
         const queued = inbox ? queuedInboxResponse(inbox, tmuxTarget, reason) : null;
+        if (inbox?.ok) await notifyQueuedInboxReceiver(inbox, tmuxTarget, reason);
         if (queued) return queued;
         set.status = status;
         emitLifecycle({
@@ -671,9 +645,10 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
       }
 
       const errDetail = resolved?.type === "error" ? { reason: resolved.reason, detail: resolved.detail, hint: resolved.hint } : {};
+      const reason = errDetail.detail || "target not live; persisted for receiver inbox polling";
       const inbox = await writeInboundInbox(target);
-      if (inbox?.ok) await notifyLiveInboxReceiver(inbox);
-      const queued = inbox ? queuedInboxResponse(inbox, target, errDetail.detail || "target not live; persisted for receiver inbox polling") : null;
+      const queued = inbox ? queuedInboxResponse(inbox, target, reason) : null;
+      if (inbox?.ok) await notifyQueuedInboxReceiver(inbox, target, reason);
       if (queued) return queued;
       emitLifecycle({
         direction: "inbound",

--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -23,6 +23,7 @@ import {
 } from "./hey-locate-resolution";
 import { checkBusyGuard, queueForDispatch } from "../../core/agent-status-guard";
 import { runPluginEventHooks } from "../../plugin/event-hooks";
+import { notifyLiveInboxReceiver } from "./live-inbox-notify";
 
 /**
  * Resolve a `session:window` target to a specific pane running an agent
@@ -865,6 +866,29 @@ export async function cmdSend(
   const warnOfflineInboxOnly = (): void => {
     console.warn(`\x1b[33m⚠ target node offline — message written to inbox only, will not be seen until node wakes\x1b[0m`);
   };
+  const notifyQueuedInbox = async (inbox: ReceiverInboxResult | null, target: string, reason: string): Promise<void> => {
+    if (!inbox?.ok) return;
+    const notify = await notifyLiveInboxReceiver(inbox, senderIdentity.display, {
+      listSessions: async () => sessions,
+      tmux: new Tmux(),
+    });
+    if (notify.status !== "sent") {
+      const detail = notify.reason || "unknown notify failure";
+      console.warn(`\x1b[33mwarn\x1b[0m: inbox pane notify skipped for ${inbox.oracle}: ${detail}`);
+      emitMessageFeed({
+        direction: "outbound",
+        state: "queued",
+        channel: "hey",
+        route: "inbox-notify",
+        from: senderIdentity.display,
+        to: query,
+        target: notify.target || target,
+        text: outboundMessage,
+        lastLine: `${reason}; notify skipped: ${detail}`,
+        signed: true,
+      }, config.port || 3456);
+    }
+  };
 
   // Local target (or self-node) → send via tmux.
   // Resolve to a specific pane first: when the oracle window has multiple
@@ -875,7 +899,10 @@ export async function cmdSend(
     const target = await resolveOraclePane(result.target);
     if (opts.inboxOnly) {
       const inbox = await writeReceiverInbox(target);
-      if (logQueuedInbox(inbox, target, "--inbox requested; pane injection skipped")) return;
+      if (logQueuedInbox(inbox, target, "--inbox requested; pane injection skipped")) {
+        await notifyQueuedInbox(inbox, target, "--inbox requested; pane injection skipped");
+        return;
+      }
       const reason = inbox && !inbox.ok && inbox.reason ? `: ${inbox.reason}` : "";
       console.error(`\x1b[31merror\x1b[0m: --inbox requested but receiver inbox is unavailable for ${target}${reason}`);
       process.exit(1);
@@ -885,7 +912,11 @@ export async function cmdSend(
     if (guard.busy) {
       queueForDispatch({ from: `${config.node ?? "local"}:${senderName}`, to: query, target, message: outboundMessage });
       const inbox = await writeReceiverInbox(target);
-      if (logQueuedInbox(inbox, target, `target '${guard.oracle}' is busy; queued for auto-delivery`)) return;
+      const reason = `target '${guard.oracle}' is busy; queued for auto-delivery`;
+      if (logQueuedInbox(inbox, target, reason)) {
+        await notifyQueuedInbox(inbox, target, reason);
+        return;
+      }
       console.log(`\x1b[33mqueued\x1b[0m target '${guard.oracle}' is busy — will auto-deliver when idle`);
       return;
     }
@@ -898,7 +929,11 @@ export async function cmdSend(
       await sendKeys(target, outboundMessage);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      if (logQueuedInbox(inbox, target, `tmux delivery failed: ${msg}`)) return;
+      const reason = `tmux delivery failed: ${msg}`;
+      if (logQueuedInbox(inbox, target, reason)) {
+        await notifyQueuedInbox(inbox, target, reason);
+        return;
+      }
       console.error(`\x1b[31merror\x1b[0m: tmux delivery failed for ${target}: ${msg}`);
       process.exit(1);
     }
@@ -1096,12 +1131,21 @@ export async function cmdSend(
   // Try receiver inbox queue before surfacing a local-only resolver miss.
   if (bareResolution.locate?.repoPath) {
     const reason = `${query} found at ${bareResolution.locate.repoPath} but no active session — written to inbox only`;
-    if (logQueuedInbox(await writeReceiverInbox(bareResolution.locate.repoPath), query, reason)) {
+    const inbox = await writeReceiverInbox(bareResolution.locate.repoPath);
+    if (logQueuedInbox(inbox, query, reason)) {
+      await notifyQueuedInbox(inbox, query, reason);
       warnOfflineInboxOnly();
       return;
     }
     console.warn(`\x1b[33mwarn\x1b[0m: ${reason}`);
-  } else if (logQueuedInbox(await writeReceiverInbox(), query, "target not live; persisted for receiver inbox polling")) return;
+  } else {
+    const reason = "target not live; persisted for receiver inbox polling";
+    const inbox = await writeReceiverInbox();
+    if (logQueuedInbox(inbox, query, reason)) {
+      await notifyQueuedInbox(inbox, query, reason);
+      return;
+    }
+  }
 
   // Local-only miss — no network was attempted (#411). Show resolver's own detail.
   if (result?.type === "error") {

--- a/src/commands/shared/live-inbox-notify.ts
+++ b/src/commands/shared/live-inbox-notify.ts
@@ -1,0 +1,85 @@
+import type { Session } from "../../core/transport/ssh";
+import type { ReceiverInboxResult } from "./receiver-inbox";
+
+export type LiveInboxNotifyStatus = "sent" | "not-live" | "failed";
+
+export interface LiveInboxNotifyResult {
+  status: LiveInboxNotifyStatus;
+  target?: string;
+  message?: string;
+  reason?: string;
+}
+
+export interface LiveInboxNotifyDeps {
+  listSessions: () => Promise<Session[]>;
+  tmux: { run: (...args: string[]) => Promise<string> };
+}
+
+function normalizeInboxTargetName(value: string | undefined): string {
+  return (value ?? "")
+    .trim()
+    .replace(/\.[0-9]+$/, "")
+    .replace(/^\d+-/, "")
+    .replace(/-oracle$/i, "")
+    .toLowerCase();
+}
+
+function windowTarget(session: Session, window: Session["windows"][number] | undefined): string {
+  if (!window) return session.name;
+  return `${session.name}:${window.name || window.index}`;
+}
+
+function receiverNamedWindow(session: Session, wanted: string): Session["windows"][number] | undefined {
+  return session.windows.find((window) => normalizeInboxTargetName(window.name) === wanted);
+}
+
+/** @internal exported for tests. Resolve an inbox oracle to a live tmux target. */
+export function resolveLiveInboxNotificationTarget(oracle: string, sessions: Session[]): string | null {
+  const wanted = normalizeInboxTargetName(oracle);
+  if (!wanted) return null;
+
+  for (const session of sessions) {
+    const namedWindow = receiverNamedWindow(session, wanted);
+    if (namedWindow) return windowTarget(session, namedWindow);
+
+    if (normalizeInboxTargetName(session.name) === wanted) {
+      return windowTarget(session, session.windows.find(w => w.active) ?? session.windows[0]);
+    }
+  }
+
+  return null;
+}
+
+/** @internal exported for tests. */
+export function formatInboxNotification(inbox: Extract<ReceiverInboxResult, { ok: true }>, from: string): string {
+  return `📬 inbox +1 from ${from} — ว่างแล้วค่อย maw inbox (ψ/inbox/${inbox.filename})`;
+}
+
+export async function notifyLiveInboxReceiver(
+  inbox: ReceiverInboxResult,
+  from: string,
+  deps: LiveInboxNotifyDeps,
+): Promise<LiveInboxNotifyResult> {
+  if (!inbox.ok) return { status: "failed", reason: inbox.reason || "receiver inbox write failed" };
+
+  let sessions: Session[];
+  try {
+    sessions = await deps.listSessions();
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { status: "failed", reason: `list tmux sessions failed: ${reason}` };
+  }
+
+  const target = resolveLiveInboxNotificationTarget(inbox.oracle, sessions);
+  if (!target) return { status: "not-live", reason: `no live tmux pane resolved for inbox receiver '${inbox.oracle}'` };
+
+  const message = formatInboxNotification(inbox, from);
+  try {
+    // Awareness only: tmux status message, not send-keys into the agent input.
+    await deps.tmux.run("display-message", "-d", "5000", "-t", target, message);
+    return { status: "sent", target, message };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { status: "failed", target, reason: `tmux display-message failed for ${target}: ${reason}` };
+  }
+}

--- a/test/api-send-inbox-notify-2057.test.ts
+++ b/test/api-send-inbox-notify-2057.test.ts
@@ -25,6 +25,7 @@ async function json(res: Response) {
 
 function harness(overrides: Partial<SessionsApiDeps> = {}) {
   const calls: any[] = [];
+  const lifecycleCalls: any[] = [];
   const sessions = [
     session("50-atlas", [{ index: 0, name: "atlas-oracle", active: true }]),
   ];
@@ -44,8 +45,14 @@ function harness(overrides: Partial<SessionsApiDeps> = {}) {
     resolveTarget: (() => ({ type: "error", reason: "missing", detail: "not live", hint: "wake" })) as any,
     processMirror: ((raw: string) => raw) as any,
     resolveFleetSession: () => null,
-    createTmux: () => ({ sendKeysLiteral: async () => undefined, sendKeys: async () => undefined, listPanes: async () => [], capture: async () => "" }) as any,
-    emitMessageLifecycle: () => undefined,
+    createTmux: () => ({
+      sendKeysLiteral: async () => undefined,
+      sendKeys: async () => undefined,
+      listPanes: async () => [],
+      capture: async () => "",
+      run: async (...args: string[]) => { calls.push(["tmux.run", ...args]); return ""; },
+    }) as any,
+    emitMessageLifecycle: (input: any) => { lifecycleCalls.push(input); },
     writeReceiverInbox: () => ({
       ok: true,
       oracle: "atlas",
@@ -59,7 +66,7 @@ function harness(overrides: Partial<SessionsApiDeps> = {}) {
     cmdSleepOne: async () => undefined,
     ...overrides,
   };
-  return { app: new Elysia().use(createSessionsApi(deps)), calls };
+  return { app: new Elysia().use(createSessionsApi(deps)), calls, lifecycleCalls };
 }
 
 describe("/api/send queued inbox live notification (#2057)", () => {
@@ -79,7 +86,7 @@ describe("/api/send queued inbox live notification (#2057)", () => {
     expect(resolveLiveInboxNotificationTarget("ghost", sessions)).toBeNull();
   });
 
-  test("injects a notification after queueing inbox when receiver is live", async () => {
+  test("shows a gentle tmux status notification after queueing inbox when receiver is live", async () => {
     const h = harness();
 
     const res = await h.app.handle(postSend(
@@ -89,9 +96,13 @@ describe("/api/send queued inbox live notification (#2057)", () => {
 
     expect(await json(res)).toMatchObject({ ok: true, source: "inbox", state: "queued" });
     expect(h.calls).toEqual([[
-      "sendKeys",
+      "tmux.run",
+      "display-message",
+      "-d",
+      "5000",
+      "-t",
       "50-atlas:atlas-oracle",
-      "📬 maw inbox: new message from m5:mawjs in ψ/inbox/msg.md. Run `maw inbox` to read.",
+      "📬 inbox +1 from m5:mawjs — ว่างแล้วค่อย maw inbox (ψ/inbox/msg.md)",
     ]]);
   });
 
@@ -104,10 +115,13 @@ describe("/api/send queued inbox live notification (#2057)", () => {
       state: "queued",
     });
     expect(h.calls).toEqual([]);
+    const notifyLifecycle = h.lifecycleCalls.find((call) => call.route === "inbox-notify");
+    expect(notifyLifecycle).toMatchObject({ route: "inbox-notify", state: "queued" });
+    expect(notifyLifecycle.lastLine).toContain("notify skipped");
   });
 
   test("formats concise inbox notification text", () => {
     expect(formatInboxNotification({ ok: true, oracle: "atlas", inboxDir: "/x", path: "/x/msg.md", filename: "msg.md" }, "m5:mawjs"))
-      .toBe("📬 maw inbox: new message from m5:mawjs in ψ/inbox/msg.md. Run `maw inbox` to read.");
+      .toBe("📬 inbox +1 from m5:mawjs — ว่างแล้วค่อย maw inbox (ψ/inbox/msg.md)");
   });
 });

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -130,6 +130,7 @@ mock.module(join(import.meta.dir, "../src/core/transport/tmux"), () => {
       tmuxRunCalls.push(args);
       if (args.join(" ") === "display-message -p #S") return "mock-session\n";
       if (args[0] === "list-panes") return "0 claude\n";
+      if (args[0] === "display-message" && args.includes("-t")) return "";
       throw new Error(`unexpected test tmux run: ${args.join(" ")}`);
     }
     async tryRun(...args: string[]) {
@@ -532,6 +533,45 @@ describe("cmdSend — delivery branch coverage", () => {
     expect(emitFeedCalls[0].data).toMatchObject({ route: "inbox", state: "queued" });
     expect(logs.join("\n")).toContain("queued");
     expect(logs.join("\n")).toContain("ψ/inbox/msg.md");
+    expect(sendKeysCalls).toEqual([]);
+    expect(tmuxRunCalls).toContainEqual([
+      "display-message",
+      "-d",
+      "5000",
+      "-t",
+      "session:oracle",
+      "📬 inbox +1 from test-node:sender — ว่างแล้วค่อย maw inbox (ψ/inbox/msg.md)",
+    ]);
+  });
+
+
+  test("same-machine CLI inbox queue gently notifies a live receiver pane (#2789)", async () => {
+    listSessionsReturn = [{ name: "157-noah", windows: [{ index: 0, name: "noah-oracle", active: true }] }];
+    resolveTargetReturn = { type: "local", target: "157-noah:noah-oracle.0" };
+
+    await runCmd(() => cmdSend("m5:noah", "queued for later", false, {
+      inboxOnly: true,
+      receiverInbox: () => ({
+        ok: true,
+        oracle: "noah",
+        inboxDir: "/repo/ψ/inbox",
+        path: "/repo/ψ/inbox/noah.md",
+        filename: "noah.md",
+      }),
+    }));
+
+    expect(exitCode).toBeUndefined();
+    expect(sendKeysCalls).toEqual([]);
+    expect(logMessageCalls).toEqual([{ from: "sender", to: "m5:noah", message: "[test-node:sender] queued for later", route: "inbox" }]);
+    expect(tmuxRunCalls).toContainEqual([
+      "display-message",
+      "-d",
+      "5000",
+      "-t",
+      "157-noah:noah-oracle",
+      "📬 inbox +1 from test-node:sender — ว่างแล้วค่อย maw inbox (ψ/inbox/noah.md)",
+    ]);
+    expect(warns.join("\n")).not.toContain("notify skipped");
   });
 
   test("--inbox receiver inbox writer failures surface as queue-only errors", async () => {
@@ -593,6 +633,14 @@ describe("cmdSend — delivery branch coverage", () => {
     expect(logMessageCalls).toEqual([{ from: "sender", to: "local:session:oracle", message: "[test-node:sender] queued while busy", route: "inbox" }]);
     expect(emitFeedCalls[0].data).toMatchObject({ route: "inbox", state: "queued", lastLine: "--inbox requested; pane injection skipped" });
     expect(logs.join("\n")).toContain("busy.md");
+    expect(tmuxRunCalls).toContainEqual([
+      "display-message",
+      "-d",
+      "5000",
+      "-t",
+      "session:oracle",
+      "📬 inbox +1 from test-node:sender — ว่างแล้วค่อย maw inbox (ψ/inbox/busy.md)",
+    ]);
   });
 
   test("peer delivery marks accepted-only responses queued until delivery is proven", async () => {
@@ -874,7 +922,9 @@ describe("cmdSend — bare-name, wake, and safety gates", () => {
     expect(receiverWrites).toHaveLength(1);
     expect(receiverWrites[0].target).toBe("/tmp/renamed-oracle");
     expect(logs.join("\n")).toContain("renamed found at /tmp/renamed-oracle but no active session — written to inbox only");
+    expect(warns.join("\n")).toContain("inbox pane notify skipped for renamed: no live tmux pane resolved for inbox receiver 'renamed'");
     expect(warns.join("\n")).toContain("⚠ target node offline — message written to inbox only, will not be seen until node wakes");
+    expect(emitFeedCalls.some((call) => call.data?.route === "inbox-notify" && String(call.data?.lastLine).includes("notify skipped"))).toBe(true);
   });
 
   test("bare located repo resolves to active local session by cwd before inbox fallback (#2056)", async () => {

--- a/test/sessions-api-default.test.ts
+++ b/test/sessions-api-default.test.ts
@@ -61,6 +61,7 @@ function makeHarness(overrides: SessionsApiDeps = {}) {
       sendKeys: async (target: string, key: string) => { calls.push(["tmuxKeys", target, key]); },
       listPanes: async () => [],
       capture: async (target: string, lines?: number) => { calls.push(["tmuxCapture", target, lines]); return ""; },
+      run: async (...args: string[]) => { calls.push(["tmuxRun", ...args]); return ""; },
     } as any),
     emitMessageLifecycle: (input) => { lifecycle.push(input); },
     writeReceiverInbox: null,


### PR DESCRIPTION
Closes #2789

Summary:
- share live inbox notification resolution between /api/send and CLI comm-send queue paths
- use a gentle tmux display-message ping (no send-keys / no focus steal / no read-state mutation)
- fail loud via warning + message lifecycle event when pane notification cannot resolve or display
- add same-machine live-pane CLI regression for the noah case

Verification:
- targeted api/comm-send/sessions tests: pass (88/88)
- bun run test: pass
- bun run test:isolated: pass (661/661 files)
- bun run test:coverage: pass
- bun run build: pass