### PR TITLE
Fix headless send sender attribution

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -77,15 +77,19 @@ export async function resolveOraclePane(
   }
 }
 
-/** Resolve the current oracle name from CLAUDE_AGENT_NAME or tmux session */
+/** Resolve the current oracle name from CLAUDE_AGENT_NAME or the attached tmux pane. */
 /** @internal */
 export function resolveMyName(config: ReturnType<typeof loadConfig>): string {
   if (process.env.CLAUDE_AGENT_NAME) return process.env.CLAUDE_AGENT_NAME;
-  // Try tmux session name: "08-mawjs" → "mawjs"
-  try {
-    const tmuxSession = require("child_process").execSync("tmux display-message -p '#{session_name}'", { encoding: "utf-8" }).trim();
-    if (tmuxSession) return tmuxSession.replace(/^\d+-/, "");
-  } catch {}
+  // Only trust tmux when this process is actually running inside a tmux pane.
+  // Outside tmux, `tmux display-message` can still succeed by reporting the
+  // server's current/last-active session, which misattributes sender envelopes.
+  if (process.env.TMUX) {
+    try {
+      const tmuxSession = require("child_process").execSync("tmux display-message -p '#{session_name}'", { encoding: "utf-8" }).trim();
+      if (tmuxSession) return tmuxSession.replace(/^\d+-/, "");
+    } catch {}
+  }
   return config.node || "cli";
 }
 

--- a/test/isolated/comm-list.test.ts
+++ b/test/isolated/comm-list.test.ts
@@ -298,6 +298,7 @@ const origClaudeAgentName = process.env.CLAUDE_AGENT_NAME;
 const origSshClient = process.env.SSH_CLIENT;
 const origSshConnection = process.env.SSH_CONNECTION;
 const origSshTty = process.env.SSH_TTY;
+const origTmux = process.env.TMUX;
 
 let outs: string[] = [];
 let errs: string[] = [];
