### PR TITLE
Add persistent inbox unread badge

### DIFF
--- a/packages/sdk/index.d.ts
+++ b/packages/sdk/index.d.ts
@@ -378,6 +378,16 @@ export declare function cmdPeek(query?: string): Promise<void>;
 /** Resolve a local target using the same session/window resolver as maw peek. */
 export declare function resolvePeekTarget(query: string): Promise<string | null>;
 
+export interface InboxStatusBadgeResult {
+  status: "set" | "cleared" | "unchanged" | "failed";
+  session: string;
+  unread: number;
+  reason?: string;
+}
+
+/** Set or clear the persistent tmux status-line unread inbox badge. */
+export declare function updateInboxStatusBadge(target: string, unread: number): Promise<InboxStatusBadgeResult>;
+
 /** Send a message to an oracle/window target. */
 export declare function cmdSend(target: string, message: string, force?: boolean): Promise<void>;
 export declare function resolveOraclePane(target: string): Promise<string>;

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -68,6 +68,7 @@ export { sparkline } from "../../src/lib/sparkline";
 // ─── src/commands/shared/comm ────────────────────────────────────────────────
 // Federation-aware communication helpers used by small command plugins.
 export { cmdPeek, cmdSend, resolvePeekTarget } from "../../src/commands/shared/comm";
