### PR TITLE
Refuse peer installs on identity mismatch

### DIFF
--- a/src/commands/plugins/plugin/install-impl.ts
+++ b/src/commands/plugins/plugin/install-impl.ts
@@ -108,6 +108,17 @@ export async function cmdPluginInstall(args: string[]): Promise<void> {
         (resolved.peerSha256 ? ` (sha256: ${resolved.peerSha256.slice(0, 12)}…)` : ""),
       );
 
+      if (resolved.identityMismatch) {
+        console.error([
+          `\x1b[31m✗ peer identity mismatch\x1b[0m: refusing plugin install from '${resolved.peerName}'`,
+          `  configured peer: ${resolved.peerName}  [${resolved.peerUrl}]`,
+          resolved.peerNode ? `  manifest claimed node: ${resolved.peerNode}` : "",
+          `  refusing to bind consent/trust to the claimed peer node`,
+          `  retry after fixing namedPeers or the peer manifest identity`,
+        ].filter(Boolean).join("\n"));
+        process.exit(1);
+      }
+
       // #644 Phase 3 — PIN consent before we touch the network for the artifact.
       // Default OFF; opt in via MAW_CONSENT=1. Gate lives here (not in resolver)
       // so the operator sees what the peer advertised BEFORE being asked to
@@ -124,6 +135,7 @@ export async function cmdPluginInstall(args: string[]): Promise<void> {
           pluginName: mode.name,
           pluginVersion: resolved.version,
           pluginSha256: resolved.peerSha256,
+          identityMismatch: resolved.identityMismatch,
         });
         if (!decision.allow) {
           if (decision.message) console.error(decision.message);

--- a/src/commands/plugins/plugin/install-peer-resolver.ts
+++ b/src/commands/plugins/plugin/install-peer-resolver.ts
@@ -18,6 +18,12 @@ export interface ResolvedPeerSource {
   peerName: string;
   /** Peer's node name, if it identified itself (for the success label). */
   peerNode?: string;
+  /**
+   * True when searchPeers detected the peer's configured name and manifest
+   * node disagree. When set, peerNode is untrusted evidence only and must not
+   * be used for consent/trust routing.
+   */
+  identityMismatch?: boolean;
   /** The version the peer advertised — surfaced in the success label. */
   version: string;
   /** Peer base URL — used by the #644 Phase 3 consent gate to POST /api/consent/request. */
@@ -92,5 +98,6 @@ export async function resolvePeerInstall(
     peerUrl: hit.peerUrl,
   };
   if (hit.peerNode) resolved.peerNode = hit.peerNode;
+  if (hit.identityMismatch) resolved.identityMismatch = true;
   return resolved;
 }

--- a/src/core/consent/gate-plugin-install.ts
+++ b/src/core/consent/gate-plugin-install.ts
@@ -34,6 +34,11 @@ export interface PluginInstallGateContext {
   pluginVersion: string;
   /** sha256 the peer advertised. Truncated to first 8 hex chars in the summary. */
   pluginSha256?: string | null;
+  /**
+   * Search-time identity check failed; peerNode is attacker-controlled
+   * evidence and must never become the trust key.
+   */
+  identityMismatch?: boolean;
 }
 
 export interface PluginInstallGateDecision {
@@ -53,7 +58,20 @@ export function shortSha(sha?: string | null): string {
 export async function maybeGatePluginInstall(
   ctx: PluginInstallGateContext,
 ): Promise<PluginInstallGateDecision> {
-  const { myNode, peerName, peerNode, peerUrl, pluginName, pluginVersion, pluginSha256 } = ctx;
+  const { myNode, peerName, peerNode, peerUrl, pluginName, pluginVersion, pluginSha256, identityMismatch } = ctx;
+
+  if (identityMismatch) {
+    return {
+      allow: false,
+      exitCode: 1,
+      message: [
+        `\x1b[31m✗ peer identity mismatch\x1b[0m: refusing plugin-install consent`,
+        `  configured peer: ${peerName}  [${peerUrl}]`,
+        peerNode ? `  manifest claimed node: ${peerNode}` : "",
+        `  refusing to bind trust to the claimed peer node`,
+      ].filter(Boolean).join("\n"),
+    };
+  }
 
   // Trust key requires a stable peer node identifier. Fall back to peerName
   // when the peer didn't advertise its node (legacy) so install isn't silently

--- a/test/core/consent/gate-plugin-install.test.ts
+++ b/test/core/consent/gate-plugin-install.test.ts
@@ -60,6 +60,32 @@ describe("shortSha", () => {
 });
 
 describe("maybeGatePluginInstall", () => {
+  it("refuses identity-mismatched peers before checking trust or requesting consent", async () => {
+    recordTrust({
+      from: "me",
+      to: "attacker",
+      action: "plugin-install",
+      approvedAt: new Date().toISOString(),
+      approvedBy: "human",
+      requestId: null,
+    });
+
+    const d = await maybeGatePluginInstall({
+      myNode: "me",
+      peerName: "white",
+      peerNode: "attacker",
+      peerUrl: "http://white:3456",
+      pluginName: "ping",
+      pluginVersion: "1.0.0",
+      identityMismatch: true,
+    });
+
+    expect(d.allow).toBe(false);
+    expect(d.exitCode).toBe(1);
+    expect(d.message).toContain("peer identity mismatch");
+    expect(d.message).toContain("refusing to bind trust");
+  });
+
   it("allows when peer is already trusted for plugin-install", async () => {
     recordTrust({
       from: "neo", to: "white", action: "plugin-install",

--- a/test/integration/plugin-install-consent.test.ts
+++ b/test/integration/plugin-install-consent.test.ts
@@ -157,7 +157,7 @@ describe.skipIf(SKIP)("plugin install — @peer + consent gate (#644 Phase 3)", 
   const pluginName = "integ-consent-ping";
   const pluginVersion = "1.0.0";
   const myNode = "client-node";
-  const peerNode = "peer-alpha";
+  const peerNode = "alpha";
 
   const prev = {
     pluginsDir: process.env.MAW_PLUGINS_DIR,
@@ -229,6 +229,7 @@ describe.skipIf(SKIP)("plugin install — @peer + consent gate (#644 Phase 3)", 
       pluginName,
       pluginVersion: resolved.version,
       pluginSha256: resolved.peerSha256,
+      identityMismatch: resolved.identityMismatch,
     });
 
     expect(decision.allow).toBe(false);
@@ -279,6 +280,7 @@ describe.skipIf(SKIP)("plugin install — @peer + consent gate (#644 Phase 3)", 
       pluginName,
       pluginVersion: resolved.version,
       pluginSha256: resolved.peerSha256,
+      identityMismatch: resolved.identityMismatch,
     });
     expect(decision.allow).toBe(true);
 

--- a/test/isolated/plugin-install-impl-more-coverage.test.ts
+++ b/test/isolated/plugin-install-impl-more-coverage.test.ts
@@ -27,6 +27,7 @@ type HandlerCall = { fn: string; args: unknown[] };
 type ResolvedPeer = {
   peerName: string;
   peerNode?: string;
+  identityMismatch?: boolean;
   peerUrl: string;
   version: string;
   peerSha256?: string;
@@ -307,6 +308,30 @@ describe("cmdPluginInstall peer source flow", () => {
         ],
       },
     ]);
+  });
+
+  test("refuses identity-mismatched peers before consent or download", async () => {
+    resolvedPeer = {
+      peerName: "white",
+      peerNode: "attacker",
+      identityMismatch: true,
+      peerUrl: "http://white.internal:2700",
+      version: "2.0.0",
+      peerSha256: "sha256:abcdef1234567890",
+      downloadUrl: "http://white.internal:2700/api/plugin/download/ping",
+    };
+    plannedMode = { kind: "peer", src: "ping@white", name: "ping", peer: "white" };
+
+    await expect(cmdPluginInstall(["ping@white"])).rejects.toThrow(
+      /__plugin_install_impl_test_exit__:1/,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toContain("peer identity mismatch");
+    expect(stderr.join("\n")).toContain("manifest claimed node: attacker");
+    expect(stderr.join("\n")).toContain("refusing to bind consent/trust");
+    expect(consentCalls).toEqual([]);
+    expect(handlerCalls).toEqual([]);
   });
 
   test("uses local fallback node name and continues when consent allows", async () => {

--- a/test/security/peer-manifest-adversarial.test.ts
+++ b/test/security/peer-manifest-adversarial.test.ts
@@ -23,6 +23,8 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 import { searchPeers } from "../../src/commands/plugins/plugin/search-peers";
+import { resolvePeerInstall } from "../../src/commands/plugins/plugin/install-peer-resolver";
+import { maybeGatePluginInstall } from "../../src/core/consent/gate-plugin-install";
 import type { CurlResponse } from "../../src/core/transport/curl-fetch";
 
 // ─── Harness ─────────────────────────────────────────────────────────────────
@@ -153,6 +155,48 @@ describe("identity swap (peer claims another node's name)", () => {
     } finally {
       console.warn = origWarn;
     }
+  });
+
+  test("resolvePeerInstall surfaces identityMismatch so install can refuse before trust binding", async () => {
+    const resolved = await resolvePeerInstall("example", "white", {
+      searchImpl: async () => ({
+        hits: [{
+          name: "example",
+          version: "1.0.0",
+          peerName: "white",
+          peerNode: "attacker",
+          peerUrl: "http://white:3456",
+          identityMismatch: true,
+        }],
+        queried: 1,
+        responded: 1,
+        errors: [],
+        elapsedMs: 1,
+      }),
+    });
+
+    expect(resolved.peerName).toBe("white");
+    // Preserved only as evidence for the refusal message, not as a trust key.
+    expect(resolved.peerNode).toBe("attacker");
+    expect(resolved.identityMismatch).toBe(true);
+  });
+
+  test("plugin consent gate refuses identityMismatch before claimed peerNode can become trust key", async () => {
+    const decision = await maybeGatePluginInstall({
+      myNode: "m5",
+      peerName: "white",
+      peerNode: "attacker",
+      peerUrl: "http://white:3456",
+      pluginName: "example",
+      pluginVersion: "1.0.0",
+      identityMismatch: true,
+    });
+
+    expect(decision.allow).toBe(false);
+    expect(decision.exitCode).toBe(1);
+    expect(decision.message).toContain("peer identity mismatch");
+    expect(decision.message).toContain("refusing to bind trust");
+    expect(decision.message).toContain("attacker");
   });
 
   test("honest peer (node matches configured name) → no mismatch flag, no warn", async () => {


### PR DESCRIPTION
## Summary
- surface search-time identityMismatch through resolvePeerInstall
- refuse peer plugin installs before consent/download when identity mismatches
- add resolver, consent gate, install flow, and adversarial regressions

Closes #2787

## Test plan
- bun test test/core/consent/gate-plugin-install.test.ts
- bun test test/security/peer-manifest-adversarial.test.ts
- bun test test/isolated/plugin-install-impl-more-coverage.test.ts
- bun test test/integration/plugin-install-consent.test.ts
- MAW_SENDER=m5:mawjs bun test test/ghq-helper.test.ts
- MAW_SENDER=m5:mawjs bun run test (2447 pass; one unrelated ghq helper timeout in full run, passed on focused rerun)