### PR TITLE
Constrain maw wtf --fix transactions (#2806)

### DIFF
--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -27,6 +27,7 @@ import { cmdPreflight } from "../commands/shared/preflight";
 import { cmdNew } from "./cmd-new";
 import { cmdPromote } from "../commands/shared/promote-cmd";
 import { cmdTeamWtf } from "../commands/plugins/team/team-wtf";
+import { cmdTeamWtfFix } from "../commands/plugins/team/team-wtf-fix";
 import { parseFlags } from "./parse-args";
 import { UserError } from "../core/util/user-error";
 import { parseBringToTarget } from "../commands/shared/bring-flags";
@@ -322,6 +323,7 @@ export interface TopAliasHandlerDeps {
   cmdPreflight?: (opts: { fix: boolean }) => MaybePromise;
   cmdPromote?: (argv: string[]) => MaybePromise;
   cmdTeamWtf?: (teamArg?: string, opts?: { json?: boolean; session?: string }) => MaybePromise;
+  cmdTeamWtfFix?: (teamArg?: string, opts?: { json?: boolean; session?: string; dryRun?: boolean; confirm?: string }) => MaybePromise;
   loadConfig?: () => { commands?: Record<string, unknown> };
   log?: (line: string) => void;
   error?: (line: string) => void;
@@ -345,6 +347,7 @@ export async function invokeDirectHandler(
   const directCmdPreflight = deps.cmdPreflight ?? cmdPreflight;
   const directCmdPromote = deps.cmdPromote ?? cmdPromote;
   const directCmdTeamWtf = deps.cmdTeamWtf ?? cmdTeamWtf;
+  const directCmdTeamWtfFix = deps.cmdTeamWtfFix ?? cmdTeamWtfFix;
   const log = deps.log ?? console.log;
   const error = deps.error ?? console.error;
 
@@ -581,11 +584,20 @@ export async function invokeDirectHandler(
   }
 
   if (exportName === "cmdTeamWtf") {
-    const flags = parseFlags(argv, { "--json": Boolean, "--session": String }, 0);
-    await directCmdTeamWtf(flags._[0] as string | undefined, {
-      json: Boolean(flags["--json"]),
-      session: flags["--session"] as string | undefined,
-    });
+    const flags = parseFlags(argv, { "--json": Boolean, "--session": String, "--fix": Boolean, "--dry-run": Boolean, "--confirm": String }, 0);
+    if (flags["--fix"]) {
+      await directCmdTeamWtfFix(flags._[0] as string | undefined, {
+        json: Boolean(flags["--json"]),
+        session: flags["--session"] as string | undefined,
+        dryRun: Boolean(flags["--dry-run"]),
+        confirm: flags["--confirm"] as string | undefined,
+      });
+    } else {
+      await directCmdTeamWtf(flags._[0] as string | undefined, {
+        json: Boolean(flags["--json"]),
+        session: flags["--session"] as string | undefined,
+      });
+    }
     return;
   }
 

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -217,15 +217,28 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       cmdTeamTaskAssign(team, id, agent);
 
     } else if (sub === "wtf") {
-      const { cmdTeamWtf } = await import("./team-wtf");
       const flags = parseFlags(args, {
         "--json": Boolean,
         "--session": String,
+        "--fix": Boolean,
+        "--dry-run": Boolean,
+        "--confirm": String,
       }, 1);
-      await cmdTeamWtf(flags._[0] as string | undefined, {
-        json: Boolean(flags["--json"]),
-        session: flags["--session"] as string | undefined,
-      });
+      if (flags["--fix"]) {
+        const { cmdTeamWtfFix } = await import("./team-wtf-fix");
+        await cmdTeamWtfFix(flags._[0] as string | undefined, {
+          json: Boolean(flags["--json"]),
+          session: flags["--session"] as string | undefined,
+          dryRun: Boolean(flags["--dry-run"]),
+          confirm: flags["--confirm"] as string | undefined,
+        });
+      } else {
+        const { cmdTeamWtf } = await import("./team-wtf");
+        await cmdTeamWtf(flags._[0] as string | undefined, {
+          json: Boolean(flags["--json"]),
+          session: flags["--session"] as string | undefined,
+        });
+      }
 
     } else if (sub === "status") {
       // maw team status [team-name]

--- a/src/commands/plugins/team/team-wtf-fix.ts
+++ b/src/commands/plugins/team/team-wtf-fix.ts
@@ -1,0 +1,1 @@
+export * from "../../../vendor/mpr-plugins/team/team-wtf-fix";

--- a/src/vendor/mpr-plugins/team/index.ts
+++ b/src/vendor/mpr-plugins/team/index.ts
@@ -258,15 +258,28 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       cmdTeamTaskAssign(team, id, agent);
 
     } else if (sub === "wtf") {
-      const { cmdTeamWtf } = await import("./team-wtf");
       const flags = parseFlags(args, {
         "--json": Boolean,
         "--session": String,
+        "--fix": Boolean,
+        "--dry-run": Boolean,
+        "--confirm": String,
       }, 1);
-      await cmdTeamWtf(flags._[0] as string | undefined, {
-        json: Boolean(flags["--json"]),
-        session: flags["--session"] as string | undefined,
-      });
+      if (flags["--fix"]) {
+        const { cmdTeamWtfFix } = await import("./team-wtf-fix");
+        await cmdTeamWtfFix(flags._[0] as string | undefined, {
+          json: Boolean(flags["--json"]),
+          session: flags["--session"] as string | undefined,
+          dryRun: Boolean(flags["--dry-run"]),
+          confirm: flags["--confirm"] as string | undefined,
+        });
+      } else {
+        const { cmdTeamWtf } = await import("./team-wtf");
+        await cmdTeamWtf(flags._[0] as string | undefined, {
+          json: Boolean(flags["--json"]),
+          session: flags["--session"] as string | undefined,
+        });
+      }
 
     } else if (sub === "status") {
       // maw team status [team-name]

--- a/src/vendor/mpr-plugins/team/team-wtf-fix.ts
+++ b/src/vendor/mpr-plugins/team/team-wtf-fix.ts
@@ -1,0 +1,376 @@
+import { mkdirSync, statSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import type { DoctorCheck } from "../doctor/impl";
+import type { TeamPaneSnapshot } from "./team-liveness";
+import type { TeamWtfResult } from "./team-wtf";
+import { inspectTeamWtf } from "./team-wtf";
+
+export interface WtfProtectedIds {
+  currentSessionId?: string;
+  currentWindowId?: string;
+  currentPaneId?: string;
+  leadWindowIds?: string[];
+}
+
+export interface WtfFixContext {
+  team: string;
+  sessionName: string;
+  sessionId?: string;
+  protected?: WtfProtectedIds;
+  cwd?: string;
+}
+
+export interface WtfFixPlanInput {
+  checks: DoctorCheck[];
+  context: WtfFixContext;
+  confirm?: string;
+}
+
+export type WtfTransactionKind = "send-text" | "send-enter" | "done" | "kill-window" | "kill-pid" | "team-up" | "verify";
+
+export interface WtfFixTransaction {
+  kind: WtfTransactionKind;
+  command: string;
+  check: string;
+  target?: unknown;
+  signal?: "SIGTERM";
+  verifyAfter?: boolean;
+}
+
+export interface WtfFixDenial {
+  check: string;
+  command: string;
+  reason: string;
+  message: string;
+}
+
+export interface WtfFixPlanResult {
+  transactions: WtfFixTransaction[];
+  denied: WtfFixDenial[];
+  commands: string[];
+}
+
+export interface WtfFixApplyDeps {
+  exec?: (command: string) => Promise<string> | string;
+  inspectTeamWtfFn?: typeof inspectTeamWtf;
+  archiveWipFn?: (check: DoctorCheck, context: WtfFixContext) => Promise<WipArchiveResult> | WipArchiveResult;
+}
+
+export interface WipArchiveResult {
+  path: string;
+  bytes: number;
+  verifiedApplicable: boolean;
+}
+
+function detailsOf(check: DoctorCheck): Record<string, any> {
+  return check.details && typeof check.details === "object" ? check.details as Record<string, any> : {};
+}
+
+function targetOf(check: DoctorCheck): Record<string, any> {
+  const details = detailsOf(check);
+  if (details.target && typeof details.target === "object") return details.target;
+  if (details.pane && typeof details.pane === "object") return details.pane;
+  return {};
+}
+
+function paneOf(check: DoctorCheck): TeamPaneSnapshot | undefined {
+  const details = detailsOf(check);
+  return details.pane && typeof details.pane === "object" ? details.pane as TeamPaneSnapshot : undefined;
+}
+
+function protectedWindowIds(context: WtfFixContext): Set<string> {
+  return new Set([
+    context.protected?.currentWindowId,
+    ...(context.protected?.leadWindowIds ?? []),
+  ].filter(Boolean) as string[]);
+}
+
+function isProtectedTarget(target: Record<string, any>, context: WtfFixContext): boolean {
+  const sessionId = String(target.sessionId ?? "");
+  const windowId = String(target.windowId ?? "");
+  const paneId = String(target.paneId ?? "");
+  if (context.protected?.currentSessionId && sessionId && sessionId === context.protected.currentSessionId && !windowId && !paneId) return true;
+  if (context.protected?.currentPaneId && paneId && paneId === context.protected.currentPaneId) return true;
+  return Boolean(windowId && protectedWindowIds(context).has(windowId));
+}
+
+function hasAmbiguousMatches(check: DoctorCheck): boolean {
+  const details = detailsOf(check);
+  const matches = Array.isArray(details.matches) ? details.matches : [];
+  if (matches.length > 1) return true;
+  const normalized = new Map<string, number>();
+  for (const match of matches) {
+    const name = String(match?.windowName ?? "");
+    if (!name) continue;
+    const key = name.replace(/[-_.]/g, "").toLowerCase();
+    normalized.set(key, (normalized.get(key) ?? 0) + 1);
+  }
+  return [...normalized.values()].some((count) => count > 1);
+}
+
+function isDownAll(command: string): boolean {
+  return /\bmaw\s+team\s+down\b.*\s--all(?:\s|$)/.test(command) || /\bteam\s+down\b.*\s--all(?:\s|$)/.test(command);
+}
+
+function isKillSession(command: string): boolean {
+  return /\btmux\s+kill-session\b/.test(command) || /\bmaw\s+kill\s+[^\s:]+\s*$/.test(command);
+}
+
+function isDone(command: string): boolean {
+  return /\bmaw\s+done\s+/.test(command);
+}
+
+function isMawKill(command: string): boolean {
+  return /\bmaw\s+kill\s+/.test(command);
+}
+
+function isPidKill(command: string): boolean {
+  return /^\s*(?:kill|kill\s+-TERM|kill\s+-SIGTERM)\s+\d+\s*$/.test(command);
+}
+
+function isSendText(command: string): boolean {
+  return /\bmaw\s+send-text\s+%\S+\s+/.test(command);
+}
+
+function isSendEnter(command: string): boolean {
+  return /\bmaw\s+send-enter\s+%\S+\s*$/.test(command);
+}
+
+function isTeamUp(command: string): boolean {
+  return /\bmaw\s+team\s+up\s+/.test(command);
+}
+
+function deny(check: DoctorCheck, command: string, reason: string, message = reason): WtfFixDenial {
+  return { check: check.name, command, reason, message };
+}
+
+function commandForExactDone(command: string, check: DoctorCheck): string {
+  const pane = paneOf(check);
+  if (pane?.windowName) return command.replace(/\bmaw\s+done\s+.+$/, `maw done ${pane.windowName}`);
+  return command;
+}
+
+function commandForExactKill(command: string, check: DoctorCheck): string {
+  const pane = paneOf(check);
+  const target = targetOf(check);
+  const sessionName = String(pane?.sessionName ?? target.sessionName ?? "");
+  const windowName = String(pane?.windowName ?? target.windowName ?? "");
+  if (sessionName && windowName) return `maw kill ${sessionName}:${windowName}`;
+  return command;
+}
+
+function hasVerifiedWipArchive(check: DoctorCheck): boolean {
+  const archive = detailsOf(check).wipArchive;
+  return Boolean(archive && typeof archive === "object" && Number(archive.bytes) > 0 && archive.verifiedApplicable === true);
+}
+
+function hasStrongPidConfirm(input: WtfFixPlanInput, check: DoctorCheck): boolean {
+  const pid = targetOf(check).pid;
+  const confirm = input.confirm ?? "";
+  return Boolean(pid && new RegExp(`\\b${pid}\\b`).test(confirm) && /sigterm|term/i.test(confirm) && /understand|confirm/i.test(confirm));
+}
+
+function addVerify(transactions: WtfFixTransaction[], check: DoctorCheck, context: WtfFixContext): void {
+  transactions.push({ kind: "verify", command: `maw wtf ${context.team} --json`, check: check.name, verifyAfter: true });
+}
+
+export function planWtfFixTransactions(input: WtfFixPlanInput): WtfFixPlanResult {
+  const transactions: WtfFixTransaction[] = [];
+  const denied: WtfFixDenial[] = [];
+
+  for (const check of input.checks) {
+    for (const rawCommand of check.fix ?? []) {
+      const command = rawCommand.trim();
+      if (!command || check.ok) continue;
+      const target = targetOf(check);
+
+      if (isDownAll(command)) {
+        denied.push(deny(check, command, "down --all denied", "maw wtf --fix never invokes team down --all"));
+        continue;
+      }
+      if (hasAmbiguousMatches(check)) {
+        denied.push(deny(check, command, "ambiguous normalized target collision", "refusing duplicate-name / normalized-collision target"));
+        continue;
+      }
+      if (isProtectedTarget(target, input.context) || detailsOf(check).protectedLead === true) {
+        denied.push(deny(check, command, "protected lead/current target", "refusing to modify current or charter lead target"));
+        continue;
+      }
+      if (isKillSession(command)) {
+        const targetSessionId = String(target.sessionId ?? "");
+        if (targetSessionId && input.context.protected?.currentSessionId && targetSessionId === input.context.protected.currentSessionId) {
+          denied.push(deny(check, command, "current session protected", "refusing to kill current/lead session"));
+        } else {
+          denied.push(deny(check, command, "kill-session manual only", "session teardown is not in the automatic --fix subset"));
+        }
+        continue;
+      }
+      if (isPidKill(command)) {
+        const pid = Number(target.pid ?? command.match(/(\d+)\s*$/)?.[1]);
+        if (!hasStrongPidConfirm(input, check)) {
+          denied.push(deny(check, command, "strong confirm required for orphan pid", "orphan-pid kill is manual unless confirmed with pid and SIGTERM"));
+          continue;
+        }
+        transactions.push({ kind: "kill-pid", command: `kill -TERM ${pid} # SIGTERM`, check: check.name, target: { ...target, pid }, signal: "SIGTERM" });
+        addVerify(transactions, check, input.context);
+        continue;
+      }
+      if (isDone(command)) {
+        if (!hasVerifiedWipArchive(check)) {
+          denied.push(deny(check, command, "WIP archive not verified", "teardown requires a verified non-empty applicable WIP archive first"));
+          continue;
+        }
+        const exact = commandForExactDone(command, check);
+        transactions.push({ kind: "done", command: exact, check: check.name, target });
+        addVerify(transactions, check, input.context);
+        continue;
+      }
+      if (isMawKill(command)) {
+        const exact = commandForExactKill(command, check);
+        if (!/:/.test(exact.replace(/^.*maw\s+kill\s+/, ""))) {
+          denied.push(deny(check, command, "exact target required", "maw kill must target an exact session:window, not a bare name"));
+          continue;
+        }
+        transactions.push({ kind: "kill-window", command: exact, check: check.name, target });
+        addVerify(transactions, check, input.context);
+        continue;
+      }
+      if (isSendText(command)) {
+        transactions.push({ kind: "send-text", command, check: check.name, target });
+        continue;
+      }
+      if (isSendEnter(command)) {
+        transactions.push({ kind: "send-enter", command, check: check.name, target });
+        addVerify(transactions, check, input.context);
+        continue;
+      }
+      if (isTeamUp(command)) {
+        transactions.push({ kind: "team-up", command, check: check.name, target });
+        addVerify(transactions, check, input.context);
+        continue;
+      }
+
+      denied.push(deny(check, command, "not allowlisted", "command is outside maw wtf --fix allowlist"));
+    }
+  }
+
+  return { transactions, denied, commands: transactions.map((tx) => tx.command) };
+}
+
+export const createWtfFixPlan = planWtfFixTransactions;
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+async function defaultExec(command: string): Promise<string> {
+  const proc = Bun.spawn(["bash", "-lc", command], { stdout: "pipe", stderr: "pipe" });
+  const [code, stdout, stderr] = await Promise.all([proc.exited, new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+  if (code !== 0) throw new Error(stderr.trim() || stdout.trim() || `command failed: ${command}`);
+  return stdout;
+}
+
+export async function archiveWipForCheck(check: DoctorCheck, context: WtfFixContext, deps: WtfFixApplyDeps = {}): Promise<WipArchiveResult> {
+  const pane = paneOf(check);
+  const cwd = pane?.path || context.cwd || process.cwd();
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const safeName = check.name.replace(/[^a-z0-9_.-]+/gi, "-");
+  const out = join(context.cwd || process.cwd(), "ψ", "inbox", "rescued-wip", stamp, `${safeName}.patch`);
+  mkdirSync(dirname(out), { recursive: true });
+  const exec = deps.exec ?? defaultExec;
+  const diff = await exec(`git -C ${shellQuote(cwd)} diff --binary HEAD 2>/dev/null || true`);
+  const staged = await exec(`git -C ${shellQuote(cwd)} diff --binary --cached HEAD 2>/dev/null || true`);
+  const untracked = await exec(`git -C ${shellQuote(cwd)} ls-files --others --exclude-standard 2>/dev/null | sed 's/^/UNTRACKED /' || true`);
+  const body = [diff, staged, untracked].filter(Boolean).join("\n");
+  writeFileSync(out, body, "utf-8");
+  const bytes = statSync(out).size;
+  return { path: out, bytes, verifiedApplicable: bytes > 0 };
+}
+
+function checkNeedsArchive(check: DoctorCheck): boolean {
+  return (check.fix ?? []).some((fix) => isDone(fix));
+}
+
+export async function enrichChecksWithWipArchives(checks: DoctorCheck[], context: WtfFixContext, deps: WtfFixApplyDeps = {}): Promise<DoctorCheck[]> {
+  const enriched: DoctorCheck[] = [];
+  for (const check of checks) {
+    if (!checkNeedsArchive(check) || detailsOf(check).protectedLead === true) {
+      enriched.push(check);
+      continue;
+    }
+    const archive = await (deps.archiveWipFn ?? archiveWipForCheck)(check, context);
+    enriched.push({ ...check, details: { ...detailsOf(check), wipArchive: archive } });
+  }
+  return enriched;
+}
+
+export async function applyWtfFixPlan(plan: WtfFixPlanResult, deps: WtfFixApplyDeps = {}): Promise<void> {
+  const exec = deps.exec ?? defaultExec;
+  for (const tx of plan.transactions) {
+    if (tx.kind === "verify") continue;
+    await exec(tx.command);
+  }
+}
+
+async function applyWtfFixPlanWithVerification(
+  plan: WtfFixPlanResult,
+  teamArg: string | undefined,
+  opts: { session?: string; cwd?: string; json?: boolean },
+  deps: WtfFixApplyDeps & Parameters<typeof inspectTeamWtf>[2] = {},
+): Promise<void> {
+  const exec = deps.exec ?? defaultExec;
+  const inspect = deps.inspectTeamWtfFn ?? inspectTeamWtf;
+  for (const tx of plan.transactions) {
+    if (tx.kind === "verify") {
+      await inspect(teamArg, { json: false, session: opts.session, cwd: opts.cwd }, deps);
+      if (!opts.json) console.log(`verified after ${tx.check}: re-ran maw wtf`);
+      continue;
+    }
+    await exec(tx.command);
+  }
+}
+
+export async function cmdTeamWtfFix(teamArg: string | undefined, opts: { json?: boolean; session?: string; cwd?: string; confirm?: string; dryRun?: boolean } = {}, deps: WtfFixApplyDeps & Parameters<typeof inspectTeamWtf>[2] = {}): Promise<WtfFixPlanResult> {
+  const inspect = deps.inspectTeamWtfFn ?? inspectTeamWtf;
+  const first = await inspect(teamArg, { json: opts.json, session: opts.session, cwd: opts.cwd }, deps);
+  const context = contextFromWtfResult(first, opts.cwd);
+  const confirmed = Boolean(opts.confirm?.trim());
+  const checks = confirmed && !opts.dryRun
+    ? await enrichChecksWithWipArchives(first.checks, context, deps)
+    : first.checks;
+  const plan = planWtfFixTransactions({ checks, context, confirm: opts.confirm });
+  if (opts.json) console.log(JSON.stringify(plan, null, 2));
+  else renderFixPlan(plan);
+  if (!opts.dryRun && !confirmed) {
+    if (!opts.json) console.log("  ! no --confirm supplied; plan only (per-item confirm required by default)");
+    return plan;
+  }
+  if (!opts.dryRun) {
+    await applyWtfFixPlanWithVerification(plan, teamArg, opts, deps);
+  }
+  return plan;
+}
+
+export function contextFromWtfResult(result: TeamWtfResult, cwd = process.cwd()): WtfFixContext {
+  const contextCheck = result.checks.find((check) => check.name === "team:context");
+  const details = contextCheck ? detailsOf(contextCheck) : {};
+  const leadWindowRef = String(details.leadWindowRef ?? "");
+  const [leadSessionId, leadWindowId] = leadWindowRef.split(":");
+  return {
+    team: result.team,
+    sessionName: result.session,
+    sessionId: leadSessionId || undefined,
+    cwd,
+    protected: {
+      currentSessionId: leadSessionId || undefined,
+      currentWindowId: leadWindowId || undefined,
+      leadWindowIds: leadWindowId ? [leadWindowId] : [],
+    },
+  };
+}
+
+function renderFixPlan(plan: WtfFixPlanResult): void {
+  console.log("maw wtf --fix plan");
+  for (const tx of plan.transactions) console.log(`  + ${tx.command}`);
+  for (const item of plan.denied) console.log(`  ! denied ${item.command}: ${item.message}`);
+}

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -96,6 +96,9 @@ mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-apply.ts
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-wtf.ts"), () => ({
   cmdTeamWtf: async (...args: unknown[]) => calls.push({ name: "wtf", args }),
 }));
+mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/team-wtf-fix.ts"), () => ({
+  cmdTeamWtfFix: async (...args: unknown[]) => calls.push({ name: "wtf-fix", args }),
+}));
 mock.module(import.meta.resolve("../../src/vendor/mpr-plugins/team/task-ops.ts"), () => ({
   cmdTeamTaskAdd: (...args: unknown[]) => calls.push({ name: "task-add", args }),
   cmdTeamTaskList: (...args: unknown[]) => calls.push({ name: "task-list", args }),
@@ -121,7 +124,7 @@ describe("team command plugin standalone boundary (#2336)", () => {
   test("entrypoint and touched team-up files keep explicit standalone import boundaries", () => {
     const imports = expectStandalonePluginBoundary({
       plugin: "team",
-      files: ["index.ts", "team-liveness.ts", "team-wtf.ts", "team-up.ts", "team-apply.ts"],
+      files: ["index.ts", "team-liveness.ts", "team-wtf.ts", "team-wtf-fix.ts", "team-up.ts", "team-apply.ts"],
       allowRelative: [
         "../../../core/transport/tmux",
         "../../../core/agent-detect",
@@ -138,7 +141,7 @@ describe("team command plugin standalone boundary (#2336)", () => {
 
     expect(command).toMatchObject({ name: "team" });
     expect(imports).toContain("maw-js/sdk");
-    expect(imports).toEqual(expect.arrayContaining(["./team-up", "./team-apply", "./team-wtf", "../../../commands/shared/wake-cmd"]));
+    expect(imports).toEqual(expect.arrayContaining(["./team-up", "./team-apply", "./team-wtf", "./team-wtf-fix", "../../../commands/shared/wake-cmd"]));
     const teamUp = readFileSync(join(root, "src/vendor/mpr-plugins/team/team-up.ts"), "utf8");
     expect(teamUp).toContain("Promise.all(launchTasks.map((task) => task.run()))");
     expect(teamUp).toContain("Promise.all(launchTasks.map((task) => waitForNonShell");
@@ -200,6 +203,12 @@ describe("team command plugin standalone boundary (#2336)", () => {
     expect(calls.pop()).toEqual({
       name: "wtf",
       args: ["avengers", { json: true, session: "alpha" }],
+    });
+
+    await teamHandler({ source: "cli", args: ["wtf", "avengers", "--fix", "--dry-run", "--confirm", "confirm", "--session", "alpha"] } as any);
+    expect(calls.pop()).toEqual({
+      name: "wtf-fix",
+      args: ["avengers", { json: false, session: "alpha", dryRun: true, confirm: "confirm" }],
     });
   });
 

--- a/test/isolated/team-wtf-fix-deny-gates.test.ts
+++ b/test/isolated/team-wtf-fix-deny-gates.test.ts
@@ -1,0 +1,256 @@
+/**
+ * team-wtf-fix-deny-gates.test.ts — #2806 prep scaffold.
+ *
+ * #2805 provides the read-only `maw wtf` diagnose surface. Its stable contract
+ * is DoctorCheck[] with string `fix` verbs; `details` may carry advisory machine
+ * hints but is not a stable action API. These tests pin #2806's safety contract:
+ * `--fix` is an allowlisted exact-ID transaction runner, never a name-based
+ * destructive command loop.
+ */
+import { describe, expect, test } from "bun:test";
+import type { DoctorCheck } from "../../src/vendor/mpr-plugins/doctor/impl";
+import { cmdTeamWtfFix, planWtfFixTransactions } from "../../src/vendor/mpr-plugins/team/team-wtf-fix";
+
+type ProtectedIds = {
+  currentSessionId: string;
+  currentWindowId: string;
+  currentPaneId: string;
+  leadWindowIds: string[];
+};
+
+type FixtureContext = {
+  team: string;
+  sessionName: string;
+  sessionId: string;
+  protected: ProtectedIds;
+};
+
+type FixPlanInput = {
+  checks: DoctorCheck[];
+  context: FixtureContext;
+  confirm?: string;
+};
+
+type FixPlanResult = {
+  transactions?: unknown[];
+  denied?: Array<{ reason?: string; message?: string; command?: string }>;
+  commands?: string[];
+};
+
+function planner() {
+  return planWtfFixTransactions;
+}
+
+const baseContext: FixtureContext = {
+  team: "alpha",
+  sessionName: "167-alpha",
+  sessionId: "$lead-session",
+  protected: {
+    currentSessionId: "$lead-session",
+    currentWindowId: "@lead-window",
+    currentPaneId: "%lead-pane",
+    leadWindowIds: ["@lead-window", "@charter-lead"],
+  },
+};
+
+function check(name: string, fix: string[], details: unknown = {}): DoctorCheck {
+  return { name, ok: false, severity: "error", message: name, fix, details };
+}
+
+function denialText(result: FixPlanResult): string {
+  return JSON.stringify(result.denied ?? result, null, 2).toLowerCase();
+}
+
+function plannedCommands(result: FixPlanResult): string[] {
+  return result.commands ?? result.transactions?.map((tx) => JSON.stringify(tx)) ?? [];
+}
+
+describe("maw wtf --fix deny gates (#2806)", () => {
+  test("denies any team down --all codepath even when a diagnosis suggests it", async () => {
+    const result = await planner()({
+      context: baseContext,
+      checks: [check("team:dangerous-fix", ["maw team down alpha --all"])],
+    });
+
+    expect(plannedCommands(result).join("\n")).not.toContain("team down");
+    expect(denialText(result)).toContain("down --all");
+  });
+
+  test("denies killing the current session by exact tmux session id", async () => {
+    const result = await planner()({
+      context: baseContext,
+      checks: [check("team:zombie-session", ["tmux kill-session -t 167-alpha"], {
+        target: { sessionName: "167-alpha", sessionId: "$lead-session" },
+      })],
+    });
+
+    expect(plannedCommands(result).join("\n")).not.toContain("kill-session");
+    expect(denialText(result)).toMatch(/current|protected|lead/);
+  });
+
+  test("denies killing any charter lead window even when the member name collides", async () => {
+    const result = await planner()({
+      context: baseContext,
+      checks: [check("team:orphan-window", ["maw kill alpha:coder-1"], {
+        role: "coder-1",
+        target: { sessionId: "$lead-session", windowId: "@charter-lead", windowName: "coder-1" },
+      })],
+    });
+
+    expect(plannedCommands(result).join("\n")).not.toContain("maw kill");
+    expect(denialText(result)).toMatch(/lead|protected/);
+  });
+
+  test("denies ambiguous duplicate-name and normalized-collision window targets", async () => {
+    const result = await planner()({
+      context: baseContext,
+      checks: [check("team:ambiguous-window", ["maw done wt-coder-2"], {
+        target: { windowName: "wt-coder-2" },
+        matches: [
+          { sessionId: "$lead-session", windowId: "@one", windowName: "web-v2.wt-coder-2" },
+          { sessionId: "$lead-session", windowId: "@two", windowName: "web-v2-wt-coder-2" },
+        ],
+      })],
+    });
+
+    expect(plannedCommands(result).join("\n")).not.toContain("maw done");
+    expect(denialText(result)).toMatch(/ambiguous|collision|duplicate/);
+  });
+
+  test("requires verified non-empty WIP archive before teardown", async () => {
+    const result = await planner()({
+      context: baseContext,
+      checks: [check("team:dead-frame", ["maw done wt-coder-3"], {
+        target: { sessionId: "$lead-session", windowId: "@dead", worktree: "agents/1-wt-coder-3" },
+        wipArchive: { path: "ψ/inbox/rescued-wip/empty.patch", bytes: 0, verifiedApplicable: false },
+      })],
+    });
+
+    expect(plannedCommands(result).join("\n")).not.toContain("maw done");
+    expect(denialText(result)).toMatch(/wip|archive|non-empty|applicable/);
+  });
+
+  test("orphan-pid fixes require strong confirm and prefer SIGTERM before any escalation", async () => {
+    const withoutConfirm = await planner()({
+      context: baseContext,
+      checks: [check("team:orphan-pid", ["kill 4242"], {
+        target: { pid: 4242, startTime: 1718251200, argv: "omx --yolo", cwd: "/tmp/wt" },
+      })],
+    });
+
+    expect(plannedCommands(withoutConfirm).join("\n")).not.toContain("kill 4242");
+    expect(denialText(withoutConfirm)).toMatch(/strong|confirm|manual/);
+
+    const withConfirm = await planner()({
+      context: baseContext,
+      confirm: "I understand this kills orphan pid 4242 with SIGTERM first",
+      checks: [check("team:orphan-pid", ["kill 4242"], {
+        target: { pid: 4242, startTime: 1718251200, argv: "omx --yolo", cwd: "/tmp/wt" },
+      })],
+    });
+
+    const commands = plannedCommands(withConfirm).join("\n");
+    expect(commands).toContain("SIGTERM");
+    expect(commands).not.toContain("SIGKILL");
+  });
+
+
+  test("cmdTeamWtfFix is plan-only without explicit confirm", async () => {
+    const executed: string[] = [];
+    const result = await cmdTeamWtfFix("alpha", { dryRun: false }, {
+      inspectTeamWtfFn: async () => ({
+        ok: false,
+        team: "alpha",
+        session: "167-alpha",
+        charterPath: "/repo/.maw/teams/alpha.yaml",
+        checks: [
+          {
+            name: "team:context",
+            ok: true,
+            message: "context",
+            details: { leadWindowRef: "$lead-session:@lead-window" },
+            fix: [],
+          },
+          check("team:missing", ["maw team up alpha --only coder-1"]),
+        ],
+      }),
+      exec: async (command: string) => { executed.push(command); return ""; },
+    });
+
+    expect(result.commands).toContain("maw team up alpha --only coder-1");
+    expect(executed).toEqual([]);
+  });
+
+  test("plan-only mode does not archive WIP as a side effect", async () => {
+    let archived = false;
+    await cmdTeamWtfFix("alpha", { dryRun: false }, {
+      inspectTeamWtfFn: async () => ({
+        ok: false,
+        team: "alpha",
+        session: "167-alpha",
+        charterPath: "/repo/.maw/teams/alpha.yaml",
+        checks: [
+          {
+            name: "team:context",
+            ok: true,
+            message: "context",
+            details: { leadWindowRef: "$lead-session:@lead-window" },
+            fix: [],
+          },
+          check("team:dead-frame", ["maw done wt-coder-3"]),
+        ],
+      }),
+      archiveWipFn: () => { archived = true; return { path: "x.patch", bytes: 1, verifiedApplicable: true }; },
+      exec: async () => "",
+    });
+
+    expect(archived).toBe(false);
+  });
+
+  test("execution re-runs diagnosis immediately after each transaction", async () => {
+    const calls: string[] = [];
+    await cmdTeamWtfFix("alpha", { dryRun: false, confirm: "confirm" }, {
+      inspectTeamWtfFn: async () => {
+        calls.push("inspect");
+        return {
+          ok: false,
+          team: "alpha",
+          session: "167-alpha",
+          charterPath: "/repo/.maw/teams/alpha.yaml",
+          checks: [
+            {
+              name: "team:context",
+              ok: true,
+              message: "context",
+              details: { leadWindowRef: "$lead-session:@lead-window" },
+              fix: [],
+            },
+            check("team:missing", ["maw team up alpha --only coder-1"]),
+            check("team:stuck", ["maw send-enter %2"]),
+          ],
+        };
+      },
+      exec: async (command: string) => { calls.push(command); return ""; },
+    });
+
+    expect(calls).toEqual([
+      "inspect",
+      "maw team up alpha --only coder-1",
+      "inspect",
+      "maw send-enter %2",
+      "inspect",
+    ]);
+  });
+
+  test("plans a fresh diagnosis re-run after every applied transaction", async () => {
+    const result = await planner()({
+      context: baseContext,
+      checks: [check("team:orphan-window", ["maw kill 167-alpha:stale"], {
+        target: { sessionId: "$lead-session", windowId: "@stale", windowName: "stale" },
+        lifecycleOwned: false,
+      })],
+    });
+
+    expect(JSON.stringify(result).toLowerCase()).toMatch(/diagnos|re-?run|verify/);
+  });
+});


### PR DESCRIPTION
## Summary
- add maw wtf --fix transaction planning/apply path behind per-item confirm
- deny broad teardown, protected lead/current targets, ambiguous matches, unverified WIP, and unconfirmed orphan PID kills
- wire top-level and team subcommand --fix dispatch with re-diagnosis after each transaction

Closes #2806

## Verification
- bun run build
- MAW_TEST_MODE=1 bun test test/isolated/team-wtf-fix-deny-gates.test.ts --path-ignore-patterns '**/agents/**'
- bun run test:isolated
- bun run test:default:safe