### PR TITLE
Fix team up worktree base for charter projects

### DIFF
--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -3,9 +3,10 @@
 // Paths differ from the core copy: charter is a sibling here, and commands/shared
 // is three levels up (vendored dir is src/vendor/mpr-plugins/team).
 import { existsSync, readFileSync } from "fs";
-import { resolve } from "path";
+import { basename, resolve } from "path";
 import { readTeamCharter, type TeamCharter } from "./team-charter";
 import { loadConfig } from "../../../config/load";
+import { ghqFind } from "maw-js/sdk";
 import type { MawConfig } from "../../../config/types";
 import { Tmux } from "../../../core/transport/tmux";
 import type { WakeOptions } from "../../../commands/shared/wake-cmd";
@@ -81,6 +82,8 @@ export interface TeamUpDeps {
   sleep?: (ms: number) => Promise<void>;
   repoRoot?: string;
   repoSlug?: string;
+  projectRepoRoot?: string;
+  ghqFindFn?: typeof ghqFind;
   logger?: (line: string) => void;
 }
 
@@ -146,6 +149,30 @@ function freshWakePlan(item: ClassifiedTeamMember, repoSlug: string, session: st
     return `${prefix} ${memberWakeTarget(repoSlug, item.member)} -e ${displayEngine(item)} --session ${session}${channelFlag(channels)}`;
   }
   return `${prefix} --wt ${item.worktree} -e ${displayEngine(item)} --session ${session}${channelFlag(channels)}`;
