### PR TITLE
Fix swarm stale pane anchors

### DIFF
--- a/src/commands/plugins/swarm/index.ts
+++ b/src/commands/plugins/swarm/index.ts
@@ -20,6 +20,39 @@ function unknownFlagMessage(flag: string): string {
   return `unknown flag for swarm: ${flag} (supported: ${SUPPORTED_FLAGS.join(", ")})`;
 }
 
+function shellArg(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+async function resolveLiveAnchorPane(
+  envPane: string,
+  hostExec: (cmd: string) => Promise<string>,
+): Promise<string> {
+  const candidate = envPane.trim();
+  if (!candidate) return "";
+
+  try {
+    const resolved = (await hostExec(
+      `tmux display-message -p -t ${shellArg(candidate)} '#{pane_id}'`,
+    )).trim();
+    if (resolved.startsWith("%")) return resolved;
+  } catch {
+    // $TMUX_PANE can be stale when maw swarm is injected through maw run,
+    // especially on WSL/headless paths. Fall through to the tmux current pane
+    // context rather than handing the stale %N to split-window.
+  }
+
+  try {
+    const resolved = (await hostExec("tmux display-message -p '#{pane_id}'")).trim();
+    if (resolved.startsWith("%")) return resolved;
+  } catch {
+    // Splitting without an explicit target is safer than crashing on a known
+    // stale pane id; tmux can still use its current command context.
+  }
+
+  return "";
+}
+
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
   const origLog = console.log;
@@ -89,7 +122,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     const { homedir } = await import("os");
     const { prefixCommandWithSpawnSessionEnv } = await import("../../../core/fleet/parent-session");
 
-    const anchor = process.env.TMUX_PANE ?? "";
+    const anchor = await resolveLiveAnchorPane(process.env.TMUX_PANE ?? "", hostExec);
     const teamName = "swarm";
     const teamsDir = join(homedir(), ".claude/teams");
     const teamDir = join(teamsDir, teamName);
@@ -123,7 +156,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     // Phase 1: Split all panes (empty shells) — no agents yet
     const spawned: { name: string; agentId: string; agentCmd: string; label: string; color: AgentColor; paneId: string }[] = [];
     for (const agent of paneIds) {
-      const targetFlag = anchor ? `-t '${anchor}' ` : "";
+      const targetFlag = anchor ? `-t ${shellArg(anchor)} ` : "";
       let paneId = "";
       await withPaneLock(async () => {
         paneId = (await hostExec(

--- a/test/isolated/swarm-index-coverage.test.ts
+++ b/test/isolated/swarm-index-coverage.test.ts
@@ -53,6 +53,8 @@ let configCommands: Record<string, string> = {};
 let splitCounter = 0;
 let sendKeysCounter = 0;
 let failOnSendKeysNumber: number | undefined;
+let currentPaneId = "%leader";
+let stalePaneTargets = new Set<string>();
 
 const swarmEngineSeed = {
   claude: {
@@ -87,6 +89,11 @@ mock.module("os", () => ({
 mock.module(at("../../src/sdk"), () => ({
   hostExec: async (cmd: string) => {
     calls.hostExec.push(cmd);
+    if (cmd.includes("tmux display-message") && cmd.includes("#{pane_id}")) {
+      const target = cmd.match(/-t '([^']+)'/)?.[1];
+      if (target && stalePaneTargets.has(target)) throw new Error(`can't find pane: ${target}`);
+      return `${target || currentPaneId}\n`;
+    }
     if (cmd.includes("tmux split-window")) return `%pane${++splitCounter}\n`;
     if (cmd.includes("tmux send-keys")) {
       sendKeysCounter += 1;
@@ -173,6 +180,8 @@ beforeEach(() => {
   splitCounter = 0;
   sendKeysCounter = 0;
   failOnSendKeysNumber = undefined;
+  currentPaneId = "%leader";
+  stalePaneTargets = new Set<string>();
   process.env.TMUX = "/tmp/tmux-coverage";
   process.env.TMUX_PANE = "%leader";
   console.log = originalLog;
@@ -283,6 +292,25 @@ describe("swarm index handler isolated coverage", () => {
       { name: "claude-2", agentId: "claude-2@swarm", tmuxPaneId: "%pane2", color: "green", model: "claude" },
       { name: "claude-3", agentId: "claude-3@swarm", tmuxPaneId: "%pane3", color: "yellow", model: "claude" },
     ]);
+  });
+
+  test("falls back from stale TMUX_PANE to the live current pane before splitting", async () => {
+    process.env.TMUX_PANE = "%stale";
+    currentPaneId = "%live";
+    stalePaneTargets.add("%stale");
+
+    const result = await run(["claude", "codex"]);
+
+    expect(result.ok).toBe(true);
+    expect(calls.hostExec).toContain("tmux display-message -p -t '%stale' '#{pane_id}'");
+    expect(calls.hostExec).toContain("tmux display-message -p '#{pane_id}'");
+    expect(calls.hostExec.some((cmd) => cmd.includes("tmux split-window -t '%stale'"))).toBe(false);
+    expect(calls.hostExec.filter((cmd) => cmd.includes("tmux split-window"))).toEqual([
+      "tmux split-window -t '%live' -h -P -F '#{pane_id}' 'exec zsh -li'",
+      "tmux split-window -t '%live' -h -P -F '#{pane_id}' 'exec zsh -li'",
+    ]);
+    expect(calls.applyTeamLayout).toEqual([["window-1", "%live"]]);
+    expect(calls.saveLayoutSnapshot).toEqual([["swarm", "%live"]]);
   });
 
   test("ignores non-cli args and skips layout selection when there is no anchor and --tiled is absent", async () => {


### PR DESCRIPTION
## Summary
- validate the inherited TMUX_PANE before using it as the swarm split anchor
- fall back to the live tmux current pane when maw run/headless paths provide a stale %N
- add regression coverage proving split-window never targets the stale pane

Closes #2801

## Verification
- bun test test/isolated/swarm-index-coverage.test.ts
- bun run test:isolated
- bun run build