### PR TITLE
Add read-only maw wtf team doctor

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -26,6 +26,7 @@ import { activeDurationArg, cmdTmuxLayout, cmdTmuxLs, parseActiveDurationSeconds
 import { cmdPreflight } from "../commands/shared/preflight";
 import { cmdNew } from "./cmd-new";
 import { cmdPromote } from "../commands/shared/promote-cmd";
+import { cmdTeamWtf } from "../commands/plugins/team/team-wtf";
 import { parseFlags } from "./parse-args";
 import { UserError } from "../core/util/user-error";
 import { parseBringToTarget } from "../commands/shared/bring-flags";
@@ -58,6 +59,7 @@ export const ALIAS_DESCRIPTIONS: Record<string, string> = {
   new: "Create a plain tmux workspace session",
   preflight: "Pre-flight check — version, plugins, dead agents, config",
   snapshots: "List and inspect fleet recovery snapshots",
+  wtf: "Read-only team drift doctor for the current tmux team",
 };
 
 export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
@@ -94,6 +96,7 @@ export const TOP_ALIASES: Record<string, string[] | DirectHandler> = {
 
   preflight: { kind: "direct", handler: "../commands/shared/preflight:cmdPreflight" },
   snapshots: ["fleet", "snapshots"],
+  wtf: { kind: "direct", handler: "../commands/plugins/team/team-wtf:cmdTeamWtf" },
 };
 
 /**
@@ -318,6 +321,7 @@ export interface TopAliasHandlerDeps {
   cmdNew?: (argv: string[]) => MaybePromise;
   cmdPreflight?: (opts: { fix: boolean }) => MaybePromise;
   cmdPromote?: (argv: string[]) => MaybePromise;
+  cmdTeamWtf?: (teamArg?: string, opts?: { json?: boolean; session?: string }) => MaybePromise;
   loadConfig?: () => { commands?: Record<string, unknown> };
   log?: (line: string) => void;
   error?: (line: string) => void;
@@ -340,6 +344,7 @@ export async function invokeDirectHandler(
   const directCmdNew = deps.cmdNew ?? cmdNew;
   const directCmdPreflight = deps.cmdPreflight ?? cmdPreflight;
   const directCmdPromote = deps.cmdPromote ?? cmdPromote;
+  const directCmdTeamWtf = deps.cmdTeamWtf ?? cmdTeamWtf;
   const log = deps.log ?? console.log;
   const error = deps.error ?? console.error;
 
@@ -572,6 +577,15 @@ export async function invokeDirectHandler(
   if (exportName === "cmdPreflight") {
     const flags = parseFlags(argv, { "--fix": Boolean }, 0);
     await directCmdPreflight({ fix: !!flags["--fix"] });
+    return;
+  }
+
+  if (exportName === "cmdTeamWtf") {
+    const flags = parseFlags(argv, { "--json": Boolean, "--session": String }, 0);
+    await directCmdTeamWtf(flags._[0] as string | undefined, {
+      json: Boolean(flags["--json"]),
+      session: flags["--session"] as string | undefined,
+    });
     return;
   }
 

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -216,6 +216,17 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const team = (flags["--team"] as string | undefined) || resolveTeamFromContext();
       cmdTeamTaskAssign(team, id, agent);
 
+    } else if (sub === "wtf") {
+      const { cmdTeamWtf } = await import("./team-wtf");
+      const flags = parseFlags(args, {
+        "--json": Boolean,
+        "--session": String,
+      }, 1);
+      await cmdTeamWtf(flags._[0] as string | undefined, {
+        json: Boolean(flags["--json"]),
+        session: flags["--session"] as string | undefined,
+      });
+
     } else if (sub === "status") {
       // maw team status [team-name]
       const { cmdTeamStatus } = await import("./team-status");

--- a/src/commands/plugins/team/team-wtf.ts
+++ b/src/commands/plugins/team/team-wtf.ts
@@ -1,0 +1,1 @@
+export * from "../../../vendor/mpr-plugins/team/team-wtf";

--- a/src/vendor/mpr-plugins/team/impl.ts
+++ b/src/vendor/mpr-plugins/team/impl.ts
@@ -115,3 +115,5 @@ export async function cmdTeamList(opts: { all?: boolean } = {}) {
 
   console.log();
 }
+
+export { cmdTeamWtf, inspectTeamWtf, sampleProcessMap, parsePs } from "./team-wtf";

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -257,6 +257,17 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const team = (flags["--team"] as string | undefined) || resolveTeamFromContext();
       cmdTeamTaskAssign(team, id, agent);
 
+    } else if (sub === "wtf") {
+      const { cmdTeamWtf } = await import("./team-wtf");
+      const flags = parseFlags(args, {
+        "--json": Boolean,
+        "--session": String,
+      }, 1);
+      await cmdTeamWtf(flags._[0] as string | undefined, {
+        json: Boolean(flags["--json"]),
+        session: flags["--session"] as string | undefined,
+      });
+
     } else if (sub === "status") {
       // maw team status [team-name]
       const { cmdTeamStatus } = await import("./team-status");
@@ -470,7 +481,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|plan|preflight|load|up|down|apply|remove|reassign|spawn-from|spawn|bring|send|shutdown|prune|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
+      logs.push("usage: maw team <create|plan|preflight|load|up|down|apply|remove|reassign|spawn-from|spawn|bring|send|shutdown|prune|resume|lives|list|status|wtf|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -18,6 +18,9 @@ export interface TeamPaneSnapshot {
   command: string;
   path: string;
   paneId: string;
+  panePid?: string;
+  sessionId?: string;
+  windowId?: string;
 }
 
 export interface TeamSessionSnapshot {
@@ -133,10 +136,10 @@ export function resolveCharterPath(team: string, cwd = process.cwd(), configNode
 }
 
 export async function listPaneSnapshots(tmux: Pick<Tmux, "run"> = new Tmux()): Promise<TeamPaneSnapshot[]> {
-  const raw = await tmux.run("list-panes", "-a", "-F", "#{session_name}|#{window_name}|#{pane_current_command}|#{pane_current_path}|#{pane_id}");
+  const raw = await tmux.run("list-panes", "-a", "-F", "#{session_name}|#{window_name}|#{pane_current_command}|#{pane_current_path}|#{pane_id}|#{pane_pid}|#{session_id}|#{window_id}");
   return raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).map((line) => {
-    const [sessionName = "", windowName = "", command = "", path = "", paneId = ""] = line.split("|");
-    return { sessionName, windowName, command, path, paneId };
+    const [sessionName = "", windowName = "", command = "", path = "", paneId = "", panePid = "", sessionId = "", windowId = ""] = line.split("|");
+    return { sessionName, windowName, command, path, paneId, panePid, sessionId, windowId };
   });
 }
 

--- a/src/vendor/mpr-plugins/team/team-wtf.ts
+++ b/src/vendor/mpr-plugins/team/team-wtf.ts
@@ -1,0 +1,436 @@
+import type { DoctorCheck } from "../doctor/impl";
+import { loadConfig } from "../../../config/load";
+import { resolveEngine } from "../../../config/engine-registry";
+import { UserError } from "../../../core/util/user-error";
+import { Tmux } from "../../../core/transport/tmux";
+import type { MawConfig } from "../../../config/types";
+import {
+  classifyMember,
+  currentTmuxSession,
+  listPaneSnapshots,
+  memberEngineForClassification,
+  memberWindowCandidates,
+  memberWindowIdentity,
+  oracleStemFromRepoSlug,
+  repoSlugFromRoot,
+  resolveCharterPath,
+  type TeamPaneSnapshot,
+} from "./team-liveness";
+import { readTeamCharter, type TeamCharter, type TeamCharterMember } from "./team-charter";
+
+export type TeamWtfVerb = "up" | "done" | "kill" | "send-text" | "report" | "leave" | "none";
+
+export interface ProcessRow {
+  pid: number;
+  ppid: number;
+  pgid?: number;
+  args: string;
+}
+
+export interface PaneProcessBinding {
+  pane: TeamPaneSnapshot;
+  processes: ProcessRow[];
+  engineProcesses: ProcessRow[];
+}
+
+export interface ProcessMapSample {
+  byPaneId: Map<string, PaneProcessBinding>;
+  rows: ProcessRow[];
+}
+
+export interface TeamWtfProcessDeps {
+  ps?: () => Promise<ProcessRow[]> | ProcessRow[];
+  /** Optional cwd lookup for future corroboration. Not used as the binding key. */
+  lsofCwd?: (pid: number) => Promise<string | undefined> | string | undefined;
+}
+
+export interface TeamWtfDeps extends TeamWtfProcessDeps {
+  tmux?: Pick<Tmux, "run">;
+  listPaneSnapshotsFn?: typeof listPaneSnapshots;
+  currentTmuxSessionFn?: typeof currentTmuxSession;
+  resolveCharterPathFn?: typeof resolveCharterPath;
+  readTeamCharterFn?: typeof readTeamCharter;
+  loadConfigFn?: typeof loadConfig;
+  currentWindowRefFn?: (tmux: Pick<Tmux, "run">) => Promise<string | undefined> | string | undefined;
+  processSampleCount?: number;
+}
+
+export interface TeamWtfOptions {
+  json?: boolean;
+  session?: string;
+  cwd?: string;
+  /** Test-only: one sample is intentionally UNKNOWN for negative BUSY evidence. */
+  processSampleCount?: number;
+}
+
+export interface TeamWtfResult {
+  ok: boolean;
+  team: string;
+  session: string;
+  charterPath: string;
+  checks: DoctorCheck[];
+}
+
+const PROMPT_RE = /(?:do you trust|yes, continue|allow\?|allow\s+\[?y|\(y\/n\)|\[y\/n\]|permission|approval)/i;
+
+function stripNumberedSessionPrefix(session: string): string {
+  return session.replace(/^\d+-/, "");
+}
+
+export function detectTeamNameFromSession(session: string): string {
+  return stripNumberedSessionPrefix(session.trim());
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function processBasename(args: string): string {
+  const first = args.trim().split(/\s+/)[0] || "";
+  return first.split(/[\\/]/).pop() || first;
+}
+
+function matchesProcessName(row: ProcessRow, names: readonly string[]): boolean {
+  const base = processBasename(row.args);
+  return names.some((name) => {
+    const wanted = name.trim();
+    if (!wanted) return false;
+    const wantedBase = wanted.split(/[\\/]/).pop() || wanted;
+    return base === wantedBase || row.args.includes(`/${wantedBase} `) || row.args.endsWith(`/${wantedBase}`);
+  });
+}
+
+function descendantsOf(rows: ProcessRow[], rootPid: number): ProcessRow[] {
+  const byPid = new Map(rows.map((row) => [row.pid, row]));
+  const descendants: ProcessRow[] = [];
+  for (const row of rows) {
+    let cursor = row.ppid;
+    const seen = new Set<number>([row.pid]);
+    while (cursor && !seen.has(cursor)) {
+      if (cursor === rootPid) {
+        descendants.push(row);
+        break;
+      }
+      seen.add(cursor);
+      cursor = byPid.get(cursor)?.ppid ?? 0;
+    }
+  }
+  return descendants;
+}
+
+function engineProcessNames(engine: string | undefined, config: MawConfig): string[] {
+  if (!engine) {
+    const names: string[] = [];
+    for (const key of Object.keys(config.engines ?? {})) {
+      try { names.push(...(resolveEngine(key, config).processNames ?? [])); } catch { /* ignore bad config entry */ }
+    }
+    for (const key of Object.keys(config.commands ?? {})) {
+      try { names.push(...(resolveEngine(key, config).processNames ?? [])); } catch { /* ignore bad config entry */ }
+    }
+    return [...new Set(names.filter(Boolean))];
+  }
+  try {
+    return [...new Set((resolveEngine(engine, config).processNames ?? []).filter(Boolean))];
+  } catch {
+    return [];
+  }
+}
+
+async function defaultPs(): Promise<ProcessRow[]> {
+  const proc = Bun.spawn(["ps", "-axo", "pid=,ppid=,pgid=,args="], { stdout: "pipe", stderr: "pipe" });
+  const [code, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+  if (code !== 0) return [];
+  return parsePs(stdout);
+}
+
+export function parsePs(raw: string): ProcessRow[] {
+  return raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).flatMap((line) => {
+    const match = /^(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/.exec(line);
+    if (!match) return [];
+    return [{ pid: Number(match[1]), ppid: Number(match[2]), pgid: Number(match[3]), args: match[4] ?? "" }];
+  });
+}
+
+export async function sampleProcessMap(
+  panes: TeamPaneSnapshot[],
+  engineNames: readonly string[],
+  deps: TeamWtfProcessDeps = {},
+): Promise<ProcessMapSample> {
+  const rows = await (deps.ps ?? defaultPs)();
+  const byPaneId = new Map<string, PaneProcessBinding>();
+  for (const pane of panes) {
+    const panePid = Number(pane.panePid ?? 0);
+    if (!pane.paneId || !Number.isFinite(panePid) || panePid <= 0) continue;
+    const processes = descendantsOf(rows, panePid);
+    const engineProcesses = processes.filter((row) => matchesProcessName(row, engineNames));
+    byPaneId.set(pane.paneId, { pane, processes, engineProcesses });
+  }
+  return { byPaneId, rows };
+}
+
+async function doubleSampleProcessMap(
+  panes: TeamPaneSnapshot[],
+  engineNames: readonly string[],
+  deps: TeamWtfDeps,
+  sampleCount: number,
+): Promise<ProcessMapSample[]> {
+  const samples: ProcessMapSample[] = [];
+  for (let i = 0; i < Math.max(1, sampleCount); i++) {
+    samples.push(await sampleProcessMap(panes, engineNames, deps));
+  }
+  return samples;
+}
+
+function matchingEngineCount(sample: ProcessMapSample, paneId: string, names: readonly string[]): number {
+  return (sample.byPaneId.get(paneId)?.processes ?? []).filter((row) => matchesProcessName(row, names)).length;
+}
+
+function allSamplesHaveEngine(samples: ProcessMapSample[], paneId: string, names: readonly string[]): boolean {
+  return samples.length >= 2 && samples.every((sample) => matchingEngineCount(sample, paneId, names) > 0);
+}
+
+function allSamplesHaveNoEngine(samples: ProcessMapSample[], paneId: string, names: readonly string[]): boolean {
+  return samples.length >= 2 && samples.every((sample) => sample.byPaneId.has(paneId) && matchingEngineCount(sample, paneId, names) === 0);
+}
+
+function memberTarget(member: TeamCharterMember): string {
+  return memberWindowIdentity(member);
+}
+
+function reviveVerb(team: string, member: TeamCharterMember): string {
+  return `maw team up ${team} --only ${member.role}`;
+}
+
+function paneWindowRef(pane: TeamPaneSnapshot): string | undefined {
+  return pane.sessionId && pane.windowId ? `${pane.sessionId}:${pane.windowId}` : undefined;
+}
+
+function isLeadPane(pane: TeamPaneSnapshot, leadWindowRef: string | undefined): boolean {
+  const ref = paneWindowRef(pane);
+  return Boolean(ref && leadWindowRef && ref === leadWindowRef);
+}
+
+async function currentWindowRef(tmux: Pick<Tmux, "run">): Promise<string | undefined> {
+  const ref = (await tmux.run("display-message", "-p", "#{session_id}:#{window_id}")).trim();
+  return ref || undefined;
+}
+
+function exactPaneTarget(pane: TeamPaneSnapshot): string {
+  return `${pane.sessionName}:${pane.windowName}`;
+}
+
+function memberCheckName(member: TeamCharterMember, suffix = "state"): string {
+  return `team:${member.role}:${suffix}`;
+}
+
+function diagnoseMember(opts: {
+  team: string;
+  member: TeamCharterMember;
+  panes: TeamPaneSnapshot[];
+  samples: ProcessMapSample[];
+  repoSlug: string;
+  session: string;
+  config: MawConfig;
+  leadWindowRef?: string;
+}): DoctorCheck {
+  const { team, member, panes, samples, repoSlug, session, config, leadWindowRef } = opts;
+  const classified = classifyMember(member, panes, session, { repoSlug, currentNode: config.node });
+  const identity = memberTarget(member);
+
+  if (classified.state === "skipped") {
+    return {
+      name: memberCheckName(member, "off-node"),
+      ok: true,
+      severity: "info",
+      message: `${identity}: off-node (${classified.skipReason}); report only`,
+      fix: [],
+      details: { role: member.role, state: "off-node", verb: "report" satisfies TeamWtfVerb },
+    };
+  }
+
+  if (classified.state === "missing") {
+    return {
+      name: memberCheckName(member),
+      ok: false,
+      severity: "warn",
+      message: `${identity}: missing from ${session}; rehydrate from charter`,
+      fix: [reviveVerb(team, member)],
+      details: { role: member.role, state: "missing", verb: "up" satisfies TeamWtfVerb },
+    };
+  }
+
+  const pane = classified.pane;
+  if (!pane) {
+    return {
+      name: memberCheckName(member),
+      ok: false,
+      severity: "warn",
+      message: `${identity}: unknown pane state`,
+      fix: [],
+      details: { role: member.role, state: "unknown", verb: "none" satisfies TeamWtfVerb },
+    };
+  }
+
+  const protectedLead = isLeadPane(pane, leadWindowRef);
+
+  const candidates = memberWindowCandidates(member, repoSlug);
+  const exactOrSuffix = candidates.some((candidate) => pane.windowName === candidate || new RegExp(`-${escapeRegex(candidate)}$`).test(pane.windowName));
+  if (!exactOrSuffix) {
+    return {
+      name: memberCheckName(member, "wrong-name"),
+      ok: false,
+      severity: "error",
+      message: `${identity}: wrong-name window '${pane.windowName}'`,
+      fix: protectedLead ? [] : [`archive WIP for ${pane.windowName}`, `maw done ${pane.windowName}`, reviveVerb(team, member)],
+      details: { role: member.role, state: "wrong-name", pane, protectedLead, verb: protectedLead ? "none" : "done" satisfies TeamWtfVerb },
+    };
+  }
+
+  if (classified.state === "dead") {
+    return {
+      name: memberCheckName(member, "dead-frame"),
+      ok: false,
+      severity: "error",
+      message: protectedLead ? `${identity}: dead-frame (${pane.command || "shell"}); lead protected` : `${identity}: dead-frame (${pane.command || "shell"})`,
+      fix: protectedLead ? [] : [`archive WIP for ${identity}`, `maw done ${identity}`],
+      details: { role: member.role, state: "dead-frame", pane, protectedLead, verb: protectedLead ? "none" : "done" satisfies TeamWtfVerb },
+    };
+  }
+
+  const engine = memberEngineForClassification(member);
+  const names = engineProcessNames(engine, config);
+  if (PROMPT_RE.test(`${pane.command}\n${pane.path}`)) {
+    return {
+      name: memberCheckName(member, "blocked-prompt"),
+      ok: false,
+      severity: "warn",
+      message: `${identity}: possible stuck trust/permission prompt`,
+      fix: [`maw send-text ${pane.paneId} y`, `maw send-enter ${pane.paneId}`],
+      details: { role: member.role, state: "blocked-prompt", pane, verb: "send-text" satisfies TeamWtfVerb },
+    };
+  }
+
+  if (names.length === 0 || !pane.panePid || samples.length < 2) {
+    return {
+      name: memberCheckName(member, "unknown-busy"),
+      ok: false,
+      severity: "warn",
+      message: `${identity}: live pane but process map is unknown (needs two samples and engine processNames)`,
+      fix: [],
+      details: { role: member.role, state: "unknown", pane, engine, processNames: names, verb: "none" satisfies TeamWtfVerb },
+    };
+  }
+
+  if (allSamplesHaveEngine(samples, pane.paneId, names)) {
+    return {
+      name: memberCheckName(member),
+      ok: true,
+      severity: "info",
+      message: `${identity}: aligned; engine descendant present`,
+      fix: [],
+      details: { role: member.role, state: "aligned", pane, engine, processNames: names, verb: "leave" satisfies TeamWtfVerb },
+    };
+  }
+
+  if (allSamplesHaveNoEngine(samples, pane.paneId, names)) {
+    return {
+      name: memberCheckName(member, "dead-frame"),
+      ok: false,
+      severity: "error",
+      message: protectedLead ? `${identity}: dead-frame; lead protected; no ${engine ?? "engine"} descendant under pane pid ${pane.panePid} in two samples` : `${identity}: dead-frame; no ${engine ?? "engine"} descendant under pane pid ${pane.panePid} in two samples`,
+      fix: protectedLead ? [] : [`archive WIP for ${identity}`, `maw done ${identity}`],
+      details: { role: member.role, state: "dead-frame", pane, engine, processNames: names, protectedLead, verb: protectedLead ? "none" : "done" satisfies TeamWtfVerb },
+    };
+  }
+
+  return {
+    name: memberCheckName(member, "unknown-busy"),
+    ok: false,
+    severity: "warn",
+    message: `${identity}: process map changed between samples; not safe to classify`,
+    fix: [],
+    details: { role: member.role, state: "unknown", pane, engine, processNames: names, verb: "none" satisfies TeamWtfVerb },
+  };
+}
+
+function paneMatchesDeclaredMember(pane: TeamPaneSnapshot, charter: TeamCharter, repoSlug: string): boolean {
+  return charter.members.some((member) => memberWindowCandidates(member, repoSlug).some((candidate) =>
+    pane.windowName === candidate || new RegExp(`-${escapeRegex(candidate)}$`).test(pane.windowName)
+  ));
+}
+
+function orphanChecks(team: string, charter: TeamCharter, panes: TeamPaneSnapshot[], session: string, repoSlug: string): DoctorCheck[] {
+  const checks: DoctorCheck[] = [];
+  for (const pane of panes.filter((pane) => pane.sessionName === session)) {
+    if (!pane.windowName || paneMatchesDeclaredMember(pane, charter, repoSlug)) continue;
+    const likelyTeamWindow = pane.windowName.includes(oracleStemFromRepoSlug(repoSlug)) || pane.windowName.includes(team);
+    if (!likelyTeamWindow) continue;
+    checks.push({
+      name: `team:orphan:${pane.windowName}`,
+      ok: false,
+      severity: "warn",
+      message: `${pane.windowName}: extra team-looking window not declared in charter`,
+      fix: [`maw kill ${exactPaneTarget(pane)}`],
+      details: { state: "orphan", pane, verb: "kill" satisfies TeamWtfVerb },
+    });
+  }
+  return checks;
+}
+
+export async function inspectTeamWtf(teamArg: string | undefined, opts: TeamWtfOptions = {}, deps: TeamWtfDeps = {}): Promise<TeamWtfResult> {
+  const cwd = opts.cwd ?? process.cwd();
+  const tmux = deps.tmux ?? new Tmux();
+  const session = opts.session || (teamArg ? "" : await (deps.currentTmuxSessionFn ?? currentTmuxSession)(tmux));
+  const team = (teamArg?.trim() || detectTeamNameFromSession(session)).trim();
+  if (!team) throw new UserError("maw wtf: not in a tmux team session; pass an explicit team: maw wtf <team>");
+  const config = (deps.loadConfigFn ?? loadConfig)({ cwd });
+  const charterPath = (deps.resolveCharterPathFn ?? resolveCharterPath)(team, cwd, config.node);
+  if (!charterPath) throw new UserError(`maw wtf: no charter found for '${team}' from ${cwd}`);
+  const charter = (deps.readTeamCharterFn ?? readTeamCharter)(charterPath);
+  const effectiveSession = opts.session || charter.session || session || team;
+  if (!effectiveSession) throw new UserError("maw wtf: no tmux session detected; pass an explicit team inside a repo with a charter session");
+  const panes = await (deps.listPaneSnapshotsFn ?? listPaneSnapshots)(tmux);
+  const leadWindowRef = await (deps.currentWindowRefFn ?? currentWindowRef)(tmux).catch(() => undefined);
+  const repoSlug = charter.project || repoSlugFromRoot(cwd);
+
+  const allProcessNames = [...new Set(charter.members.flatMap((member) => engineProcessNames(memberEngineForClassification(member), config)))];
+  const samples = await doubleSampleProcessMap(panes, allProcessNames, deps, opts.processSampleCount ?? deps.processSampleCount ?? 2).catch(() => []);
+
+  const checks: DoctorCheck[] = [
+    {
+      name: "team:context",
+      ok: true,
+      severity: "info",
+      message: `TEAM ${team} charter: ${charterPath} session: ${effectiveSession}`,
+      fix: [],
+      details: { team, charterPath, session: effectiveSession, repoSlug, leadWindowRef },
+    },
+    ...charter.members.map((member) => diagnoseMember({ team, member, panes, samples, repoSlug, session: effectiveSession, config, leadWindowRef })),
+    ...orphanChecks(team, charter, panes, effectiveSession, repoSlug),
+  ];
+  const ok = checks.every((check) => check.ok || check.severity === "info");
+  return { ok, team, session: effectiveSession, charterPath, checks };
+}
+
+function renderChecks(result: TeamWtfResult): void {
+  const issues = result.checks.filter((check) => !check.ok || check.severity === "warn");
+  if (issues.length === 0) {
+    const aligned = result.checks.filter((check) => check.name.startsWith("team:") && check.name.endsWith(":state") && check.ok).length;
+    console.log(`✅ ${aligned} aligned, lead protected`);
+    return;
+  }
+  console.log(`TEAM ${result.team}   charter: ${result.charterPath}   session: ${result.session}`);
+  console.log("member/check                 status  diagnosis");
+  for (const check of result.checks.filter((check) => check.name !== "team:context")) {
+    const icon = check.ok ? "✅" : check.severity === "warn" ? "⚠️" : "❌";
+    console.log(`${icon} ${check.name.padEnd(26)} ${check.message}`);
+    for (const fix of check.fix ?? []) console.log(`   → ${fix}`);
+  }
+}
+
+export async function cmdTeamWtf(teamArg?: string, opts: TeamWtfOptions = {}, deps: TeamWtfDeps = {}): Promise<TeamWtfResult> {
+  const result = await inspectTeamWtf(teamArg, opts, deps);
+  if (opts.json) console.log(JSON.stringify({ ok: result.ok, checks: result.checks }, null, 2));
+  else renderChecks(result);
+  return result;
+}

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -93,6 +93,9 @@ mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-up.ts"),
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-apply.ts"), () => ({
   cmdTeamApply: async (...args: unknown[]) => calls.push({ name: "apply", args }),
 }));
+mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-wtf.ts"), () => ({
+  cmdTeamWtf: async (...args: unknown[]) => calls.push({ name: "wtf", args }),
+}));
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/task-ops.ts"), () => ({
   cmdTeamTaskAdd: (...args: unknown[]) => calls.push({ name: "task-add", args }),
   cmdTeamTaskList: (...args: unknown[]) => calls.push({ name: "task-list", args }),
@@ -118,7 +121,7 @@ describe("team command plugin standalone boundary (#2336)", () => {
   test("entrypoint and touched team-up files keep explicit standalone import boundaries", () => {
     const imports = expectStandalonePluginBoundary({
       plugin: "team",
-      files: ["index.ts", "team-liveness.ts", "team-up.ts", "team-apply.ts"],
+      files: ["index.ts", "team-liveness.ts", "team-wtf.ts", "team-up.ts", "team-apply.ts"],
       allowRelative: [
         "../../../core/transport/tmux",
         "../../../core/agent-detect",
@@ -135,11 +138,16 @@ describe("team command plugin standalone boundary (#2336)", () => {
 
     expect(command).toMatchObject({ name: "team" });
     expect(imports).toContain("maw-js/sdk");
-    expect(imports).toEqual(expect.arrayContaining(["./team-up", "./team-apply", "../../../commands/shared/wake-cmd"]));
+    expect(imports).toEqual(expect.arrayContaining(["./team-up", "./team-apply", "./team-wtf", "../../../commands/shared/wake-cmd"]));
     const teamUp = readFileSync(join(root, "src/vendor/mpr-plugins/team/team-up.ts"), "utf8");
     expect(teamUp).toContain("Promise.all(launchTasks.map((task) => task.run()))");
     expect(teamUp).toContain("Promise.all(launchTasks.map((task) => waitForNonShell");
     expect(teamUp).toContain("validateRosterEngines(roster, charter, config, opts.engine)");
+    const teamLiveness = readFileSync(join(root, "src/vendor/mpr-plugins/team/team-liveness.ts"), "utf8");
+    expect(teamLiveness).toContain("#{pane_pid}");
+    const teamWtf = readFileSync(join(root, "src/vendor/mpr-plugins/team/team-wtf.ts"), "utf8");
+    expect(teamWtf).toContain("DoctorCheck[]");
+    expect(teamWtf).toContain("processSampleCount");
     const sdk = readFileSync(join(root, "src/sdk/index.ts"), "utf8");
     expect(sdk).toContain("parseFlags");
     expect(sdk).toContain("hostExec");
@@ -186,6 +194,12 @@ describe("team command plugin standalone boundary (#2336)", () => {
     expect(calls.pop()).toEqual({
       name: "apply",
       args: ["avengers", { apply: true, session: "alpha", charterPath: "/tmp/team.yaml" }],
+    });
+
+    await teamHandler({ source: "cli", args: ["wtf", "avengers", "--json", "--session", "alpha"] } as any);
+    expect(calls.pop()).toEqual({
+      name: "wtf",
+      args: ["avengers", { json: true, session: "alpha" }],
     });
   });
 

--- a/test/isolated/team-reassign-coverage.test.ts
+++ b/test/isolated/team-reassign-coverage.test.ts
@@ -94,7 +94,7 @@ describe("team-reassign helper", () => {
       },
     ]]);
     expect(promptCalls).toEqual([123]);
-    expect(calls).toContainEqual(["list-panes", "-a", "-F", "#{session_name}|#{window_name}|#{pane_current_command}|#{pane_current_path}|#{pane_id}"]);
+    expect(calls).toContainEqual(["list-panes", "-a", "-F", "#{session_name}|#{window_name}|#{pane_current_command}|#{pane_current_path}|#{pane_id}|#{pane_pid}|#{session_id}|#{window_id}"]);
   });
 
   test("rejects unresolved members", async () => {

--- a/test/isolated/team-wtf-coverage.test.ts
+++ b/test/isolated/team-wtf-coverage.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import {
+  detectTeamNameFromSession,
+  inspectTeamWtf,
+  parsePs,
+  sampleProcessMap,
+  type ProcessRow,
+} from "../../src/vendor/mpr-plugins/team/team-wtf";
+import type { TeamCharter } from "../../src/vendor/mpr-plugins/team/team-charter";
+import type { TeamPaneSnapshot } from "../../src/vendor/mpr-plugins/team/team-liveness";
+import type { MawConfig } from "../../src/config/types";
+
+const config = {
+  host: "local",
+  port: 3456,
+  oracleUrl: "http://localhost:47779",
+  env: {},
+  commands: {},
+  sessions: {},
+  node: "m5",
+  engines: {
+    codex: { name: "codex", cmd: "codex", processNames: ["codex"] },
+    claude: { name: "claude", cmd: "claude", processNames: ["claude"] },
+  },
+} as MawConfig;
+
+function charter(overrides: Partial<TeamCharter> = {}): TeamCharter {
+  return {
+    name: "web-v2",
+    session: "167-web-v2",
+    project: "Soul-Brews-Studio/web-v2",
+    members: [
+      { role: "coder-1", engine: "codex" },
+    ],
+    ...overrides,
+  };
+}
+
+function pane(overrides: Partial<TeamPaneSnapshot> = {}): TeamPaneSnapshot {
+  return {
+    sessionName: "167-web-v2",
+    windowName: "web-v2-coder-1",
+    command: "codex",
+    path: "/repo/agents/1-coder-1",
+    paneId: "%1",
+    panePid: "100",
+    sessionId: "$167",
+    windowId: "@1",
+    ...overrides,
+  };
+}
+
+function deps(opts: {
+  charter?: TeamCharter;
+  panes?: TeamPaneSnapshot[];
+  psSamples?: ProcessRow[][];
+  session?: string;
+} = {}) {
+  let idx = 0;
+  const samples = opts.psSamples ?? [[{ pid: 101, ppid: 100, pgid: 100, args: "codex --yolo" }]];
+  return {
+    currentTmuxSessionFn: async () => opts.session ?? "167-web-v2",
+    currentWindowRefFn: async () => undefined,
+    resolveCharterPathFn: (team: string) => team === "web-v2" ? "/repo/.maw/teams/web-v2.yaml" : null,
+    readTeamCharterFn: () => opts.charter ?? charter(),
+    listPaneSnapshotsFn: async () => opts.panes ?? [pane()],
+    loadConfigFn: () => config,
+    ps: () => samples[Math.min(idx++, samples.length - 1)]!,
+  };
+}
+
+function byName(result: Awaited<ReturnType<typeof inspectTeamWtf>>, name: string) {
+  const check = result.checks.find((item) => item.name === name);
+  expect(check).toBeTruthy();
+  return check!;
+}
+
+describe("maw wtf read-only diagnose (#2805)", () => {
+  test("detects team name from numbered tmux session", () => {
+    expect(detectTeamNameFromSession("167-web-v2")).toBe("web-v2");
+    expect(detectTeamNameFromSession("web-v2")).toBe("web-v2");
+  });
+
+  test("processMap binds only descendants of pane_pid", async () => {
+    const sample = await sampleProcessMap([pane()], ["codex"], {
+      ps: () => parsePs(`
+        100 1 100 zsh
+        101 100 100 bash
+        102 101 100 /usr/bin/codex --yolo
+        200 1 200 codex unrelated
+      `),
+    });
+    const binding = sample.byPaneId.get("%1");
+    expect(binding?.processes.map((row) => row.pid)).toEqual([101, 102]);
+    expect(binding?.engineProcesses.map((row) => row.pid)).toEqual([102]);
+  });
+
+  test("auto-detects current team and reports healthy aligned BUSY member after double sample", async () => {
+    const result = await inspectTeamWtf(undefined, { cwd: "/repo" }, deps({
+      psSamples: [
+        [{ pid: 101, ppid: 100, pgid: 100, args: "codex --yolo" }],
+        [{ pid: 101, ppid: 100, pgid: 100, args: "codex --yolo" }],
+      ],
+    }));
+    expect(result.ok).toBe(true);
+    expect(result.team).toBe("web-v2");
+    const check = byName(result, "team:coder-1:state");
+    expect(check.ok).toBe(true);
+    expect(check.message).toContain("aligned");
+    expect(check.fix).toEqual([]);
+  });
+
+  test("two negative process samples diagnose a dead-frame and recommend done", async () => {
+    const result = await inspectTeamWtf("web-v2", { cwd: "/repo" }, deps({
+      psSamples: [
+        [{ pid: 101, ppid: 100, pgid: 100, args: "bash" }],
+        [{ pid: 101, ppid: 100, pgid: 100, args: "bash" }],
+      ],
+    }));
+    const check = byName(result, "team:coder-1:dead-frame");
+    expect(result.ok).toBe(false);
+    expect(check.severity).toBe("error");
+    expect(check.fix).toContain("maw done coder-1");
+  });
+
+  test("one negative process sample remains UNKNOWN, never safe/dead", async () => {
+    const result = await inspectTeamWtf("web-v2", { cwd: "/repo", processSampleCount: 1 }, deps({
+      psSamples: [[{ pid: 101, ppid: 100, pgid: 100, args: "bash" }]],
+    }));
+    const check = byName(result, "team:coder-1:unknown-busy");
+    expect(check.ok).toBe(false);
+    expect(check.severity).toBe("warn");
+    expect(check.fix).toEqual([]);
+  });
+
+  test("current lead window suppresses destructive dead-frame fix", async () => {
+    const result = await inspectTeamWtf("web-v2", { cwd: "/repo" }, {
+      ...deps({
+        psSamples: [
+          [{ pid: 101, ppid: 100, pgid: 100, args: "bash" }],
+          [{ pid: 101, ppid: 100, pgid: 100, args: "bash" }],
+        ],
+      }),
+      currentWindowRefFn: async () => "$167:@1",
+    });
+    const check = byName(result, "team:coder-1:dead-frame");
+    expect(check.message).toContain("lead protected");
+    expect(check.fix).toEqual([]);
+  });
+
+  test("missing member recommends exact team up --only role", async () => {
+    const result = await inspectTeamWtf("web-v2", { cwd: "/repo" }, deps({ panes: [] }));
+    const check = byName(result, "team:coder-1:state");
+    expect(check.ok).toBe(false);
+    expect(check.fix).toEqual(["maw team up web-v2 --only coder-1"]);
+  });
+
+  test("off-node member is report-only and never recommends teardown", async () => {
+    const result = await inspectTeamWtf("web-v2", { cwd: "/repo" }, deps({
+      charter: charter({ members: [{ role: "oss-coder", engine: "codex", node: "oss" }] }),
+      panes: [],
+    }));
+    const check = byName(result, "team:oss-coder:off-node");
+    expect(check.ok).toBe(true);
+    expect(check.fix).toEqual([]);
+    expect(check.message).toContain("report only");
+  });
+
+  test("stuck prompt recommends send-text/send-enter to exact pane", async () => {
+    const result = await inspectTeamWtf("web-v2", { cwd: "/repo" }, deps({
+      panes: [pane({ path: "Do you trust the contents of this directory? Yes, continue", paneId: "%42" })],
+      psSamples: [
+        [{ pid: 101, ppid: 100, pgid: 100, args: "codex --yolo" }],
+        [{ pid: 101, ppid: 100, pgid: 100, args: "codex --yolo" }],
+      ],
+    }));
+    const check = byName(result, "team:coder-1:blocked-prompt");
+    expect(check.severity).toBe("warn");
+    expect(check.fix).toEqual(["maw send-text %42 y", "maw send-enter %42"]);
+  });
+
+  test("orphan team-looking pane recommends exact maw kill target", async () => {
+    const result = await inspectTeamWtf("web-v2", { cwd: "/repo" }, deps({
+      panes: [pane(), pane({ windowName: "web-v2-extra", paneId: "%9", panePid: "900" })],
+      psSamples: [
+        [{ pid: 101, ppid: 100, pgid: 100, args: "codex --yolo" }],
+        [{ pid: 101, ppid: 100, pgid: 100, args: "codex --yolo" }],
+      ],
+    }));
+    const check = byName(result, "team:orphan:web-v2-extra");
+    expect(check.ok).toBe(false);
+    expect(check.fix).toEqual(["maw kill 167-web-v2:web-v2-extra"]);
+  });
+});

--- a/test/isolated/top-aliases-runtime-coverage.test.ts
+++ b/test/isolated/top-aliases-runtime-coverage.test.ts
@@ -17,6 +17,7 @@ let tmuxLayoutCalls: unknown[][] = [];
 let wakeCalls: unknown[][] = [];
 let newCalls: unknown[][] = [];
 let preflightCalls: unknown[] = [];
+let teamWtfCalls: unknown[][] = [];
 let lsFederatedCalls: unknown[] = [];
 let loadConfigCalls = 0;
 let logs: string[] = [];
@@ -57,6 +58,10 @@ mock.module(import.meta.resolve("../../src/cli/cmd-new"), () => ({
 
 mock.module(import.meta.resolve("../../src/commands/shared/preflight"), () => ({
   cmdPreflight: async (opts: unknown) => { preflightCalls.push(opts); },
+}));
+
+mock.module(import.meta.resolve("../../src/commands/plugins/team/team-wtf"), () => ({
+  cmdTeamWtf: async (...args: unknown[]) => { teamWtfCalls.push(args); },
 }));
 
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/ls/internal/peer-call"), () => ({
@@ -102,6 +107,7 @@ beforeEach(() => {
   wakeCalls = [];
   newCalls = [];
   preflightCalls = [];
+  teamWtfCalls = [];
   lsFederatedCalls = [];
   loadConfigCalls = 0;
   logs = [];
@@ -148,8 +154,9 @@ describe("top alias resolution table", () => {
     expect(ALIAS_DESCRIPTIONS.layout).toContain("current window");
   });
 
-  test("layout is a direct top-level handler, not a team argv alias", () => {
+  test("layout and wtf are direct top-level handlers", () => {
     expect(resolveTopAlias(["layout", "tiled"])).toEqual({ kind: "direct", handler: "cmdLayout", argv: ["tiled"] });
+    expect(resolveTopAlias(["wtf", "web-v2", "--json"])).toEqual({ kind: "direct", handler: "../commands/plugins/team/team-wtf:cmdTeamWtf", argv: ["web-v2", "--json"] });
   });
 });
 
@@ -370,13 +377,15 @@ describe("direct handler invocation", () => {
     }]]);
   });
 
-  test("new and preflight handlers dispatch to their static imports", async () => {
+  test("new, preflight, and wtf handlers dispatch to their static imports", async () => {
     await invokeDirectHandler("./cmd-new:cmdNew", ["workspace", "--no-attach"]);
     await invokeDirectHandler("../commands/shared/preflight:cmdPreflight", ["--fix"]);
     await invokeDirectHandler("../commands/shared/preflight:cmdPreflight", []);
+    await invokeDirectHandler("../commands/plugins/team/team-wtf:cmdTeamWtf", ["web-v2", "--json", "--session", "167-web-v2"]);
 
     expect(newCalls).toEqual([[["workspace", "--no-attach"]]]);
     expect(preflightCalls).toEqual([{ fix: true }, { fix: false }]);
+    expect(teamWtfCalls).toEqual([["web-v2", { json: true, session: "167-web-v2" }]]);
   });
 
   test("malformed and unknown direct handlers fail loudly", async () => {


### PR DESCRIPTION
## Summary
- add top-level `maw wtf` and `maw team wtf` read-only team drift diagnosis
- emit existing `DoctorCheck[]` shape with fix-string recommendations only
- add injectable process-map descendant binding with double-sample BUSY/dead-frame classification
- extend team pane snapshots with pane/session/window ids for process binding and lead protection

## Verification
- bash scripts/test-isolated.sh test/isolated/team-wtf-coverage.test.ts test/isolated/plugin-team-standalone.test.ts test/isolated/team-up-coverage.test.ts test/isolated/top-aliases-runtime-coverage.test.ts
- bun run test:plugin
- bun run test:mock-smoke
- bun run check:sdk-surface
- bun run test:default:safe
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun run build

Closes #2805