### PR TITLE
fix: show unread inbox total in notify pings (#2792)

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -15,7 +15,7 @@ import { Tmux } from "../core/transport/tmux";
 import { pushFeedEvent } from "./feed";
 import { buildMessageLifecycleFeedEvent, type MessageLifecycleInput } from "../lib/message-events";
 import { defaultReceiverInboxWriter, type ReceiverInboxResult, type ReceiverInboxWriter } from "../commands/shared/receiver-inbox";
-import { notifyLiveInboxReceiver } from "../commands/shared/live-inbox-notify";
+import { notifyLiveInboxReceiver, type LiveInboxNotifyDeps } from "../commands/shared/live-inbox-notify";
 export { formatInboxNotification, resolveLiveInboxNotificationTarget } from "../commands/shared/live-inbox-notify";
 import { checkBusyGuard, queueForDispatch } from "../core/agent-status-guard";
 import type { Session } from "../core/transport/ssh";
@@ -52,6 +52,7 @@ export interface SessionsApiDeps {
   shouldAutoWake?: (target: string, opts: AutoWakeOpts) => AutoWakeDecision | Promise<AutoWakeDecision>;
   cmdWake?: (target: string, opts: { noAttach: boolean; task?: string }) => Promise<unknown>;
   cmdSleepOne?: (target: string) => Promise<unknown>;
+  countUnreadInbox?: LiveInboxNotifyDeps["countUnread"];
 }
 
 function defaults(deps: SessionsApiDeps) {
@@ -378,6 +379,7 @@ export function createSessionsApi(deps: SessionsApiDeps = {}) {
         const notify = await notifyLiveInboxReceiver(inbox, messageFrom, {
           listSessions: d.listSessions,
           tmux: d.createTmux(),
+          countUnread: deps.countUnreadInbox,
         });
         if (notify.status !== "sent") {
           const detail = notify.reason || "unknown notify failure";

--- a/src/commands/shared/live-inbox-notify.ts
+++ b/src/commands/shared/live-inbox-notify.ts
@@ -1,3 +1,5 @@
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join } from "path";
 import type { Session } from "../../core/transport/ssh";
 import type { ReceiverInboxResult } from "./receiver-inbox";
 
@@ -13,6 +15,7 @@ export interface LiveInboxNotifyResult {
 export interface LiveInboxNotifyDeps {
   listSessions: () => Promise<Session[]>;
   tmux: { run: (...args: string[]) => Promise<string> };
+  countUnread?: (inboxDir: string) => number | Promise<number>;
 }
 
 function normalizeInboxTargetName(value: string | undefined): string {
@@ -50,9 +53,33 @@ export function resolveLiveInboxNotificationTarget(oracle: string, sessions: Ses
   return null;
 }
 
+function isUnreadInboxFile(content: string): boolean {
+  return /^read:\s*false\s*$/im.test(content);
+}
+
 /** @internal exported for tests. */
-export function formatInboxNotification(inbox: Extract<ReceiverInboxResult, { ok: true }>, from: string): string {
-  return `📬 inbox +1 from ${from} — ว่างแล้วค่อย maw inbox (ψ/inbox/${inbox.filename})`;
+export function countUnreadInboxFiles(inboxDir: string): number {
+  if (!existsSync(inboxDir)) throw new Error(`inbox dir not found: ${inboxDir}`);
+  let count = 0;
+  for (const name of readdirSync(inboxDir)) {
+    if (!name.endsWith(".md")) continue;
+    try {
+      if (isUnreadInboxFile(readFileSync(join(inboxDir, name), "utf8"))) count += 1;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(`read inbox file failed: ${name}: ${reason}`);
+    }
+  }
+  return count;
+}
+
+/** @internal exported for tests. */
+export function formatInboxNotification(
+  inbox: Extract<ReceiverInboxResult, { ok: true }>,
+  from: string,
+  unreadCount: number,
+): string {
+  return `📬 inbox +${unreadCount} from ${from} — ว่างแล้วค่อย maw inbox (ψ/inbox/${inbox.filename})`;
 }
 
 export async function notifyLiveInboxReceiver(
@@ -73,7 +100,15 @@ export async function notifyLiveInboxReceiver(
   const target = resolveLiveInboxNotificationTarget(inbox.oracle, sessions);
   if (!target) return { status: "not-live", reason: `no live tmux pane resolved for inbox receiver '${inbox.oracle}'` };
 
-  const message = formatInboxNotification(inbox, from);
+  let unreadCount: number;
+  try {
+    unreadCount = await (deps.countUnread ?? countUnreadInboxFiles)(inbox.inboxDir);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { status: "failed", target, reason: `count unread inbox failed for ${inbox.inboxDir}: ${reason}` };
+  }
+
+  const message = formatInboxNotification(inbox, from, unreadCount);
   try {
     // Awareness only: tmux status message, not send-keys into the agent input.
     await deps.tmux.run("display-message", "-d", "5000", "-t", target, message);

--- a/test/api-send-inbox-notify-2057.test.ts
+++ b/test/api-send-inbox-notify-2057.test.ts
@@ -53,6 +53,7 @@ function harness(overrides: Partial<SessionsApiDeps> = {}) {
       run: async (...args: string[]) => { calls.push(["tmux.run", ...args]); return ""; },
     }) as any,
     emitMessageLifecycle: (input: any) => { lifecycleCalls.push(input); },
+    countUnreadInbox: () => 1,
     writeReceiverInbox: () => ({
       ok: true,
       oracle: "atlas",
@@ -106,6 +107,26 @@ describe("/api/send queued inbox live notification (#2057)", () => {
     ]]);
   });
 
+  test("uses actual unread total in the gentle tmux status ping (#2792)", async () => {
+    const h = harness({ countUnreadInbox: () => 24 });
+
+    const res = await h.app.handle(postSend(
+      { target: "atlas", text: "reply body" },
+      { "x-maw-from": "mawjs:m5" },
+    ));
+
+    expect(await json(res)).toMatchObject({ ok: true, source: "inbox", state: "queued" });
+    expect(h.calls.at(-1)).toEqual([
+      "tmux.run",
+      "display-message",
+      "-d",
+      "5000",
+      "-t",
+      "50-atlas:atlas-oracle",
+      "📬 inbox +24 from m5:mawjs — ว่างแล้วค่อย maw inbox (ψ/inbox/msg.md)",
+    ]);
+  });
+
   test("keeps inbox-only fallback when receiver has no live session", async () => {
     const h = harness({ listSessions: async () => [] });
 
@@ -121,7 +142,7 @@ describe("/api/send queued inbox live notification (#2057)", () => {
   });
 
   test("formats concise inbox notification text", () => {
-    expect(formatInboxNotification({ ok: true, oracle: "atlas", inboxDir: "/x", path: "/x/msg.md", filename: "msg.md" }, "m5:mawjs"))
-      .toBe("📬 inbox +1 from m5:mawjs — ว่างแล้วค่อย maw inbox (ψ/inbox/msg.md)");
+    expect(formatInboxNotification({ ok: true, oracle: "atlas", inboxDir: "/x", path: "/x/msg.md", filename: "msg.md" }, "m5:mawjs", 7))
+      .toBe("📬 inbox +7 from m5:mawjs — ว่างแล้วค่อย maw inbox (ψ/inbox/msg.md)");
   });
 });

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -6,6 +6,8 @@
  * the real modules so later tests do not inherit fake behavior.
  */
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 
 let mockActive = false;
@@ -99,6 +101,18 @@ let ghqFindCalls: string[];
 let ghqListCalls: number;
 let fleetLoadCalls: number;
 let tmuxRunCalls: string[][];
+let tempDirs: string[];
+
+function createUnreadInbox(unreadCount: number, filename: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "maw-inbox-count-"));
+  tempDirs.push(dir);
+  writeFileSync(join(dir, filename), `---\nread: false\n---\n\nlatest\n`);
+  for (let i = 1; i < unreadCount; i += 1) {
+    writeFileSync(join(dir, `older-${i}.md`), `---\nread: false\n---\n\nolder ${i}\n`);
+  }
+  writeFileSync(join(dir, "already-read.md"), `---\nread: true\n---\n\nread\n`);
+  return dir;
+}
 
 mock.module(join(import.meta.dir, "../src/core/ghq"), () => ({
   ..._rGhq,
@@ -360,6 +374,7 @@ beforeEach(() => {
   ghqListCalls = 0;
   fleetLoadCalls = 0;
   tmuxRunCalls = [];
+  tempDirs = [];
   process.env.CLAUDE_AGENT_NAME = "sender";
   process.env.MAW_TEST_MODE = "1";
   delete process.env.MAW_CONSENT;
@@ -390,6 +405,7 @@ afterEach(() => {
   else process.env.SSH_TTY = origSshTty;
   if (origTmux === undefined) delete process.env.TMUX;
   else process.env.TMUX = origTmux;
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
 });
 
 afterAll(() => {
@@ -515,14 +531,15 @@ describe("cmdSend — delivery branch coverage", () => {
 
   test("--inbox queues to receiver inbox without pane injection", async () => {
     getPaneCommandReturn = "zsh";
+    const inboxDir = createUnreadInbox(1, "msg.md");
 
     await runCmd(() => cmdSend("local:session:oracle", "offline task", false, {
       inboxOnly: true,
       receiverInbox: () => ({
         ok: true,
         oracle: "oracle",
-        inboxDir: "/repo/ψ/inbox",
-        path: "/repo/ψ/inbox/msg.md",
+        inboxDir,
+        path: join(inboxDir, "msg.md"),
         filename: "msg.md",
       }),
     }));
@@ -548,14 +565,15 @@ describe("cmdSend — delivery branch coverage", () => {
   test("same-machine CLI inbox queue gently notifies a live receiver pane (#2789)", async () => {
     listSessionsReturn = [{ name: "157-noah", windows: [{ index: 0, name: "noah-oracle", active: true }] }];
     resolveTargetReturn = { type: "local", target: "157-noah:noah-oracle.0" };
+    const inboxDir = createUnreadInbox(24, "noah.md");
 
     await runCmd(() => cmdSend("m5:noah", "queued for later", false, {
       inboxOnly: true,
       receiverInbox: () => ({
         ok: true,
         oracle: "noah",
-        inboxDir: "/repo/ψ/inbox",
-        path: "/repo/ψ/inbox/noah.md",
+        inboxDir,
+        path: join(inboxDir, "noah.md"),
         filename: "noah.md",
       }),
     }));
@@ -569,7 +587,7 @@ describe("cmdSend — delivery branch coverage", () => {
       "5000",
       "-t",
       "157-noah:noah-oracle",
-      "📬 inbox +1 from test-node:sender — ว่างแล้วค่อย maw inbox (ψ/inbox/noah.md)",
+      "📬 inbox +24 from test-node:sender — ว่างแล้วค่อย maw inbox (ψ/inbox/noah.md)",
     ]);
     expect(warns.join("\n")).not.toContain("notify skipped");
   });
@@ -615,14 +633,15 @@ describe("cmdSend — delivery branch coverage", () => {
 
   test("--inbox queues to receiver inbox when the pane is busy", async () => {
     captureResponses = ["❯ draft one", "❯ draft two"];
+    const inboxDir = createUnreadInbox(2, "busy.md");
 
     await runCmd(() => cmdSend("local:session:oracle", "queued while busy", false, {
       inboxOnly: true,
       receiverInbox: () => ({
         ok: true,
         oracle: "oracle",
-        inboxDir: "/repo/ψ/inbox",
-        path: "/repo/ψ/inbox/busy.md",
+        inboxDir,
+        path: join(inboxDir, "busy.md"),
         filename: "busy.md",
       }),
     }));
@@ -639,7 +658,7 @@ describe("cmdSend — delivery branch coverage", () => {
       "5000",
       "-t",
       "session:oracle",
-      "📬 inbox +1 from test-node:sender — ว่างแล้วค่อย maw inbox (ψ/inbox/busy.md)",
+      "📬 inbox +2 from test-node:sender — ว่างแล้วค่อย maw inbox (ψ/inbox/busy.md)",
     ]);
   });
 

--- a/test/sessions-api-default.test.ts
+++ b/test/sessions-api-default.test.ts
@@ -64,6 +64,7 @@ function makeHarness(overrides: SessionsApiDeps = {}) {
       run: async (...args: string[]) => { calls.push(["tmuxRun", ...args]); return ""; },
     } as any),
     emitMessageLifecycle: (input) => { lifecycle.push(input); },
+    countUnreadInbox: () => 1,
     writeReceiverInbox: null,
     sleep: async (ms: number) => { calls.push(["sleep", ms]); },
     shouldAutoWake: () => ({ wake: false, reason: "policy" }),


### PR DESCRIPTION
Closes #2792

Summary:
- count durable `read: false` inbox markdown files before the gentle tmux status ping
- keep #2789 contract: display-message only, no send-keys, no read-state mutation
- cover +24 burst behavior and busy/inbox queue counts

Verification:
- targeted api/comm-send/sessions tests: pass (89/89)
- bun run test: pass
- bun run test:isolated: pass (661/661 files)
- bun run test:coverage: pass
- bun run build: pass