### PR TITLE
Guard codex team agents from shared checkouts

### DIFF
--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from "fs";
 import { createHash } from "crypto";
-import { join } from "path";
+import { join, resolve as resolvePath } from "path";
 import { tmux } from "../../../sdk";
 import { assertValidOracleName } from "../../../core/fleet/validate";
 import { prefixCommandWithSpawnSessionEnv } from "../../../core/fleet/parent-session";
@@ -75,6 +75,42 @@ export function mergeTeamKnowledge(name: string, teammates: Array<{ name: string
     const archiveDest = join(PSI, "memory", "mailbox", "teams", name);
     mkdirSync(archiveDest, { recursive: true });
     copyFileSync(manifestSrc, join(archiveDest, "manifest.json"));
+  }
+}
+
+
+function isCodexLikeSpawnEngine(engine: string, config: ReturnType<typeof loadConfig>): boolean {
+  try {
+    const resolved = resolveEngine(engine, config) as { name?: string; cmd?: string; processNames?: string[] };
+    const haystack = [engine, resolved.name, resolved.cmd, ...(resolved.processNames ?? [])]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ");
+    return /(^|[\s/_-])(codex|omx)([\s/_-]|$)/i.test(haystack);
+  } catch {
+    return /^(codex|omx)$/i.test(engine);
+  }
+}
+
+function gitTopLevel(cwd: string): string | null {
+  try {
+    const proc = Bun.spawnSync(["git", "-C", cwd, "rev-parse", "--show-toplevel"], { stdout: "pipe", stderr: "pipe" });
+    if (proc.exitCode !== 0) return null;
+    const top = new TextDecoder().decode(proc.stdout).trim();
+    return top ? resolvePath(top) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function assertTeamSpawnWorktreeIsolation(role: string, engine: string, opts: { cwd?: string }, config: ReturnType<typeof loadConfig>, currentCwd = process.cwd()): void {
+  if (!isCodexLikeSpawnEngine(engine, config)) return;
+  if (!opts.cwd) {
+    throw new Error(`codex-like team spawn for '${role}' requires --worktree/--cwd; refusing to run in the shared checkout (#2764)`);
+  }
+  const targetTop = gitTopLevel(opts.cwd);
+  const currentTop = gitTopLevel(currentCwd);
+  if (targetTop && currentTop && targetTop === currentTop) {
+    throw new Error(`codex-like team spawn for '${role}' must use an isolated git worktree, not the shared checkout: ${opts.cwd} (#2764)`);
   }
 }
 
@@ -245,6 +281,7 @@ export async function cmdTeamSpawn(
   // Build spawn prompt
   const config = loadConfig();
   const engine = opts.engine || config.defaultEngine || defaultEngineNameForConfig(config);
+  assertTeamSpawnWorktreeIsolation(role, engine, opts, config);
   const resolvedEngine = resolveEngine(engine, config);
   const model = opts.model || resolvedEngine.model?.default;
   const shellQuote = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;

--- a/src/vendor/mpr-plugins/team/team-lifecycle.ts
+++ b/src/vendor/mpr-plugins/team/team-lifecycle.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, rmSync } from "fs";
 import { createHash } from "crypto";
-import { join } from "path";
+import { join, resolve as resolvePath } from "path";
 import { tmux } from "maw-js/sdk";
 import { defaultEngineNameForConfig, resolveEngine } from "../../../config/engine-registry";
 import { assertValidOracleName } from "maw-js/core/fleet/validate";
@@ -76,6 +76,42 @@ export function mergeTeamKnowledge(name: string, teammates: Array<{ name: string
     const archiveDest = join(PSI, "memory", "mailbox", "teams", name);
     mkdirSync(archiveDest, { recursive: true });
     copyFileSync(manifestSrc, join(archiveDest, "manifest.json"));
+  }
+}
+
+
+function isCodexLikeSpawnEngine(engine: string, config: ReturnType<typeof loadConfig>): boolean {
+  try {
+    const resolved = resolveEngine(engine, config) as { name?: string; cmd?: string; processNames?: string[] };
+    const haystack = [engine, resolved.name, resolved.cmd, ...(resolved.processNames ?? [])]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ");
+    return /(^|[\s/_-])(codex|omx)([\s/_-]|$)/i.test(haystack);
+  } catch {
+    return /^(codex|omx)$/i.test(engine);
+  }
+}
+
+function gitTopLevel(cwd: string): string | null {
+  try {
+    const proc = Bun.spawnSync(["git", "-C", cwd, "rev-parse", "--show-toplevel"], { stdout: "pipe", stderr: "pipe" });
+    if (proc.exitCode !== 0) return null;
+    const top = new TextDecoder().decode(proc.stdout).trim();
+    return top ? resolvePath(top) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function assertTeamSpawnWorktreeIsolation(role: string, engine: string, opts: { cwd?: string }, config: ReturnType<typeof loadConfig>, currentCwd = process.cwd()): void {
+  if (!isCodexLikeSpawnEngine(engine, config)) return;
+  if (!opts.cwd) {
+    throw new Error(`codex-like team spawn for '${role}' requires --worktree/--cwd; refusing to run in the shared checkout (#2764)`);
+  }
+  const targetTop = gitTopLevel(opts.cwd);
+  const currentTop = gitTopLevel(currentCwd);
+  if (targetTop && currentTop && targetTop === currentTop) {
+    throw new Error(`codex-like team spawn for '${role}' must use an isolated git worktree, not the shared checkout: ${opts.cwd} (#2764)`);
   }
 }
 
@@ -275,6 +311,7 @@ export async function cmdTeamSpawn(
   // Build spawn prompt
   const config = loadConfig();
   const engine = opts.engine || config.defaultEngine || defaultEngineNameForConfig(config);
+  assertTeamSpawnWorktreeIsolation(role, engine, opts, config);
   if (opts.cwd && existsSync(opts.cwd)) writeWorktreeEngineFile(opts.cwd, engine, console.log.bind(console));
   const resolvedEngine = resolveEngine(engine, config);
   const model = opts.model || resolvedEngine.model?.default;

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -100,6 +100,18 @@ export function memberEngineForClassification(member: TeamCharterMember, overrid
   return override ?? member.engine ?? member.model;
 }
 
+export function isCodexLikeTeamEngine(engine: string, config: MawConfig = loadConfig()): boolean {
+  try {
+    const resolved = mawSdk.resolveEngine(engine, config) as { name?: string; cmd?: string; processNames?: string[] };
+    const haystack = [engine, resolved.name, resolved.cmd, ...(resolved.processNames ?? [])]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ");
+    return /(^|[\s/_-])(codex|omx)([\s/_-]|$)/i.test(haystack);
+  } catch {
+    return /^(codex|omx)$/i.test(engine);
+  }
+}
+
 export function memberMatchesSelector(member: TeamCharterMember, selector: string): boolean {
   const wanted = selector.trim();
   if (!wanted) return false;

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -25,6 +25,7 @@ import {
   memberWakeTarget,
   memberWindowIdentity,
   wakeMember,
+  isCodexLikeTeamEngine,
   type ClassifiedTeamMember,
 } from "./team-liveness";
 
@@ -163,6 +164,17 @@ function memberPrimingTarget(session: string, member: TeamCharter["members"][num
 }
 
 
+
+function validateRosterWorktreeIsolation(roster: ClassifiedTeamMember[], config: MawConfig, override?: string): void {
+  const bad = roster
+    .filter((item) => item.state !== "skipped" && item.member.worktree === false)
+    .map((item) => ({ item, engine: resolvedMemberEngine(item, override, config) }))
+    .filter(({ engine }) => isCodexLikeTeamEngine(engine, config))
+    .map(({ item, engine }) => `${item.role}: engine '${engine}' cannot use worktree:false`);
+  if (bad.length === 0) return;
+  throw new UserError(`team up preflight failed: codex-like members must run in isolated worktrees (#2764): ${bad.join("; ")} — remove worktree:false or set worktree:<name>`);
+}
+
 function validateRosterEngines(roster: ClassifiedTeamMember[], charter: TeamCharter, config: MawConfig, override?: string): void {
   const known = new Set(knownTeamEngineNames(config, charter.engines));
   const bad = roster
@@ -264,6 +276,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   }
 
   validateRosterEngines(roster, charter, config, opts.engine);
+  validateRosterWorktreeIsolation(roster, config, opts.engine);
 
   if (opts.dryRun) {
     for (const [index, item] of roster.entries()) {

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -124,14 +124,18 @@ describe("team command plugin standalone boundary (#2336)", () => {
   test("entrypoint and touched team-up files keep explicit standalone import boundaries", () => {
     const imports = expectStandalonePluginBoundary({
       plugin: "team",
-      files: ["index.ts", "team-liveness.ts", "team-wtf.ts", "team-wtf-fix.ts", "team-up.ts", "team-apply.ts"],
+      files: ["index.ts", "team-liveness.ts", "team-lifecycle.ts", "team-wtf.ts", "team-wtf-fix.ts", "team-up.ts", "team-apply.ts"],
+      allowMawJs: ["maw-js/core/fleet/validate"],
       allowRelative: [
         "../../../core/transport/tmux",
         "../../../core/agent-detect",
         "../../../config/load",
         "../../../config/types",
         "../../../config/engine-registry",
+        "../../../config/command",
         "../../../commands/shared/wake-cmd",
+        "../../../commands/shared/wake-session",
+        "../../../core/fleet/parent-session",
         "../../../commands/shared/comm-send",
         "../../../core/util/user-error",
         "../done/impl",
@@ -146,8 +150,13 @@ describe("team command plugin standalone boundary (#2336)", () => {
     expect(teamUp).toContain("Promise.all(launchTasks.map((task) => task.run()))");
     expect(teamUp).toContain("Promise.all(launchTasks.map((task) => waitForNonShell");
     expect(teamUp).toContain("validateRosterEngines(roster, charter, config, opts.engine)");
+    expect(teamUp).toContain("validateRosterWorktreeIsolation(roster, config, opts.engine)");
+    const teamLifecycle = readFileSync(join(root, "src/vendor/mpr-plugins/team/team-lifecycle.ts"), "utf8");
+    expect(teamLifecycle).toContain("assertTeamSpawnWorktreeIsolation");
+    expect(teamLifecycle).toContain("requires --worktree/--cwd");
     const teamLiveness = readFileSync(join(root, "src/vendor/mpr-plugins/team/team-liveness.ts"), "utf8");
     expect(teamLiveness).toContain("#{pane_pid}");
+    expect(teamLiveness).toContain("isCodexLikeTeamEngine");
     const teamWtf = readFileSync(join(root, "src/vendor/mpr-plugins/team/team-wtf.ts"), "utf8");
     expect(teamWtf).toContain("DoctorCheck[]");
     expect(teamWtf).toContain("processSampleCount");
@@ -296,7 +305,7 @@ describe("team command plugin standalone boundary (#2336)", () => {
     const previousCwd = process.cwd();
     try {
       process.chdir(cwd);
-      await lifecycle.cmdTeamSpawn("avengers", "builder");
+      await lifecycle.cmdTeamSpawn("avengers", "builder", { cwd: join(tmp, "builder-wt") });
 
       const toolConfig = JSON.parse(readFileSync(join(teamsDir, "avengers", "config.json"), "utf8"));
       expect(toolConfig.members).toEqual([{ name: "builder", engine: "codex", model: "gpt-5.5" }]);

--- a/test/isolated/team-lifecycle-default.test.ts
+++ b/test/isolated/team-lifecycle-default.test.ts
@@ -220,11 +220,14 @@ describe("team-lifecycle coverage", () => {
   test("spawn can render a non-Claude engine through buildCommandFromConfig", async () => {
     lifecycle.cmdTeamCreate("qa-team");
 
-    await lifecycle.cmdTeamSpawn("qa-team", "codexer", { engine: "codex" });
+    await expect(lifecycle.cmdTeamSpawn("qa-team", "codexer", { engine: "codex" })).rejects.toThrow("requires --worktree/--cwd");
+
+    await lifecycle.cmdTeamSpawn("qa-team", "codexer", { engine: "codex", cwd: "/tmp/codexer-wt" });
 
     const output = logs.join("\n");
     expect(output).toContain("engine: codex");
     expect(output).toContain("Run:");
+    expect(output).toContain("cd '/tmp/codexer-wt' && ");
     expect(output).toContain("codex");
     expect(output).not.toContain("--model sonnet");
     expect(output).not.toContain("--system-prompt-file");

--- a/test/isolated/team-lifecycle-second-pass-coverage.test.ts
+++ b/test/isolated/team-lifecycle-second-pass-coverage.test.ts
@@ -357,10 +357,13 @@ describe("vendor team-lifecycle second-pass coverage", () => {
   test("spawn supports non-Claude engines without Claude-only launch flags", async () => {
     lifecycle.cmdTeamCreate("qa-team");
 
-    await lifecycle.cmdTeamSpawn("qa-team", "codexer", { engine: "codex" });
+    await expect(lifecycle.cmdTeamSpawn("qa-team", "codexer", { engine: "codex" })).rejects.toThrow("requires --worktree/--cwd");
+
+    await lifecycle.cmdTeamSpawn("qa-team", "codexer", { engine: "codex", cwd: "/tmp/codexer-wt" });
 
     const output = logs.join("\n");
     expect(output).toContain("engine: codex");
+    expect(output).toContain("cd '/tmp/codexer-wt' && ");
     expect(output).toContain("codex");
     expect(output).not.toContain("--model sonnet");
     expect(output).not.toContain("--system-prompt-file");

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -493,6 +493,27 @@ members:
   });
 
 
+
+  test("team up preflight rejects codex-like members pinned to shared checkout with worktree:false (#2764)", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "shared-codex.yaml"), `
+name: shared-codex
+session: charter-session
+members:
+  - role: codex-main
+    engine: codex
+    worktree: false
+`, "utf-8");
+    const { tmux } = fakeTmux([]);
+
+    await expect(cmdTeamUp("shared-codex", { dryRun: true }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => config,
+      logger: () => {},
+    })).rejects.toThrow("codex-like members must run in isolated worktrees");
+  });
+
   test("classifyMember matches wake-produced dot worktree windows (#2802)", () => {
     const panes = [{ sessionName: "s", windowName: "web-v2-web-v2.wt-coder-2", command: "codex", path: "/wt/web-v2.wt-coder-2", paneId: "%2" }];
     expect(classifyMember({ role: "coder-2", worktree: "web-v2.wt-coder-2" }, panes, "s", { repoSlug: "web-v2" }).state).toBe("live");


### PR DESCRIPTION
Closes #2764

## Summary
- reject codex/omx charter members that opt into worktree:false before maw team up launches them
- require codex-like maw team spawn calls to provide an isolated cwd/worktree and reject the current shared checkout
- refresh team standalone boundary coverage plus lifecycle/up regressions

## Tests
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bash scripts/test-isolated.sh test/isolated/team-lifecycle-default.test.ts test/isolated/team-lifecycle-second-pass-coverage.test.ts test/isolated/team-up-coverage.test.ts test/isolated/plugin-team-standalone.test.ts
- bun run test:plugin
- bun run test:mock-smoke
- bun run check:sdk-surface
- bun run build