@@ -352,6 +353,7 @@ beforeEach(() => {
   delete process.env.SSH_CLIENT;
   delete process.env.SSH_CONNECTION;
   delete process.env.SSH_TTY;
+  delete process.env.TMUX;
   childProcess.execSync = ((command: string, ...rest: unknown[]) => {
     if (!mockActive) return realExecSync(command, ...(rest as [unknown]));
     for (const response of execSyncResponses) {
@@ -375,6 +377,8 @@ afterEach(() => {
   else process.env.SSH_CONNECTION = origSshConnection;
   if (origSshTty === undefined) delete process.env.SSH_TTY;
   else process.env.SSH_TTY = origSshTty;
+  if (origTmux === undefined) delete process.env.TMUX;
+  else process.env.TMUX = origTmux;
   childProcess.execSync = realExecSync;
 });
 
@@ -757,13 +761,23 @@ describe("resolveMyName", () => {
 
   test("tmux session name is stripped to the bare oracle name", () => {
     delete process.env.CLAUDE_AGENT_NAME;
+    process.env.TMUX = "/tmp/tmux-test,1,0";
     execSyncResponses = [{ match: /tmux display-message/, result: "08-mawjs\n" }];
     const out = resolveMyName({ node: "ignored" } as unknown as Parameters<typeof resolveMyName>[0]);
     expect(out).toBe("mawjs");
   });
 
+  test("outside tmux does not trust tmux server current session", () => {
+    delete process.env.CLAUDE_AGENT_NAME;
+    delete process.env.TMUX;
+    execSyncResponses = [{ match: /tmux display-message/, result: "05-nari\n" }];
+    const out = resolveMyName({ node: "white" } as unknown as Parameters<typeof resolveMyName>[0]);
+    expect(out).toBe("white");
+  });
+
   test("no CLAUDE_AGENT_NAME, no tmux session → config.node fallback", () => {
     delete process.env.CLAUDE_AGENT_NAME;
+    process.env.TMUX = "/tmp/tmux-test,1,0";
     execSyncResponses = [{ match: /tmux display-message/, error: "not in tmux" }];
     const out = resolveMyName({ node: "white" } as unknown as Parameters<typeof resolveMyName>[0]);
     expect(out).toBe("white");
@@ -771,6 +785,7 @@ describe("resolveMyName", () => {
 
   test("no CLAUDE_AGENT_NAME and no config.node → 'cli' fallback", () => {
     delete process.env.CLAUDE_AGENT_NAME;
+    process.env.TMUX = "/tmp/tmux-test,1,0";
     execSyncResponses = [{ match: /tmux display-message/, error: "not in tmux" }];
     const out = resolveMyName({} as unknown as Parameters<typeof resolveMyName>[0]);
     expect(out).toBe("cli");

--- a/test/isolated/comm-send-xhigh-coverage.test.ts
+++ b/test/isolated/comm-send-xhigh-coverage.test.ts
@@ -11,6 +11,7 @@ import { resolveMyName } from "../../src/commands/shared/comm-send";
 const childProcess = require("child_process") as typeof import("child_process");
 const originalExecSync = childProcess.execSync;
 const originalAgentName = process.env.CLAUDE_AGENT_NAME;
+const originalTmux = process.env.TMUX;
 
 type ExecSyncCall = { command: string; options: unknown };
 
@@ -18,15 +19,22 @@ function withoutAgentName() {
   delete process.env.CLAUDE_AGENT_NAME;
 }
 
+function insideTmux() {
+  process.env.TMUX = "/tmp/tmux-test,1,0";
+}
+
 afterEach(() => {
   childProcess.execSync = originalExecSync;
   if (originalAgentName === undefined) delete process.env.CLAUDE_AGENT_NAME;
   else process.env.CLAUDE_AGENT_NAME = originalAgentName;
+  if (originalTmux === undefined) delete process.env.TMUX;
+  else process.env.TMUX = originalTmux;
 });
 
 describe("resolveMyName tmux fallback coverage", () => {
   test("uses the tmux session name and strips the numeric maw prefix when no env override exists", () => {
     withoutAgentName();
+    insideTmux();
     const calls: ExecSyncCall[] = [];
     childProcess.execSync = ((command: string, options: unknown) => {
       calls.push({ command, options });
@@ -39,13 +47,28 @@ describe("resolveMyName tmux fallback coverage", () => {
 
   test("falls through to config.node when tmux returns only whitespace", () => {
     withoutAgentName();
+    insideTmux();
     childProcess.execSync = (() => "  \n") as typeof childProcess.execSync;
 
     expect(resolveMyName({ node: "config-node" } as any)).toBe("config-node");
   });
 
+  test("does not query tmux outside a tmux pane", () => {
+    withoutAgentName();
+    delete process.env.TMUX;
+    const calls: ExecSyncCall[] = [];
+    childProcess.execSync = ((command: string, options: unknown) => {
+      calls.push({ command, options });
+      return "05-nari\n";
+    }) as typeof childProcess.execSync;
+
+    expect(resolveMyName({ node: "actual-node" } as any)).toBe("actual-node");
+    expect(calls).toEqual([]);
+  });
+
   test("falls through to cli when tmux lookup throws and config has no node", () => {
     withoutAgentName();
+    insideTmux();
     childProcess.execSync = (() => { throw new Error("tmux unavailable"); }) as typeof childProcess.execSync;
 
     expect(resolveMyName({} as any)).toBe("cli");


### PR DESCRIPTION
## Summary
- gate tmux-derived sender identity on `TMUX` so headless/non-pane sends do not borrow the tmux server's current session
- preserve existing explicit `CLAUDE_AGENT_NAME` and config fallback behavior
- add regressions proving non-tmux callers do not query/trust `tmux display-message`

## Tests
- `bun test test/isolated/comm-send-xhigh-coverage.test.ts test/comm-send-default.test.ts test/comm-send-signing.test.ts test/isolated/comm-list.test.ts --path-ignore-patterns '**/agents/**'`
- `bun run test:default:safe`
- `bun run test:isolated`
- `bun run build`

Closes #2783