+}
+
+
+function normalizeProjectSlug(project: string): string {
+  return project
+    .trim()
+    .replace(/^https?:\/\/github\.com\//i, "")
+    .replace(/^git@github\.com:/i, "")
+    .replace(/\.git$/i, "")
+    .replace(/^\/+|\/+$/g, "");
+}
+
+async function resolveProjectRepoRoot(project: string, deps: Pick<TeamUpDeps, "projectRepoRoot" | "ghqFindFn"> = {}): Promise<string> {
+  if (deps.projectRepoRoot) return deps.projectRepoRoot;
+  const slug = normalizeProjectSlug(project);
+  if (!slug) throw new UserError(`charter.project is empty; cannot resolve team worktree base`);
+  const find = deps.ghqFindFn ?? ghqFind;
+  const candidates = [`/${slug}`];
+  for (const candidate of candidates) {
+    const hit = await find(candidate);
+    if (hit) return hit;
+  }
+  const repoName = basename(slug);
+  throw new UserError(`charter.project '${project}' is not cloned under ghq; cannot create team worktrees. Run: ghq get github.com/${slug.includes("/") ? slug : repoName}`);
 }
 
 function resolvePrimingPrompt(member: TeamCharter["members"][number], repoRoot: string): string | undefined {
@@ -234,9 +261,14 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   const read = deps.readTeamCharterFn ?? ((path: string) => quickCount !== undefined ? quickCharter(quickCount, { name: team, engine: opts.engine, session: opts.session }) : readTeamCharter(path));
   const charter: TeamCharter = read(charterPath as string);
   const tmux = deps.tmux ?? new Tmux();
-  const repoRoot = deps.repoRoot ?? findRepoRoot(cwd);
-  const repoSlug = deps.repoSlug ?? repoSlugFromRoot(repoRoot);
-  const targetRepoSlug = charter.project ?? repoSlug;
+  const callerRepoRoot = deps.repoRoot ?? findRepoRoot(cwd);
+  const repoSlug = deps.repoSlug ?? repoSlugFromRoot(callerRepoRoot);
+  const targetRepoSlug = charter.project ? normalizeProjectSlug(charter.project) : repoSlug;
+  let worktreeRepoRootPromise: Promise<string> | undefined;
+  const getWorktreeRepoRoot = () => {
+    worktreeRepoRootPromise ??= charter.project ? resolveProjectRepoRoot(charter.project, deps) : Promise.resolve(callerRepoRoot);
+    return worktreeRepoRootPromise;
+  };
   const currentSession = await currentTmuxSession(tmux).catch(() => "");
   const session = opts.session?.trim() || charter.session || currentSession;
   if (!session) throw new Error(`session required: pass --session <name> when running team up outside tmux and charter.session is omitted`);
@@ -319,7 +351,8 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
         item,
         run: async () => {
           if (item.pane) await tmux.run("kill-window", "-t", `${item.pane.sessionName ?? session}:${item.pane.windowName}`);
-          await wakeMember(targetRepoSlug, item.member, { engine: launchEngine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
+          const repoPath = await getWorktreeRepoRoot();
+          await wakeMember(targetRepoSlug, item.member, { engine: launchEngine, session, repoPath, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
         },
       });
     } else if (item.state === "live") {
@@ -342,7 +375,8 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
       launchTasks.push({
         item,
         run: async () => {
-          await wakeMember(targetRepoSlug, item.member, { engine: launchEngine, session, repoPath: repoRoot, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
+          const repoPath = await getWorktreeRepoRoot();
+          await wakeMember(targetRepoSlug, item.member, { engine: launchEngine, session, repoPath, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
         },
       });
     }
@@ -351,7 +385,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   if (launchTasks.length > 0) {
     await Promise.all(launchTasks.map((task) => waitForNonShell(task.item.member, session, tmux, sleep, targetRepoSlug)));
     await sleep(promptDelayMs(charter));
-    await Promise.all(launchTasks.map((task) => primeMember(task.item.member, session, repoRoot, deps, warnings)));
+    await Promise.all(launchTasks.map((task) => primeMember(task.item.member, session, callerRepoRoot, deps, warnings)));
   }
 
   const finalPanes = await listPaneSnapshots(tmux).catch(() => panes);

--- a/test/isolated/plugin-team-standalone.test.ts
+++ b/test/isolated/plugin-team-standalone.test.ts
@@ -151,6 +151,10 @@ describe("team command plugin standalone boundary (#2336)", () => {
     expect(teamUp).toContain("Promise.all(launchTasks.map((task) => waitForNonShell");
     expect(teamUp).toContain("validateRosterEngines(roster, charter, config, opts.engine)");
     expect(teamUp).toContain("validateRosterWorktreeIsolation(roster, config, opts.engine)");
+    expect(teamUp).toContain("resolveProjectRepoRoot");
+    expect(teamUp).toContain("ghqFind");
+    expect(teamUp).toContain("repoPath = await getWorktreeRepoRoot()");
+    expect(teamUp).toContain("primeMember(task.item.member, session, callerRepoRoot");
     const teamLifecycle = readFileSync(join(root, "src/vendor/mpr-plugins/team/team-lifecycle.ts"), "utf8");
     expect(teamLifecycle).toContain("assertTeamSpawnWorktreeIsolation");
     expect(teamLifecycle).toContain("requires --worktree/--cwd");

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -388,10 +388,12 @@ agents:
     ]);
   });
 
-  test("team up wakes charter.project and primes inline plus file-ref prompts", async () => {
+  test("team up wakes charter.project worktrees from the project repo while priming charter-local prompts (#2798)", async () => {
     const root = mkdtempSync(join(tmpdir(), "maw-node-prompt-"));
-    dirs.push(root);
+    const projectRoot = mkdtempSync(join(tmpdir(), "maw-target-project-"));
+    dirs.push(root, projectRoot);
     mkdirSync(join(root, ".git"));
+    mkdirSync(join(projectRoot, ".git"));
     mkdirSync(join(root, ".maw"), { recursive: true });
     mkdirSync(join(root, "prompts"), { recursive: true });
     writeFileSync(join(root, "prompts", "claude48.md"), "file prompt\n", "utf-8");
@@ -418,18 +420,46 @@ agents:
       loadConfigFn: () => ({ ...config, node: "m5" }),
       cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; },
       cmdSendFn: async (...a: any[]) => { sends.push(a); },
+      ghqFindFn: async (suffix: string) => suffix === "/soul-brews-studio/maw-js" ? projectRoot : null,
       sleep: async () => {},
       logger: () => {},
     });
 
     expect(wakes).toEqual([
-      ["soul-brews-studio/maw-js", { wt: "codex", engine: "omx", session: "charter-session", repoPath: root, channels: true }],
-      ["soul-brews-studio/maw-js", { wt: "claude48", engine: "claude48", session: "charter-session", repoPath: root, channels: true }],
+      ["soul-brews-studio/maw-js", { wt: "codex", engine: "omx", session: "charter-session", repoPath: projectRoot, channels: true }],
+      ["soul-brews-studio/maw-js", { wt: "claude48", engine: "claude48", session: "charter-session", repoPath: projectRoot, channels: true }],
     ]);
     expect(sends).toEqual([
       ["charter-session:codex", "inline prompt", false, { currentSession: "charter-session" }],
       ["charter-session:claude48", "file prompt", false, { currentSession: "charter-session" }],
     ]);
+  });
+
+  test("team up errors loudly when charter.project is not cloned for worktree creation (#2798)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-node-missing-project-"));
+    dirs.push(root);
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, ".maw"), { recursive: true });
+    writeFileSync(join(root, ".maw", "m5.yaml"), `
+name: m5-team
+project: soul-brews-studio/missing-project
+agents:
+  codex:
+    engine: omx
+`, "utf-8");
+    const { tmux } = fakeTmux([]);
+    const wakes: any[] = [];
+
+    await expect(cmdTeamUp("any", { session: "charter-session" }, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => ({ ...config, node: "m5" }),
+      cmdWakeFn: async (...a: any[]) => { wakes.push(a); return "woke"; },
+      ghqFindFn: async () => null,
+      sleep: async () => {},
+      logger: () => {},
+    })).rejects.toThrow("charter.project 'soul-brews-studio/missing-project' is not cloned under ghq");
+    expect(wakes).toEqual([]);
   });
 
   test("semantic role adopts live window by charter member name", async () => {


### PR DESCRIPTION
## Summary
- Resolve `charter.project` through ghq before waking `maw team up` members so worktrees are based on the target project, not the caller cwd repo.
- Keep prompt priming relative to the charter/caller repo so charter-local prompt files still work.
- Add regression coverage for target-project worktree roots and missing target clones.

Closes #2798

## Verification
- `bun test test/isolated/plugin-team-standalone.test.ts`
- `bun test test/isolated/team-up-coverage.test.ts`
- `bun scripts/check-plugin-coverage-gate.ts origin/alpha`
- `bun run test:default:safe`
- `bun run build`