+export { updateInboxStatusBadge } from "../../src/commands/shared/inbox-status-badge";
 export { resolveOraclePane } from "../../src/commands/shared/comm-send";
 export {
   deletePending,

--- a/scripts/check-sdk-surface-parity.ts
+++ b/scripts/check-sdk-surface-parity.ts
@@ -39,6 +39,10 @@ const REVIEWED_PUBLIC_EXPORTS = new Set([
   "FleetWindow",
   "HandlersFor",
   "Identity",
+  // Public return shape for the persistent inbox status-line badge helper;
+  // external plugins can branch on set/cleared/unchanged/failed without
+  // importing repo-internal tmux decoration code.
+  "InboxStatusBadgeResult",
   "LifecycleRunSummary",
   "LoadConfigOptions",
   "LoadedConfigWithProvenance",

--- a/src/commands/shared/inbox-status-badge.ts
+++ b/src/commands/shared/inbox-status-badge.ts
@@ -1,0 +1,84 @@
+import { Tmux } from "../../core/transport/tmux";
+
+export const INBOX_BADGE_BASE_OPTION = "@maw_inbox_status_right_base";
+const BADGE_RE = /#\[fg=colour220,bold\]📬 inbox:\d+#\[default\]\s*/g;
+
+export interface InboxStatusBadgeDeps {
+  tmux?: Pick<Tmux, "run">;
+}
+
+export interface InboxStatusBadgeResult {
+  status: "set" | "cleared" | "unchanged" | "failed";
+  session: string;
+  unread: number;
+  reason?: string;
+}
+
+function sessionFromTarget(target: string): string {
+  return target.split(":", 1)[0]?.trim() || target.trim();
+}
+
+export function formatInboxStatusBadge(unread: number): string {
+  return `#[fg=colour220,bold]📬 inbox:${unread}#[default]`;
+}
+
+export function stripInboxStatusBadge(statusRight: string): string {
+  return statusRight.replace(BADGE_RE, "").trimStart();
+}
+
+async function showOption(tmux: Pick<Tmux, "run">, session: string, option: string): Promise<string> {
+  return (await tmux.run("show-option", "-qv", "-t", session, option)).trim();
+}
+
+async function unsetOption(tmux: Pick<Tmux, "run">, session: string, option: string): Promise<void> {
+  await tmux.run("set-option", "-q", "-u", "-t", session, option);
+}
+
+/**
+ * Keep a session-local tmux status-right unread badge visible until the inbox is read.
+ *
+ * The original status-right is saved once in a @maw_* option, then restored when
+ * unread reaches zero. This is intentionally session-scoped and best-effort:
+ * message delivery must not fail just because tmux status decoration failed.
+ */
+export async function updateInboxStatusBadge(
+  target: string,
+  unread: number,
+  deps: InboxStatusBadgeDeps = {},
+): Promise<InboxStatusBadgeResult> {
+  const session = sessionFromTarget(target);
+  const count = Math.max(0, Math.floor(unread));
+  const tmux = deps.tmux ?? new Tmux();
+
+  if (!session) return { status: "failed", session, unread: count, reason: "missing tmux session target" };
+
+  try {
+    const savedBase = await showOption(tmux, session, INBOX_BADGE_BASE_OPTION).catch(() => "");
+
+    if (count <= 0) {
+      if (savedBase) {
+        await tmux.run("set-option", "-t", session, "status-right", savedBase);
+        await unsetOption(tmux, session, INBOX_BADGE_BASE_OPTION).catch(() => undefined);
+        return { status: "cleared", session, unread: count };
+      }
+
+      const current = await showOption(tmux, session, "status-right").catch(() => "");
+      const stripped = stripInboxStatusBadge(current);
+      if (stripped !== current) {
+        await tmux.run("set-option", "-t", session, "status-right", stripped);
+        return { status: "cleared", session, unread: count };
+      }
+      return { status: "unchanged", session, unread: count };
+    }
+
+    const base = savedBase || stripInboxStatusBadge(await showOption(tmux, session, "status-right").catch(() => ""));
+    if (!savedBase) await tmux.run("set-option", "-t", session, INBOX_BADGE_BASE_OPTION, base);
+
+    const next = `${formatInboxStatusBadge(count)} ${base}`.trimEnd();
+    await tmux.run("set-option", "-t", session, "status-right", next);
+    return { status: "set", session, unread: count };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { status: "failed", session, unread: count, reason };
+  }
+}

--- a/src/commands/shared/live-inbox-notify.ts
+++ b/src/commands/shared/live-inbox-notify.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import type { Session } from "../../core/transport/ssh";
 import type { ReceiverInboxResult } from "./receiver-inbox";
+import { updateInboxStatusBadge } from "./inbox-status-badge";
 
 export type LiveInboxNotifyStatus = "sent" | "not-live" | "failed";
 
@@ -107,6 +108,11 @@ export async function notifyLiveInboxReceiver(
     const reason = error instanceof Error ? error.message : String(error);
     return { status: "failed", target, reason: `count unread inbox failed for ${inbox.inboxDir}: ${reason}` };
   }
+
+  // Badge is stronger Layer-2 awareness, but advisory: do not drop the
+  // durable inbox write or transient status ping if tmux status-right cannot
+  // be decorated in this environment.
+  await updateInboxStatusBadge(target, unreadCount, { tmux: deps.tmux });
 
   const message = formatInboxNotification(inbox, from, unreadCount);
   try {

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -215,6 +215,7 @@ export { tlink } from "../core/util/terminal";
 
 // Plugin extraction helpers for tab-like command surfaces.
 export { cmdPeek, cmdSend, resolvePeekTarget } from "../commands/shared/comm";
+export { updateInboxStatusBadge } from "../commands/shared/inbox-status-badge";
 export { cmdSplit } from "../commands/plugins/split/impl";
 export { buildAgentRows } from "../commands/shared/agents";
 export type { AgentRow } from "../commands/shared/agents";

--- a/src/vendor/mpr-plugins/inbox/impl.ts
+++ b/src/vendor/mpr-plugins/inbox/impl.ts
@@ -8,7 +8,10 @@ import {
   loadFleetEntries,
   loadPending,
   loadPendingById,
+  updateInboxStatusBadge,
   updatePending,
+  hostExec,
+  tmuxCmd,
   type PendingMessage,
 } from "maw-js/sdk";
 
@@ -628,8 +631,25 @@ export function loadInboxMessages(inboxDir: string): InboxMessage[] {
   return messages.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
 }
 
+
+function countUnreadMessages(messages: InboxMessage[]): number {
+  return messages.filter((msg) => !msg.frontmatter.read).length;
+}
+
+async function refreshCurrentInboxStatusBadge(messages: InboxMessage[]): Promise<void> {
+  if (!process.env.TMUX) return;
+  try {
+    const session = (await hostExec(`${tmuxCmd()} display-message -p '#S'`)).trim();
+    if (!session) return;
+    await updateInboxStatusBadge(session, countUnreadMessages(messages));
+  } catch {
+    // Badge refresh is advisory UI; inbox reads/listing must stay reliable.
+  }
+}
 export async function cmdInboxLs(opts: { unread?: boolean; from?: string; last?: number } = {}) {
-  let msgs = loadInboxMessages(resolveInboxDir());
+  const inboxDir = resolveInboxDir();
+  let msgs = loadInboxMessages(inboxDir);
+  await refreshCurrentInboxStatusBadge(msgs);
   if (opts.unread) msgs = msgs.filter(m => !m.frontmatter.read);
   if (opts.from) msgs = msgs.filter(m => m.frontmatter.from === opts.from);
   if (!msgs.length) { console.log("\x1b[90mno inbox messages\x1b[0m"); return; }
@@ -679,12 +699,14 @@ export async function cmdInboxMarkRead(id: string) {
     return;
   }
   writeFileSync(msg.path, updated);
+  await refreshCurrentInboxStatusBadge(loadInboxMessages(resolveInboxDir()));
   console.log(`\x1b[32m✓\x1b[0m marked read: ${msg.filename}`);
 }
 
 // Legacy write shim — used by the oracle inbox skill
 export async function cmdInboxRead(target?: string) {
   const msgs = loadInboxMessages(resolveInboxDir());
+  await refreshCurrentInboxStatusBadge(msgs);
   if (!msgs.length) { console.log("\x1b[90mno inbox messages\x1b[0m"); return; }
   const n = target ? parseInt(target) : NaN;
   const msg = !target ? msgs[0]

--- a/test/api-send-inbox-notify-2057.test.ts
+++ b/test/api-send-inbox-notify-2057.test.ts
@@ -96,7 +96,15 @@ describe("/api/send queued inbox live notification (#2057)", () => {
     ));
 
     expect(await json(res)).toMatchObject({ ok: true, source: "inbox", state: "queued" });
-    expect(h.calls).toEqual([[
+    expect(h.calls).toContainEqual([
+      "tmux.run",
+      "set-option",
+      "-t",
+      "50-atlas",
+      "status-right",
+      "#[fg=colour220,bold]📬 inbox:1#[default]",
+    ]);
+    expect(h.calls.at(-1)).toEqual([
       "tmux.run",
       "display-message",
       "-d",
@@ -104,7 +112,7 @@ describe("/api/send queued inbox live notification (#2057)", () => {
       "-t",
       "50-atlas:atlas-oracle",
       "📬 inbox +1 from m5:mawjs — ว่างแล้วค่อย maw inbox (ψ/inbox/msg.md)",
-    ]]);
+    ]);
   });
 
   test("uses actual unread total in the gentle tmux status ping (#2792)", async () => {
@@ -116,6 +124,14 @@ describe("/api/send queued inbox live notification (#2057)", () => {
     ));
 
     expect(await json(res)).toMatchObject({ ok: true, source: "inbox", state: "queued" });
+    expect(h.calls).toContainEqual([
+      "tmux.run",
+      "set-option",
+      "-t",
+      "50-atlas",
+      "status-right",
+      "#[fg=colour220,bold]📬 inbox:24#[default]",
+    ]);
     expect(h.calls.at(-1)).toEqual([
       "tmux.run",
       "display-message",

--- a/test/comm-send-cmdsend-coverage.test.ts
+++ b/test/comm-send-cmdsend-coverage.test.ts
@@ -144,6 +144,8 @@ mock.module(join(import.meta.dir, "../src/core/transport/tmux"), () => {
       tmuxRunCalls.push(args);
       if (args.join(" ") === "display-message -p #S") return "mock-session\n";
       if (args[0] === "list-panes") return "0 claude\n";
+      if (args[0] === "show-option") return "";
+      if (args[0] === "set-option") return "";
       if (args[0] === "display-message" && args.includes("-t")) return "";
       throw new Error(`unexpected test tmux run: ${args.join(" ")}`);
     }
@@ -552,6 +554,13 @@ describe("cmdSend — delivery branch coverage", () => {
     expect(logs.join("\n")).toContain("ψ/inbox/msg.md");
     expect(sendKeysCalls).toEqual([]);
     expect(tmuxRunCalls).toContainEqual([
+      "set-option",
+      "-t",
+      "session",
+      "status-right",
+      "#[fg=colour220,bold]📬 inbox:1#[default]",
+    ]);
+    expect(tmuxRunCalls).toContainEqual([
       "display-message",
       "-d",
       "5000",
@@ -581,6 +590,13 @@ describe("cmdSend — delivery branch coverage", () => {
     expect(exitCode).toBeUndefined();
     expect(sendKeysCalls).toEqual([]);
     expect(logMessageCalls).toEqual([{ from: "sender", to: "m5:noah", message: "[test-node:sender] queued for later", route: "inbox" }]);
+    expect(tmuxRunCalls).toContainEqual([
+      "set-option",
+      "-t",
+      "157-noah",
+      "status-right",
+      "#[fg=colour220,bold]📬 inbox:24#[default]",
+    ]);
     expect(tmuxRunCalls).toContainEqual([
       "display-message",
       "-d",
@@ -652,6 +668,13 @@ describe("cmdSend — delivery branch coverage", () => {
     expect(logMessageCalls).toEqual([{ from: "sender", to: "local:session:oracle", message: "[test-node:sender] queued while busy", route: "inbox" }]);
     expect(emitFeedCalls[0].data).toMatchObject({ route: "inbox", state: "queued", lastLine: "--inbox requested; pane injection skipped" });
     expect(logs.join("\n")).toContain("busy.md");
+    expect(tmuxRunCalls).toContainEqual([
+      "set-option",
+      "-t",
+      "session",
+      "status-right",
+      "#[fg=colour220,bold]📬 inbox:2#[default]",
+    ]);
     expect(tmuxRunCalls).toContainEqual([
       "display-message",
       "-d",

--- a/test/inbox-status-badge-2793.test.ts
+++ b/test/inbox-status-badge-2793.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  INBOX_BADGE_BASE_OPTION,
+  formatInboxStatusBadge,
+  stripInboxStatusBadge,
+  updateInboxStatusBadge,
+} from "../src/commands/shared/inbox-status-badge";
+
+function fakeTmux(initial: Record<string, string> = {}) {
+  const options = new Map(Object.entries(initial));
+  const calls: string[][] = [];
+  return {
+    calls,
+    options,
+    tmux: {
+      async run(...args: string[]) {
+        calls.push(args);
+        if (args[0] === "show-option") {
+          const key = args.at(-1)!;
+          return options.get(key) ?? "";
+        }
+        if (args[0] === "set-option" && args.includes("-u")) {
+          options.delete(args.at(-1)!);
+          return "";
+        }
+        if (args[0] === "set-option") {
+          const key = args.at(-2)!;
+          const value = args.at(-1)!;
+          options.set(key, value);
+          return "";
+        }
+        throw new Error(`unexpected tmux call: ${args.join(" ")}`);
+      },
+    },
+  };
+}
+
+describe("persistent inbox status badge (#2793)", () => {
+  test("formats and strips the tmux status-right badge", () => {
+    const badge = formatInboxStatusBadge(3);
+    expect(badge).toBe("#[fg=colour220,bold]📬 inbox:3#[default]");
+    expect(stripInboxStatusBadge(`${badge} %H:%M`)).toBe("%H:%M");
+  });
+
+  test("saves the original session status-right and overlays unread count", async () => {
+    const h = fakeTmux({ "status-right": "%H:%M" });
+
+    await expect(updateInboxStatusBadge("50-atlas:atlas-oracle", 3, h)).resolves.toMatchObject({
+      status: "set",
+      session: "50-atlas",
+      unread: 3,
+    });
+
+    expect(h.options.get(INBOX_BADGE_BASE_OPTION)).toBe("%H:%M");
+    expect(h.options.get("status-right")).toBe("#[fg=colour220,bold]📬 inbox:3#[default] %H:%M");
+  });
+
+  test("reuses the saved base when unread count changes", async () => {
+    const h = fakeTmux({
+      [INBOX_BADGE_BASE_OPTION]: "%H:%M",
+      "status-right": "#[fg=colour220,bold]📬 inbox:3#[default] %H:%M",
+    });
+
+    await updateInboxStatusBadge("50-atlas:atlas-oracle", 5, h);
+
+    expect(h.options.get(INBOX_BADGE_BASE_OPTION)).toBe("%H:%M");
+    expect(h.options.get("status-right")).toBe("#[fg=colour220,bold]📬 inbox:5#[default] %H:%M");
+    expect(h.calls).not.toContainEqual(["set-option", "-t", "50-atlas", INBOX_BADGE_BASE_OPTION, "%H:%M"]);
+  });
+
+  test("clears badge and restores status-right once unread reaches zero", async () => {
+    const h = fakeTmux({
+      [INBOX_BADGE_BASE_OPTION]: "%H:%M",
+      "status-right": "#[fg=colour220,bold]📬 inbox:1#[default] %H:%M",
+    });
+
+    await expect(updateInboxStatusBadge("50-atlas:atlas-oracle", 0, h)).resolves.toMatchObject({
+      status: "cleared",
+      session: "50-atlas",
+      unread: 0,
+    });
+
+    expect(h.options.get("status-right")).toBe("%H:%M");
+    expect(h.options.has(INBOX_BADGE_BASE_OPTION)).toBe(false);
+  });
+});

--- a/test/isolated/plugin-inbox-standalone.test.ts
+++ b/test/isolated/plugin-inbox-standalone.test.ts
@@ -15,6 +15,8 @@ let deleted: string[] = [];
 let updated: Array<{ id: string; patch: any }> = [];
 let sent: Array<{ target: string; message: string; force?: boolean }> = [];
 let ghqCalls: string[] = [];
+let statusBadgeCalls: Array<{ target: string; unread: number }> = [];
+let hostExecCalls: string[] = [];
 
 const sdkMock = {
   loadConfig: () => ({ psiPath, node: "codex-5", oracle: "codex-5" }),
@@ -48,6 +50,15 @@ const sdkMock = {
   TTL_MS: 30 * 24 * 60 * 60 * 1000,
   cmdSend: async (target: string, message: string, force?: boolean) => {
     sent.push({ target, message, force });
+  },
+  tmuxCmd: () => "tmux",
+  hostExec: async (cmd: string) => {
+    hostExecCalls.push(cmd);
+    return "mock-session\n";
+  },
+  updateInboxStatusBadge: async (target: string, unread: number) => {
+    statusBadgeCalls.push({ target, unread });
+    return { status: unread > 0 ? "set" : "cleared", session: target, unread };
   },
 };
 
@@ -90,6 +101,8 @@ beforeEach(() => {
   updated = [];
   sent = [];
   ghqCalls = [];
+  statusBadgeCalls = [];
+  hostExecCalls = [];
 });
 
 describe("inbox plugin standalone boundary (#2329)", () => {
@@ -162,13 +175,28 @@ describe("inbox plugin standalone boundary (#2329)", () => {
       "missing read flag",
     ].join("\n"));
 
-    await cmdInboxMarkRead("compact");
-    await cmdInboxMarkRead("missing");
+    const prevTmux = process.env.TMUX;
+    process.env.TMUX = "/tmp/tmux-test/default,123,0";
+    try {
+      await cmdInboxMarkRead("compact");
+      await cmdInboxMarkRead("missing");
+    } finally {
+      if (prevTmux === undefined) delete process.env.TMUX;
+      else process.env.TMUX = prevTmux;
+    }
 
     expect(readFileSync(compact, "utf8")).toContain("read: true");
     expect(readFileSync(compact, "utf8")).toContain("readAt:");
     expect(readFileSync(missing, "utf8")).toContain("read: true");
     expect(readFileSync(missing, "utf8")).toContain("readAt:");
+    expect(hostExecCalls).toEqual([
+      "tmux display-message -p '#S'",
+      "tmux display-message -p '#S'",
+    ]);
+    expect(statusBadgeCalls).toEqual([
+      { target: "mock-session", unread: 1 },
+      { target: "mock-session", unread: 0 },
+    ]);
   });
 
   test("local inbox write and relative time are non-destructive and deterministic", async () => {


### PR DESCRIPTION
## Summary
- add a persistent tmux status-right unread inbox badge alongside the existing display-message ping
- refresh/clear the badge from inbox list/show/read paths based on actual unread files
- expose the badge updater through the SDK boundary for the vendored inbox plugin

## Tests
- bun test test/inbox-status-badge-2793.test.ts test/api-send-inbox-notify-2057.test.ts test/comm-send-cmdsend-coverage.test.ts test/isolated/plugin-inbox-standalone.test.ts
- bun scripts/check-sdk-surface-parity.ts
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun run test:default:safe
- bun run test:isolated
- bun run build

Closes #2793
