### PR TITLE
Fix maw capture target resolution

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -375,6 +375,9 @@ export declare function sparkline(values: number[], hadActivity?: boolean[]): st
 /** Peek/capture a target session or window and print the result. */
 export declare function cmdPeek(query?: string): Promise<void>;
 
+/** Resolve a local target using the same session/window resolver as maw peek. */
+export declare function resolvePeekTarget(query: string): Promise<string | null>;
+
 /** Send a message to an oracle/window target. */
 export declare function cmdSend(target: string, message: string, force?: boolean): Promise<void>;
 export declare function resolveOraclePane(target: string): Promise<string>;

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -67,7 +67,7 @@ export { sparkline } from "../../src/lib/sparkline";
 
 // ─── src/commands/shared/comm ────────────────────────────────────────────────
 // Federation-aware communication helpers used by small command plugins.
-export { cmdPeek, cmdSend } from "../../src/commands/shared/comm";
+export { cmdPeek, cmdSend, resolvePeekTarget } from "../../src/commands/shared/comm";
 export { resolveOraclePane } from "../../src/commands/shared/comm-send";
 export {
   deletePending,

--- a/src/commands/shared/comm-peek.ts
+++ b/src/commands/shared/comm-peek.ts
@@ -49,10 +49,41 @@ export function resolveSearchSessions(
   return sessions;
 }
 
-export interface CmdPeekDeps extends ResolveSearchSessionsDeps {
+export interface ResolvePeekTargetDeps extends ResolveSearchSessionsDeps {
   listSessions: typeof listSessions;
-  capture: typeof capture;
   findWindow: typeof findWindow;
+}
+
+export function resolvePeekTargetDeps(overrides: Partial<ResolvePeekTargetDeps> = {}): ResolvePeekTargetDeps {
+  return {
+    ...resolveSearchSessionsDeps(),
+    listSessions,
+    findWindow,
+    ...overrides,
+  };
+}
+
+export async function resolvePeekTarget(query: string, deps: Partial<ResolvePeekTargetDeps> = {}): Promise<string | null> {
+  const io = resolvePeekTargetDeps(deps);
+  let normalized = normalizeTarget(query);
+  const config = io.loadConfig();
+
+  // Keep the same local node-prefix behavior as cmdPeek: `local:<agent>` and
+  // `<config.node>:<agent>` are aliases for the local agent/window query, not
+  // literal tmux `session:window` targets.
+  if (normalized.includes(":") && !normalized.includes("/")) {
+    const [nodeName, agentName] = normalized.split(":", 2);
+    const localNode = config.node || "local";
+    if (nodeName === localNode || nodeName === "local") normalized = agentName;
+  }
+
+  const sessions = await io.listSessions();
+  const searchIn = resolveSearchSessions(normalized, sessions, { ...io, loadConfig: () => config });
+  return io.findWindow(searchIn, normalized);
+}
+
+export interface CmdPeekDeps extends ResolvePeekTargetDeps {
+  capture: typeof capture;
   curlFetch: typeof curlFetch;
   shouldAutoWake: typeof shouldAutoWake;
   log: (...args: unknown[]) => void;
@@ -145,8 +176,7 @@ export async function cmdPeek(query?: string, deps: Partial<CmdPeekDeps> = {}) {
     }
     return;
   }
-  const searchIn = resolveSearchSessions(query, sessions, io);
-  const target = io.findWindow(searchIn, query);
+  const target = await resolvePeekTarget(query, { ...io, listSessions: async () => sessions });
   if (!target) { io.error(`window not found: ${query}`); io.exit(1); }
   const content = await io.capture(target);
   io.log(`\x1b[36m--- ${target} ---\x1b[0m`);

--- a/src/commands/shared/comm.ts
+++ b/src/commands/shared/comm.ts
@@ -6,5 +6,5 @@
 
 export { logMessage, emitFeed } from "./comm-log-feed";
 export { renderSessionName, cmdList } from "./comm-list";
-export { resolveSearchSessions, cmdPeek } from "./comm-peek";
+export { resolveSearchSessions, resolvePeekTarget, cmdPeek } from "./comm-peek";
 export { resolveOraclePane, resolveMyName, cmdSend, checkPaneIdle } from "./comm-send";

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -214,7 +214,7 @@ export { sparkline } from "../lib/sparkline";
 export { tlink } from "../core/util/terminal";
 
 // Plugin extraction helpers for tab-like command surfaces.
-export { cmdPeek, cmdSend } from "../commands/shared/comm";
+export { cmdPeek, cmdSend, resolvePeekTarget } from "../commands/shared/comm";
 export { cmdSplit } from "../commands/plugins/split/impl";
 export { buildAgentRows } from "../commands/shared/agents";
 export type { AgentRow } from "../commands/shared/agents";

--- a/src/vendor/mpr-plugins/capture/impl.ts
+++ b/src/vendor/mpr-plugins/capture/impl.ts
@@ -1,5 +1,4 @@
-import { hostExec, listSessions, loadFleetCore as loadFleet, tmuxCmd } from "maw-js/sdk";
-import { resolveAttachTarget } from "../attach/resolve-attach-target";
+import { hostExec, resolvePeekTarget, tmuxCmd } from "maw-js/sdk";
 
 export interface CaptureOpts {
   /** Pane index within the resolved window. Default: current/first. */
@@ -25,28 +24,12 @@ export async function cmdCapture(target: string, opts: CaptureOpts = {}) {
     throw new Error("usage: maw capture <target> [--pane N] [--lines N] [--full]\n  e.g. maw capture mawjs\n       maw capture neo:0 --pane 1 --lines 100\n       maw capture mawjs --full");
   }
 
-  const [left, right] = target.includes(":")
-    ? target.split(":", 2)
-    : [target, undefined];
-  const isTmuxWindowSuffix = right !== undefined && /^\d+(?:\.\d+)?$/.test(right);
-  const rawSession = right !== undefined && !isTmuxWindowSuffix ? right : left;
-  const explicitWindow = isTmuxWindowSuffix ? right : undefined;
-  const sessions = await listSessions();
-  const result = await resolveAttachTarget(rawSession, { listSessions: async () => sessions as any, loadFleet });
+  const resolved = await resolvePeekTarget(target);
 
-  if (!result || result.tier !== 1) {
+  if (!resolved) {
     console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
-    throw new Error(`session '${rawSession}' not found`);
+    throw new Error(`target '${target}' not found`);
   }
-  if (result.ambiguousCandidates && result.ambiguousCandidates.length > 1) {
-    console.error(`  \x1b[31m✗\x1b[0m '${rawSession}' is ambiguous — matches ${result.ambiguousCandidates.length} sessions:`);
-    for (const s of result.ambiguousCandidates) console.error(`  \x1b[90m    • ${s}\x1b[0m`);
-    throw new Error(`'${rawSession}' is ambiguous — matches ${result.ambiguousCandidates.length} sessions`);
-  }
-
-  const matched = sessions.find(s => s.name === result.sessionName);
-  const windowIndex = explicitWindow ?? matched?.windows?.[0]?.index ?? 0;
-  const resolved = `${result.sessionName}:${windowIndex}`;
 
   const paneSuffix = opts.pane !== undefined ? `.${opts.pane}` : "";
   const full = resolved + paneSuffix;

--- a/test/comm-peek-default.test.ts
+++ b/test/comm-peek-default.test.ts
@@ -7,6 +7,7 @@ import type { SshSession as Session } from "../src/sdk";
 import {
   cmdPeek,
   cmdPeekDeps,
+  resolvePeekTarget,
   resolveSearchSessions,
   resolveSearchSessionsDeps,
   type CmdPeekDeps,
@@ -156,6 +157,48 @@ describe("resolveSearchSessions", () => {
       loadConfig: () => ({}) as MawConfig,
       resolveFleetSession: () => null,
     })).toBe(sessions);
+  });
+});
+
+describe("resolvePeekTarget", () => {
+  const sessions = [
+    session("167-web-v2", [
+      { index: 1, name: "web-v2-oracle" },
+      { index: 2, name: "web-v2-web-v2.wt-coder-2" },
+    ]),
+    session("50-mawjs", [{ index: 0, name: "mawjs-oracle" }]),
+  ];
+
+  test("resolves session:window through the same findWindow path peek uses", async () => {
+    const findCalls: Array<{ sessions: Session[]; query: string }> = [];
+    const target = await resolvePeekTarget("web-v2:2", {
+      loadConfig: () => ({ node: "m5" }) as MawConfig,
+      resolveFleetSession: () => null,
+      listSessions: async () => sessions,
+      findWindow: (search, query) => {
+        findCalls.push({ sessions: search, query });
+        return "167-web-v2:2";
+      },
+    });
+
+    expect(target).toBe("167-web-v2:2");
+    expect(findCalls).toEqual([{ sessions, query: "web-v2:2" }]);
+  });
+
+  test("strips local node prefixes before local lookup", async () => {
+    const queries: string[] = [];
+    const target = await resolvePeekTarget("m5:mawjs", {
+      loadConfig: () => ({ node: "m5" }) as MawConfig,
+      resolveFleetSession: () => null,
+      listSessions: async () => sessions,
+      findWindow: (_search, query) => {
+        queries.push(query);
+        return "50-mawjs:0";
+      },
+    });
+
+    expect(target).toBe("50-mawjs:0");
+    expect(queries).toEqual(["mawjs"]);
   });
 });
 

