### PR TITLE
Fix oracle scan archive fleet refs

### DIFF
--- a/src/commands/shared/fleet-ensure.test.ts
+++ b/src/commands/shared/fleet-ensure.test.ts
@@ -26,6 +26,20 @@ describe("repoFromCwd", () => {
       .toBe("github.com/acme/repo");
   });
 
+
+  it("rejects archive copies under the ghq root", () => {
+    const result = _test.repoFromCwdResult(
+      "/opt/Code/_archive/oracle-world/nat-2026-06-10/ghq/github.com/acme/repo",
+      ghqRoot,
+    );
+    expect(result).toMatchObject({
+      repo: null,
+      archiveCopy: true,
+      reason: expect.stringContaining("refusing to register archive copy"),
+    });
+    expect(repoFromCwd("/opt/Code/_archive/oracle-world/nat-2026-06-10/ghq/github.com/acme/repo", ghqRoot)).toBeNull();
+  });
+
   it("returns null for paths outside ghq root", () => {
     expect(repoFromCwd("/home/user/projects/foo", ghqRoot)).toBeNull();
   });

--- a/src/commands/shared/fleet-ensure.ts
+++ b/src/commands/shared/fleet-ensure.ts
@@ -39,8 +39,16 @@ function isInside(parent: string, child: string): boolean {
   return rel === "" || (!!rel && !rel.startsWith("..") && !rel.includes(`..${sep}`));
 }
 
