### PR TITLE
fix(team up): worktree base from charter.project not cwd

### DIFF
--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -3,6 +3,7 @@
 // Paths differ from the core copy: charter is a sibling here, and commands/shared
 // is three levels up (vendored dir is src/vendor/mpr-plugins/team).
 import { existsSync, readFileSync } from "fs";
+import { ghqFind } from "maw-js/sdk";
 import { resolve } from "path";
 import { readTeamCharter, type TeamCharter } from "./team-charter";
 import { loadConfig } from "../../../config/load";
@@ -76,6 +77,25 @@ export interface TeamUpDeps {
 
 const DEFAULT_SLEEP = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 const SHELL_RE = /^-?(zsh|bash|sh|fish)$/i;
+
+function normalizeProjectSlug(project: string): string {
+  return project
+    .trim()
+    .replace(/^https?:\/\/github\.com\//i, "")
+    .replace(/^git@github\.com:/i, "")
+    .replace(/^github\.com\//i, "")
+    .replace(/\.git$/i, "")
+    .replace(/^\/+|\/+$/g, "");
+}
+
+async function resolveProjectRepoRoot(project: string): Promise<string> {
+  const slug = normalizeProjectSlug(project);
+  const repoRoot = await ghqFind(`github.com/${slug}`) ?? await ghqFind(`/${slug}`);
+  if (!repoRoot) {
+    throw new UserError(`team up project repo not found: ${slug} (try: ghq get github.com/${slug})`);
+  }
+  return repoRoot;
+}
 
 function renderRoster(team: string, session: string, roster: ClassifiedTeamMember[], actions: TeamUpAction[], warnings: string[], tail?: string): string {
   const actionByMember = new Map(actions.map((action) => [action.memberKey, action]));
@@ -214,6 +234,11 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   const repoRoot = deps.repoRoot ?? findRepoRoot(cwd);
   const repoSlug = deps.repoSlug ?? repoSlugFromRoot(repoRoot);
   const targetRepoSlug = charter.project ?? repoSlug;
+  let worktreeRepoRoot: string | undefined;
+  const resolveWorktreeRepoRoot = async () => {
+    worktreeRepoRoot ??= charter.project ? await resolveProjectRepoRoot(charter.project) : repoRoot;
+    return worktreeRepoRoot;
+  };
   const currentSession = await currentTmuxSession(tmux).catch(() => "");
   const session = opts.session?.trim() || charter.session || currentSession;
   if (!session) throw new Error(`session required: pass --session <name> when running team up outside tmux and charter.session is omitted`);
@@ -290,7 +315,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
         item,
         run: async () => {
           if (item.pane) await tmux.run("kill-window", "-t", `${item.pane.sessionName ?? session}:${item.pane.windowName}`);
-          await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
+          await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: await resolveWorktreeRepoRoot(), channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
         },
       });
     } else if (item.state === "live") {
@@ -311,7 +336,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
       launchTasks.push({
         item,
         run: async () => {
-          await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
+          await wakeMember(targetRepoSlug, item.member, { engine: item.engine, session, repoPath: await resolveWorktreeRepoRoot(), channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
         },
       });
     }

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -13,9 +13,11 @@ import { cmdTeamUp, quickCharter } from "../../src/vendor/mpr-plugins/team/team-
 import { cmdTeamDown, TEAM_LIFECYCLE_GUARD_WINDOW } from "../../src/vendor/mpr-plugins/team/team-down";
 import { cmdTeamApply } from "../../src/vendor/mpr-plugins/team/team-apply";
 import { isUserError } from "../../src/core/util/user-error";
+import { resetRepos, setRepos } from "../../src/core/repo-discovery";
 
 const dirs: string[] = [];
 afterEach(() => {
+  resetRepos();
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -386,10 +388,12 @@ agents:
     ]);
   });
 
-  test("team up wakes charter.project and primes inline plus file-ref prompts", async () => {
+  test("team up wakes charter.project from the project repo, not the invoking cwd repo", async () => {
     const root = mkdtempSync(join(tmpdir(), "maw-node-prompt-"));
-    dirs.push(root);
+    const projectRoot = mkdtempSync(join(tmpdir(), "maw-project-root-"));
+    dirs.push(root, projectRoot);
     mkdirSync(join(root, ".git"));
+    mkdirSync(join(projectRoot, ".git"));
     mkdirSync(join(root, ".maw"), { recursive: true });
     mkdirSync(join(root, "prompts"), { recursive: true });
     writeFileSync(join(root, "prompts", "claude48.md"), "file prompt\n", "utf-8");
@@ -406,6 +410,14 @@ agents:
     engine: claude48
     prompt: ./prompts/claude48.md
 `, "utf-8");
+    setRepos({
+      name: "test-ghq",
+      list: async () => [`/ghq/github.com/soul-brews-studio/mawjs-oracle`, `${projectRoot}/github.com/soul-brews-studio/maw-js`],
+      listSync: () => [`/ghq/github.com/soul-brews-studio/mawjs-oracle`, `${projectRoot}/github.com/soul-brews-studio/maw-js`],
+      findBySuffix: async (suffix: string) => suffix.toLowerCase().includes("soul-brews-studio/maw-js") ? projectRoot : null,
+      findBySuffixSync: (suffix: string) => suffix.toLowerCase().includes("soul-brews-studio/maw-js") ? projectRoot : null,
+      detectFromCwd: () => null,
+    });
     const { tmux } = fakeTmux([]);
     const wakes: any[] = [];
     const sends: any[] = [];
@@ -421,9 +433,10 @@ agents:
     });
 
     expect(wakes).toEqual([
-      ["soul-brews-studio/maw-js", { wt: "codex", engine: "omx", session: "charter-session", repoPath: root, channels: true }],
-      ["soul-brews-studio/maw-js", { wt: "claude48", engine: "claude48", session: "charter-session", repoPath: root, channels: true }],
+      ["soul-brews-studio/maw-js", { wt: "codex", engine: "omx", session: "charter-session", repoPath: projectRoot, channels: true }],
+      ["soul-brews-studio/maw-js", { wt: "claude48", engine: "claude48", session: "charter-session", repoPath: projectRoot, channels: true }],
     ]);
+    expect(wakes.map((wake) => wake[1].repoPath)).not.toContain(root);
     expect(sends).toEqual([
       ["charter-session:codex", "inline prompt", false, { currentSession: "charter-session" }],
       ["charter-session:claude48", "file prompt", false, { currentSession: "charter-session" }],


### PR DESCRIPTION
Closes #2798

team-up resolved the worktree base from the invoking cwd instead of `charter.project`, so members spawned as worktrees of the orchestrator's repo. Now ghq-resolves `charter.project` for the wake repoPath; cwd fallback only when no project set. Regression added; test mocks the resolver (no real ghq/network — was hanging CI).

Implemented by mawjs-codex-2; verified green (28 pass / 0 fail / 424ms, exits clean) + shipped by oracle (codex stalled at commit gate).