--- a/test/isolated/plugin-capture-standalone.test.ts
+++ b/test/isolated/plugin-capture-standalone.test.ts
@@ -11,9 +11,9 @@ type Session = { name: string; windows?: Array<{ index?: number; name?: string }
 let sessions: Session[] = [];
 let hostCommands: string[] = [];
 let hostOutput = "captured output";
-let resolveResult: unknown = { tier: 1, sessionName: "54-mawjs" };
+let resolveResult: string | null = "54-mawjs:7";
 let loadFleetCalls = 0;
-let resolveCalls: Array<{ target: string; deps: Record<string, unknown> }> = [];
+let resolveCalls: string[] = [];
 
 function parseFlags(args: string[], spec: Record<string, unknown>) {
   const out: Record<string, any> = { _: [] };
@@ -42,34 +42,12 @@ mock.module("maw-js/sdk", () => ({
     loadFleetCalls += 1;
     return [{ name: "54-mawjs", windows: [{ name: "mawjs-oracle" }] }];
   },
-  parseFlags,
-  tmuxCmd: () => "tmux -L test",
-}));
-
-mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/attach/resolve-attach-target.ts"), () => ({
-  resolveAttachTarget: async (target: string, deps: Record<string, unknown>) => {
-    resolveCalls.push({ target, deps });
-    if (target === "remote:") {
-      return { tier: "error", error: "invalid remote attach target 'remote:'" };
-    }
-    if (target === "remote:neo") {
-      return { tier: 3, node: "remote", sessionName: "neo", sshAlias: "remote-ssh" };
-    }
-    if (target === "01-mawjs") {
-      const rows = await (deps.listSessions as () => Promise<Session[]>)();
-      const row = rows.find((session) => session.name === target);
-      if (row) {
-        const windowName = row.windows?.find((window) => window.name === "mawjs-oracle")?.name;
-        return { tier: 1, sessionName: row.name, ...(windowName ? { windowName } : {}) };
-      }
-    }
-    if (target === "sleepy") {
-      const rows = (deps.loadFleet as () => Session[])();
-      const row = rows.find((session) => session.name === "02-sleepy" || session.windows?.some((window) => window.name === "sleepy"));
-      if (row) return { tier: 2, fleetName: row.name };
-    }
+  resolvePeekTarget: async (target: string) => {
+    resolveCalls.push(target);
     return resolveResult;
   },
+  parseFlags,
+  tmuxCmd: () => "tmux -L test",
 }));
 
 const { command, default: captureHandler } = await import("../../src/vendor/mpr-plugins/capture/index.ts");