-function repoFromCwd(cwd: string | undefined, ghqRoot: string): string | null {
-  if (!cwd) return null;
+type RepoFromCwdResult =
+  | { repo: string }
+  | { repo: null; reason: string; archiveCopy?: boolean };
+
+function isArchivedSegment(segment: string): boolean {
+  return /^_?\.?archive(?:d)?$/i.test(segment);
+}
+
+function repoFromCwdResult(cwd: string | undefined, ghqRoot: string): RepoFromCwdResult {
+  if (!cwd) return { repo: null, reason: "missing cwd" };
   const resolvedCwd = resolve(cwd);
   const candidates: Array<{ root: string; segments: number }> = [
     { root: resolve(ghqRoot), segments: 3 },
@@ -50,9 +58,27 @@ function repoFromCwd(cwd: string | undefined, ghqRoot: string): string | null {
     if (!isInside(root, resolvedCwd)) continue;
     const parts = relative(root, resolvedCwd).split(sep);
     if (parts.length < segments || parts[0] === "..") continue;
-    return parts.slice(0, segments).join("/");
+    const repoParts = parts.slice(0, segments);
+    if (repoParts.some(isArchivedSegment)) {
+      return {
+        repo: null,
+        archiveCopy: true,
+        reason: `refusing to register archive copy: ${cwd}`,
+      };
+    }
+    // Canonical fleet repo refs come from $(ghq root)/github.com/<org>/<repo>.
+    // A cwd under $(ghq root)/_archive/... can otherwise look like a valid
+    // three-segment ghq repo and poison windows[].repo with _archive/... .
+    if (segments === 3 && repoParts[0] !== "github.com") {
+      return { repo: null, reason: `cwd is outside canonical ghq host root: ${cwd}` };
+    }
+    return { repo: repoParts.join("/") };
   }
-  return null;
+  return { repo: null, reason: `cwd is outside ghq root: ${cwd}` };
+}
+
+function repoFromCwd(cwd: string | undefined, ghqRoot: string): string | null {
+  return repoFromCwdResult(cwd, ghqRoot).repo;
 }
 
 function fleetFileNameForSession(session: string): string {
@@ -92,9 +118,13 @@ export function ensureFleetSessionEntry(
   const entries = (deps.loadFleetEntries ?? loadFleetEntries)(readDirs);
   const existing = entries.find(e => e.session?.name === session || e.file === fleetFileNameForSession(session));
   const ghqRoot = (deps.getGhqRoot ?? getGhqRoot)();
-  const repo = repoFromCwd(input.cwd, ghqRoot);
+  const repoResult = repoFromCwdResult(input.cwd, ghqRoot);
+  const repo = repoResult.repo;
   if (!repo) {
-    return { status: "skipped", reason: input.cwd ? `cwd is outside ghq root: ${input.cwd}` : "missing cwd" };
+    if (repoResult.archiveCopy) {
+      console.warn(`\x1b[33m⚠\x1b[0m ${repoResult.reason}`);
+    }
+    return { status: "skipped", reason: repoResult.reason };
   }
 
   if (existing?.path) {
@@ -131,4 +161,4 @@ export function ensureFleetSessionEntry(
   return { status: "created", file: path, entry: buildEntry(file, path, fleetSession) };
 }
 
-export const _test = { repoFromCwd, isSafeFleetSessionName };
+export const _test = { repoFromCwd, repoFromCwdResult, isSafeFleetSessionName };

--- a/src/core/fleet/registry-oracle-scan-local.ts
+++ b/src/core/fleet/registry-oracle-scan-local.ts
@@ -52,6 +52,10 @@ function normalizeFleetRepoRef(ref: unknown, source: string): string {
   return `${parsed.org}/${parsed.repo}`;
 }
 
+function warnInvalidFleetRepoRef(message: string): void {
+  console.warn(`[oracle-registry] ${message}`);
+}
+
 function addFleetLineageConfig(map: Map<string, FleetLineage>, config: any): void {
   const repos: unknown[] = config.project_repos || [];
   for (const r of repos) {
@@ -64,7 +68,8 @@ function addFleetLineageConfig(map: Map<string, FleetLineage>, config: any): voi
   }
   // Also check windows for repo references
   for (const w of config.windows || []) {
-    if (w.repo) {
+    if (!w.repo) continue;
+    try {
       const repoRef = normalizeFleetRepoRef(w.repo, "windows[].repo");
       if (!map.has(repoRef)) {
         map.set(repoRef, {
@@ -73,6 +78,10 @@ function addFleetLineageConfig(map: Map<string, FleetLineage>, config: any): voi
           budded_at: config.budded_at || null,
         });
       }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const windowName = typeof w.name === "string" && w.name ? ` '${w.name}'` : "";
+      warnInvalidFleetRepoRef(`skipping invalid fleet window${windowName}: ${message}`);
     }
   }
 }

--- a/test/fleet-ensure-entry.test.ts
+++ b/test/fleet-ensure-entry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { ensureFleetSessionEntry, _test } from "../src/commands/shared/fleet-ensure";
 
 function deps(files = new Map<string, string>()) {
@@ -44,6 +44,32 @@ describe("ensureFleetSessionEntry", () => {
       auto_registered: true,
       windows: [{ name: "mawjs-oracle", repo: "github.com/Soul-Brews-Studio/maw-js" }],
     });
+  });
+
+
+  test("refuses to register archive-copy cwd as a fleet repo (#2795)", () => {
+    const h = deps();
+    const warnings: string[] = [];
+    const warnSpy = spyOn(console, "warn").mockImplementation((...args: unknown[]) => warnings.push(args.map(String).join(" ")));
+    try {
+      const result = ensureFleetSessionEntry({
+        session: "77-mawjs",
+        window: "mawjs-codex-3",
+        cwd: "/ghq/_archive/oracle-world/nat-2026-06-10/ghq/github.com/Soul-Brews-Studio/maw-js",
+        createdBy: "maw wake",
+      }, h.deps);
+
+      expect(result).toMatchObject({
+        status: "skipped",
+        reason: expect.stringContaining("refusing to register archive copy"),
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(warnings).toEqual([expect.stringContaining("refusing to register archive copy")]);
+    expect(h.writes).toEqual([]);
+    expect(_test.repoFromCwd("/ghq/_archive/oracle-world/nat-2026-06-10/ghq/github.com/Soul-Brews-Studio/maw-js", "/ghq")).toBeNull();
   });
 
   test("updates an existing entry with the initial window instead of duplicating files", () => {

--- a/test/registry-oracle-scan-local.test.ts
+++ b/test/registry-oracle-scan-local.test.ts
@@ -65,6 +65,36 @@ describe("registry-oracle-scan-local", () => {
     expect(readFleetLineage(join(root, "missing")).size).toBe(0);
   });
 
+
+  test("readFleetLineage skips invalid window repo refs and keeps valid fleet visibility (#2795)", () => {
+    const root = tmpRoot("lineage-bad-window");
+    const fleetDir = join(root, "fleet");
+    mkdirp(fleetDir);
+    writeJson(join(fleetDir, "fleet.json"), {
+      project_repos: ["Soul-Brews-Studio/project-oracle"],
+      windows: [
+        { name: "archived", repo: "_archive/oracle-world/nat-2026-06-10" },
+        { name: "valid", repo: "github.com/Soul-Brews-Studio/live-oracle.git" },
+      ],
+    });
+
+    const warnings: string[] = [];
+    const warnSpy = spyOn(console, "warn").mockImplementation((...args: unknown[]) => warnings.push(args.map(String).join(" ")));
+    try {
+      const lineage = readFleetLineage(fleetDir);
+      expect([...lineage.keys()].sort()).toEqual([
+        "Soul-Brews-Studio/live-oracle",
+        "Soul-Brews-Studio/project-oracle",
+      ]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(warnings).toEqual([
+      expect.stringContaining("skipping invalid fleet window 'archived': invalid fleet repo reference in windows[].repo: _archive/oracle-world/nat-2026-06-10"),
+    ]);
+  });
+
   test("readFleetLineage fails loud on truncated or malformed fleet JSON", () => {
     const root = tmpRoot("lineage-broken");
     const fleetDir = join(root, "fleet");


### PR DESCRIPTION
Closes #2795

## Summary
- skip-and-warn invalid fleet `windows[].repo` refs during oracle lineage scan
- warn/refuse archive-copy cwd-derived fleet registration before writing `windows[].repo`
- add regression coverage for archive `_archive/...` fleet refs and canonical ghq cwd registration

## Tests
- MAW_TEST_MODE=1 bun test test/registry-oracle-scan-local.test.ts test/fleet-ensure-entry.test.ts src/commands/shared/fleet-ensure.test.ts --path-ignore-patterns '**/agents/**'\n- bun run build\n- bun run test:default:safe