@@ -82,7 +60,7 @@ beforeEach(() => {
   sessions = [{ name: "54-mawjs", windows: [{ index: 7, name: "mawjs-oracle" }] }];
   hostCommands = [];
   hostOutput = "captured output";
-  resolveResult = { tier: 1, sessionName: "54-mawjs" };
+  resolveResult = "54-mawjs:7";
   loadFleetCalls = 0;
   resolveCalls = [];
 });
@@ -111,15 +89,18 @@ describe("capture plugin standalone boundary (#2191)", () => {
     const result = await captureHandler({ source: "cli", args: ["mawjs", "--pane", "2", "--lines", "12"] } as any);
 
     expect(result).toEqual({ ok: true, output: "captured output" });
-    expect(resolveCalls.map((call) => call.target)).toEqual(["mawjs"]);
+    expect(resolveCalls).toEqual(["mawjs"]);
     expect(loadFleetCalls).toBe(0);
     expect(hostCommands).toEqual(["tmux -L test capture-pane -t '54-mawjs:7.2' -p -S -12"]);
   });
 
   test("API target supports explicit window suffix and full scrollback", async () => {
+    resolveResult = "54-mawjs:3";
+
     const result = await captureHandler({ source: "api", args: { target: "mawjs:3", full: true } } as any);
 
     expect(result.ok).toBe(true);
+    expect(resolveCalls).toEqual(["mawjs:3"]);
     expect(hostCommands).toEqual(["tmux -L test capture-pane -t '54-mawjs:3' -p -S -"]);
   });
 

--- a/test/isolated/ui-capture-helpers-coverage.test.ts
+++ b/test/isolated/ui-capture-helpers-coverage.test.ts
@@ -9,11 +9,6 @@ type Session = {
   windows?: Array<{ index: number; name?: string }>;
 };
 
-type ResolveResult =
-  | { tier: 1; sessionName: string; ambiguousCandidates?: string[] }
-  | { tier: 2; fleetName: string; ambiguousCandidates?: string[] }
-  | null;
-
 let namedPeers: Array<{ name: string; url: string }> = [];
 let configValue: any;
 let ghqPath: string | null = null;
@@ -21,8 +16,8 @@ let ghqCalls: string[] = [];
 let mockHomeDir: string | null = null;
 
 let sessions: Session[] = [];
-let resolveResults: ResolveResult[] = [];
-let resolveCalls: Array<{ target: string; sessions: Session[] }> = [];
+let resolveTargetResults: Array<string | null> = [];
+let resolveTargetCalls: string[] = [];
 let hostExecCalls: string[] = [];
 let hostExecResult = "";
 let hostExecError: unknown = null;
@@ -57,6 +52,10 @@ mock.module("maw-js/sdk", () => ({
   loadConfig: () => (configValue === undefined ? { namedPeers } : configValue),
   listSessions: async () => sessions,
   loadFleetCore: () => [],
+  resolvePeekTarget: async (target: string) => {
+    resolveTargetCalls.push(target);
+    return resolveTargetResults.shift() ?? null;
+  },
   hostExec: async (cmd: string) => {
     hostExecCalls.push(cmd);
     if (hostExecError) throw hostExecError;
@@ -67,14 +66,6 @@ mock.module("maw-js/sdk", () => ({
 
 mock.module("maw-js/commands/shared/fleet-load", () => ({
   loadFleet: () => [],
-}));
-
-mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/attach/resolve-attach-target.ts"), () => ({
-  resolveAttachTarget: async (target: string, deps: any) => {
-    const currentSessions = await deps.listSessions();
-    resolveCalls.push({ target, sessions: currentSessions });
-    return resolveResults.shift() ?? null;
-  },
 }));
 
 const {
@@ -113,8 +104,8 @@ beforeEach(() => {
   ghqCalls = [];
 
   sessions = [];
-  resolveResults = [];
-  resolveCalls = [];
+  resolveTargetResults = [];
+  resolveTargetCalls = [];
   hostExecCalls = [];
   hostExecResult = "";
   hostExecError = null;
@@ -230,109 +221,55 @@ describe("ui impl helpers coverage", () => {
 describe("capture impl coverage", () => {
   test("rejects a missing target before resolving sessions", async () => {
     await expect(cmdCapture("")).rejects.toThrow("usage: maw capture <target>");
-    expect(resolveCalls).toEqual([]);
+    expect(resolveTargetCalls).toEqual([]);
     expect(hostExecCalls).toEqual([]);
   });
 
-  test("reports ambiguous colon targets with all candidate names", async () => {
-    sessions = [{ name: "mawjs" }, { name: "mawjs-alpha" }];
-    resolveResults = [{ tier: 1, sessionName: "mawjs", ambiguousCandidates: ["mawjs", "mawjs-alpha"] }];
+  test("reports missing targets using peek resolver guidance", async () => {
+    resolveTargetResults = [null];
 
-    await expect(cmdCapture("maw:2")).rejects.toThrow("'maw' is ambiguous — matches 2 sessions");
+    await expect(cmdCapture("missing:4")).rejects.toThrow("target 'missing:4' not found");
 
-    expect(resolveCalls).toEqual([{ target: "maw", sessions }]);
-    expect(errors.join("\n")).toContain("'maw' is ambiguous — matches 2 sessions");
-    expect(errors.join("\n")).toContain("• mawjs");
-    expect(errors.join("\n")).toContain("• mawjs-alpha");
-    expect(hostExecCalls).toEqual([]);
-  });
-
-  test("reports missing colon targets with hints", async () => {
-    sessions = [{ name: "clinic" }];
-    resolveResults = [null];
-
-    await expect(cmdCapture("clnic:1")).rejects.toThrow("session 'clnic' not found");
-
-    expect(resolveCalls).toEqual([{ target: "clnic", sessions }]);
+    expect(resolveTargetCalls).toEqual(["missing:4"]);
     expect(errors.join("\n")).toContain("try: maw ls");
     expect(hostExecCalls).toEqual([]);
   });
 
-  test("reports missing colon targets without hints", async () => {
-    sessions = [{ name: "neo" }];
-    resolveResults = [null];
-
-    await expect(cmdCapture("missing:4")).rejects.toThrow("session 'missing' not found");
-
-    expect(resolveCalls).toEqual([{ target: "missing", sessions }]);
-    expect(errors.join("\n")).not.toContain("did you mean:");
-    expect(errors.join("\n")).toContain("try: maw ls");
-    expect(hostExecCalls).toEqual([]);
-  });
-
-  test("reports ambiguous bare targets with all candidate names", async () => {
-    sessions = [{ name: "neo" }, { name: "neo-alpha" }];
-    resolveResults = [{ tier: 1, sessionName: "neo", ambiguousCandidates: ["neo", "neo-alpha"] }];
-
-    await expect(cmdCapture("neo")).rejects.toThrow("'neo' is ambiguous — matches 2 sessions");
-
-    expect(resolveCalls).toEqual([{ target: "neo", sessions }]);
-    expect(errors.join("\n")).toContain("'neo' is ambiguous — matches 2 sessions");
-    expect(errors.join("\n")).toContain("• neo");
-    expect(errors.join("\n")).toContain("• neo-alpha");
-    expect(hostExecCalls).toEqual([]);
-  });
-
-  test("reports missing bare targets with maw ls guidance when no hints exist", async () => {
-    sessions = [{ name: "neo" }];
-    resolveResults = [null];
-
-    await expect(cmdCapture("missing")).rejects.toThrow("session 'missing' not found");
-
-    expect(resolveCalls).toEqual([{ target: "missing", sessions }]);
-    expect(errors.join("\n")).toContain("try: maw ls");
-    expect(hostExecCalls).toEqual([]);
-  });
-
-  test("captures default bare target window with requested tail lines and prints raw output", async () => {
-    sessions = [{ name: "Neo", windows: [{ index: 7, name: "shell" }] }];
-    resolveResults = [{ tier: 1, sessionName: sessions[0]!.name }];
+  test("captures the exact target returned by the shared peek resolver", async () => {
+    resolveTargetResults = ["Neo:7"];
     hostExecResult = "hello\nworld";
 
     await cmdCapture("neo", { lines: 2 });
 
-    expect(resolveCalls).toEqual([{ target: "neo", sessions }]);
+    expect(resolveTargetCalls).toEqual(["neo"]);
     expect(hostExecCalls).toEqual(["tmux-test capture-pane -t 'Neo:7' -p -S -2"]);
     expect(logs).toEqual(["hello\nworld"]);
   });
 
-  test("captures colon target with pane suffix and full scrollback", async () => {
-    sessions = [{ name: "Neo", windows: [] }];
-    resolveResults = [{ tier: 1, sessionName: sessions[0]!.name }];
+  test("regression #2804: session:window targets resolved by peek also capture", async () => {
+    resolveTargetResults = ["167-web-v2:2"];
+    hostExecResult = "web-v2 pane";
+
+    await cmdCapture("web-v2:2", { lines: 5 });
+
+    expect(resolveTargetCalls).toEqual(["web-v2:2"]);
+    expect(hostExecCalls).toEqual(["tmux-test capture-pane -t '167-web-v2:2' -p -S -5"]);
+    expect(logs).toEqual(["web-v2 pane"]);
+  });
+
+  test("preserves explicit --pane and full scrollback on the resolved target", async () => {
+    resolveTargetResults = ["Neo:3"];
     hostExecResult = "full history";
 
     await cmdCapture("neo:3", { pane: 2, full: true, lines: 1 });
 
-    expect(resolveCalls).toEqual([{ target: "neo", sessions }]);
+    expect(resolveTargetCalls).toEqual(["neo:3"]);
     expect(hostExecCalls).toEqual(["tmux-test capture-pane -t 'Neo:3.2' -p -S -"]);
     expect(logs).toEqual(["full history"]);
   });
 
-  test("uses pane zero and default tail length when a match has an empty windows list", async () => {
-    sessions = [{ name: "Sparse", windows: [] }];
-    resolveResults = [{ tier: 1, sessionName: sessions[0]!.name }];
-    hostExecResult = "";
-
-    await cmdCapture("sparse");
-
-    expect(resolveCalls).toEqual([{ target: "sparse", sessions }]);
-    expect(hostExecCalls).toEqual(["tmux-test capture-pane -t 'Sparse:0' -p -S -50"]);
-    expect(logs).toEqual([]);
-  });
-
   test("wraps tmux capture failures with capture failed context", async () => {
-    sessions = [{ name: "Neo", windows: [{ index: 0 }] }];
-    resolveResults = [{ tier: 1, sessionName: sessions[0]!.name }];
+    resolveTargetResults = ["Neo:0"];
     hostExecError = new Error("tmux missing");
 
     await expect(cmdCapture("neo")).rejects.toThrow("capture failed: tmux missing");
@@ -341,32 +278,11 @@ describe("capture impl coverage", () => {
   });
 
   test("wraps non-Error tmux failures", async () => {
-    sessions = [{ name: "Neo", windows: [{ index: 0 }] }];
-    resolveResults = [{ tier: 1, sessionName: sessions[0]!.name }];
+    resolveTargetResults = ["Neo:0"];
     hostExecError = "string boom";
 
     await expect(cmdCapture("neo")).rejects.toThrow("capture failed: string boom");
 
     expect(hostExecCalls).toEqual(["tmux-test capture-pane -t 'Neo:0' -p -S -50"]);
   });
-  test("cmdCapture treats node-qualified targets as oracle aliases", async () => {
-    resolveResults = [{ tier: 1, sessionName: "50-mawjs" }];
-    sessions = [{ name: "50-mawjs", windows: [{ index: 0, name: "mawjs-oracle" }] }];
-
-    await cmdCapture("m5:mawjs", { lines: 3 });
-
-    expect(resolveCalls.at(-1)?.target).toBe("mawjs");
-    expect(hostExecCalls.at(-1)).toContain("50-mawjs:0");
-  });
-
-  test("cmdCapture preserves numeric tmux window suffixes", async () => {
-    resolveResults = [{ tier: 1, sessionName: "neo" }];
-    sessions = [{ name: "neo", windows: [{ index: 0, name: "main" }] }];
-
-    await cmdCapture("neo:2", { pane: 1, full: true });
-
-    expect(resolveCalls.at(-1)?.target).toBe("neo");
-    expect(hostExecCalls.at(-1)).toContain("neo:2.1");
-  });
-
 });


### PR DESCRIPTION
## Summary
- add a shared `resolvePeekTarget` helper for peek-style local target resolution
- switch `maw capture` to capture the exact target resolved by that helper
- add regression coverage for #2804 session:window capture consistency

## Verification
- `bun run check:sdk-surface`
- `bun test test/isolated/ui-capture-helpers-coverage.test.ts test/comm-peek-default.test.ts test/isolated/comm-peek.test.ts test/00-ssh.test.ts`
- `bun run test:default:safe`
- `bun run build`

Closes #2804