### PR TITLE
Add share chat roadmap slice (#2752)

### DIFF
--- a/docs/roadmaps/2752-maw-share-sshx-parity.md
+++ b/docs/roadmaps/2752-maw-share-sshx-parity.md
@@ -1,0 +1,68 @@
+# #2752 maw share ← sshx parity roadmap
+
+## Requirements summary
+
+`maw share` remains the native lightweight read-only viewer. sshx parity is delivered as additive, opt-in serve-hook plugins that compose into the existing `maw serve` daemon instead of replacing share or creating a second daemon.
+
+## RALPLAN-DR summary
+
+### Principles
+- Preserve the read-only `maw share` charter unless a later issue explicitly approves multi-user write sharing.
+- Keep add-ons small, opt-in, and independently shippable.
+- Put UI-heavy work in viewers; keep maw as the authenticated data relay.
+- Reuse the existing share slug/token/auth model for all collaboration side channels.
+
+### Decision drivers
+1. Avoid expanding the trusted write/RCE surface by default.
+2. Keep each add-on easy to test with route-level and real-entry smokes.
+3. Let `maw serve` remain the single relay process for share, presence, chat, and cursors.
+
+### Viable options
+- **Option A — small opt-in data plugins (chosen):** one plugin per side channel (`share-presence`, `share-chat`, `share-cursors`). Pros: low blast radius, easy rollback, aligns with existing serve hooks. Cons: multiple endpoint contracts for frontend to consume.
+- **Option B — monolithic collaborative share plugin:** one plugin owns all sshx parity. Pros: one frontend contract. Cons: larger trusted surface and harder phased delivery.
+- **Option C — delegate to sshx:** integrate by launching/embedding sshx. Pros: fastest feature parity. Cons: violates “nothing is deleted”, adds operational dependency, and does not improve native share.
+
+## Phased roadmap
+
+| Phase | Scope | maw responsibility | Acceptance |
+| --- | --- | --- | --- |
+| P-A1 presence | Already landed as `share-presence` (#2773). | `/ws/share/:slug/presence`, viewer IDs/names, snapshots. | Opt-in, read-only, token-verified. |
+| P-A2 chat | Ephemeral chat relay for valid share viewers. | `/ws/share/:slug/chat`, sanitized viewer names/text, no persistence. | Opt-in via `maw share --chat`, read-only, token-verified. |
+| P-A3 cursors | Read-only cursor presence. | Relay normalized cursor positions only. | Opt-in, rate-limited, no pane writes. |
+| P-B canvas | Infinite canvas, move/resize/zoom/pan. | No core daemon work unless metadata gaps appear. | Viewer feature backed by share metadata. |
+| P-C polish | Toolbar, better errors, toasts. | Serve metadata/error affordances as needed. | No raw “Share not found” in polished clients. |
+| P-D write collaboration | Multi-user input + predictive echo. | Separate charter decision; builds on `serve-control`, not default share. | Explicit write token, audit/rate limits, separate issue. |
+
+## First implemented slice in this PR
+
+Implement **P-A2 `share-chat`** because `share-presence` has already merged and chat is the next small sshx parity add-on that does not require write-sharing.
+
+## Acceptance criteria
+
+- `maw share --chat` posts `{ chat: true }` to the daemon and `/api/share/:slug` returns `chat: true` only for chat-enabled shares.
+- `share-chat` registers `/ws/share/:slug/chat` only when the opt-in plugin is enabled.
+- Chat WebSockets verify the existing share token/proof before joining.
+- Chat is denied for valid shares that were not created with `--chat`.
+- Chat payloads are ephemeral, sanitized, length-bounded, broadcast to current viewers, and do not import tmux or pane write helpers.
+- Existing share, presence, and control behavior remains unchanged.
+
+## Implementation steps
+
+1. Extend `src/vendor/mpr-plugins/share/impl.ts` and `src/vendor/mpr-plugins/share/index.ts` with a `chat` share flag, CLI `--chat`, daemon create request support, and metadata exposure.
+2. Add `src/vendor/mpr-plugins/share-chat/` as an extra-tier serve-hook plugin with `/ws/share/:slug/chat`.
+3. Add unit and standalone boundary coverage for chat, plus share CLI/metadata coverage for `--chat`.
+4. Verify with targeted tests, isolated tests as practical, and `bun run build`.
+
+## ADR
+
+**Decision:** Deliver sshx parity as additive serve-hook plugins, with this PR shipping `share-chat` as the next first slice after presence.
+
+**Drivers:** read-only safety, small independent PRs, reuse of existing share auth.
+
+**Alternatives considered:** monolithic collaborative share, replacing share with sshx, and jumping directly to multi-user write-sharing.
+
+**Why chosen:** `share-chat` provides visible collaborative value while keeping maw’s trusted surface small and read-only-compatible.
+
+**Consequences:** Frontends consume another side-channel endpoint; later cursor/write phases can follow the same pattern.
+
+**Follow-ups:** `share-cursors`, viewer UI for chat/presence, and a separate write-collaboration charter issue.

--- a/src/vendor/mpr-plugins/share-chat/index.ts
+++ b/src/vendor/mpr-plugins/share-chat/index.ts
@@ -1,0 +1,243 @@
+import { randomBytes } from "crypto";
+import type { ServeHookContext } from "../../../core/serve-route-registry";
+import type { ServeWsData, ServeWsRouteRegistrar, ServeWsSocket } from "../../../core/serve-ws-registry";
+import { getShare, verifyShare } from "../share/impl";
+
+const MAX_NAME_CHARS = 48;
+const MAX_TEXT_CHARS = 2_000;
+const MAX_CHAT_VIEWERS_PER_SLUG = 256;
+
+export type ChatMessage = {
+  type: "chat";
+  slug: string;
+  id: string;
+  viewerId: string;
+  name: string;
+  text: string;
+  sentAt: number;
+};
+
+export type ChatReady = { type: "chat-ready"; slug: string; viewerId: string; name: string };
+
+type ChatWsData = ServeWsData & {
+  shareSlug?: string;
+  shareToken?: string;
+  viewerName?: string;
+  shareError?: string;
+};
+
+type ChatOpenState = {
+  slug: string;
+  viewerId: string | null;
+  name: string;
+  closing: boolean;
+};
+
+type ChatSocket = Pick<ServeWsSocket, "send">;
+
+type ChatEntry = {
+  viewers: Map<string, { name: string; socket: ChatSocket }>;
+};
+
+const registry = new Map<string, ChatEntry>();
+const openStates = new Map<ServeWsSocket, ChatOpenState>();
+
+type ChatDeps = {
+  verifyShare: (slug: string, token: string) => Promise<boolean> | boolean;
+  now: () => number;
+};
+
+let deps: ChatDeps = { verifyShare, now: () => Date.now() };
+
+export function setChatDepsForTests(next: Partial<ChatDeps>): () => void {
+  const previous = deps;
+  deps = { ...deps, ...next };
+  return () => { deps = previous; };
+}
+
+function makeViewerId(): string {
+  return `c_${randomBytes(9).toString("base64url")}`;
+}
+
+function makeMessageId(): string {
+  return `m_${randomBytes(12).toString("base64url")}`;
+}
+
+export function sanitizeChatName(input: string | null | undefined): string {
+  const stripped = (input ?? "")
+    .replace(/[\0\x01-\x1F\x7F]/g, "")
+    .trim();
+  const chars = [...stripped].slice(0, MAX_NAME_CHARS).join("");
+  return chars || "anonymous";
+}
+
+export function sanitizeChatText(input: unknown): string {
+  const raw = typeof input === "string" ? input : "";
+  const stripped = raw.replace(/[\0\x01-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "").trim();
+  return [...stripped].slice(0, MAX_TEXT_CHARS).join("");
+}
+
+function parseRoutePart(pathname: string, pattern: string): Record<string, string> | null {
+  const pathParts = pathname.split("/").filter(Boolean);
+  const patternParts = pattern.split("/").filter(Boolean);
+  if (pathParts.length !== patternParts.length) return null;
+  const params: Record<string, string> = {};
+  for (let i = 0; i < patternParts.length; i += 1) {
+    const part = patternParts[i];
+    const actual = pathParts[i];
+    if (actual === undefined) return null;
+    if (part.startsWith(":")) {
+      params[part.slice(1)] = decodeURIComponent(actual);
+      continue;
+    }
+    if (part !== actual) return null;
+  }
+  return params;
+}
+
+function parseShareToken(req: Request): string {
+  const url = new URL(req.url);
+  return url.searchParams.get("token") || url.searchParams.get("t") || url.searchParams.get("h") || "";
+}
+
+function chatWsRouteData(req: Request): ChatWsData {
+  const url = new URL(req.url);
+  const params = parseRoutePart(url.pathname, "/ws/share/:slug/chat");
+  return {
+    target: null,
+    previewTargets: new Set(),
+    shareSlug: params?.slug,
+    shareToken: parseShareToken(req),
+    viewerName: url.searchParams.get("name") ?? undefined,
+    shareError: params?.slug ? undefined : "missing slug",
+  };
+}
+
+function joinChat(slug: string, socket: ChatSocket, name: string): ChatReady | { error: "too_many_viewers" } {
+  let entry = registry.get(slug);
+  if (!entry) {
+    entry = { viewers: new Map() };
+    registry.set(slug, entry);
+  }
+  if (entry.viewers.size >= MAX_CHAT_VIEWERS_PER_SLUG) return { error: "too_many_viewers" };
+  const viewerId = makeViewerId();
+  const ready: ChatReady = { type: "chat-ready", slug, viewerId, name: sanitizeChatName(name) };
+  entry.viewers.set(viewerId, { name: ready.name, socket });
+  socket.send(JSON.stringify(ready));
+  return ready;
+}
+
+function leaveChat(slug: string, viewerId: string): void {
+  const entry = registry.get(slug);
+  if (!entry) return;
+  entry.viewers.delete(viewerId);
+  if (entry.viewers.size === 0) registry.delete(slug);
+}
+
+function parseChatText(message: unknown): string {
+  if (typeof message === "string") {
+    try {
+      const parsed = JSON.parse(message) as { text?: unknown };
+      if (parsed && typeof parsed === "object" && "text" in parsed) return sanitizeChatText(parsed.text);
+    } catch {
+      // Treat non-JSON strings as chat text for simple clients.
+    }
+    return sanitizeChatText(message);
+  }
+  if (ArrayBuffer.isView(message)) {
+    return sanitizeChatText(new TextDecoder().decode(new Uint8Array(message.buffer, message.byteOffset, message.byteLength)));
+  }
+  if (message instanceof ArrayBuffer) return sanitizeChatText(new TextDecoder().decode(new Uint8Array(message)));
+  return "";
+}
+
+function broadcastChat(slug: string, viewerId: string, text: string): ChatMessage | null {
+  const entry = registry.get(slug);
+  const viewer = entry?.viewers.get(viewerId);
+  if (!entry || !viewer || !text) return null;
+  const payload: ChatMessage = {
+    type: "chat",
+    slug,
+    id: makeMessageId(),
+    viewerId,
+    name: viewer.name,
+    text,
+    sentAt: deps.now(),
+  };
+  const raw = JSON.stringify(payload);
+  for (const peer of entry.viewers.values()) peer.socket.send(raw);
+  return payload;
+}
+
+async function openChatWebSocket(ws: ServeWsSocket): Promise<void> {
+  const data = ws.data as ChatWsData;
+  const slug = data.params?.slug || data.shareSlug || "";
+  if (data.shareError || !slug) {
+    ws.close(1008, data.shareError || "invalid share chat route");
+    return;
+  }
+  const share = getShare(slug);
+  if (!share) {
+    ws.close(1008, "invalid or expired share token");
+    return;
+  }
+  openStates.set(ws, { slug, viewerId: null, name: sanitizeChatName(data.viewerName), closing: false });
+  const verified = await deps.verifyShare(slug, data.shareToken ?? "");
+  const state = openStates.get(ws);
+  if (!state || state.closing) {
+    openStates.delete(ws);
+    return;
+  }
+  if (!verified) {
+    openStates.delete(ws);
+    ws.close(1008, "invalid or expired share token");
+    return;
+  }
+  if (share.chat !== true) {
+    openStates.delete(ws);
+    ws.close(1008, "share chat not enabled");
+    return;
+  }
+  const joined = joinChat(slug, ws, state.name);
+  if ("error" in joined) {
+    openStates.delete(ws);
+    ws.close(1013, "too many chat viewers");
+    return;
+  }
+  state.viewerId = joined.viewerId;
+  state.name = joined.name;
+}
+
+export function chatViewerCount(slug: string): number {
+  return registry.get(slug)?.viewers.size ?? 0;
+}
+
+export function clearChatRegistryForTests(): void {
+  registry.clear();
+  openStates.clear();
+  deps = { verifyShare, now: () => Date.now() };
+}
+
+export function openChatStateCountForTests(): number {
+  return openStates.size;
+}
+
+export async function serve(ctx: ServeHookContext & { ws?: ServeWsRouteRegistrar }): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!ctx.ws) return { ok: false, error: "share-chat requires ctx.ws" };
+  ctx.ws.route("/ws/share/:slug/chat", chatWsRouteData, {
+    open: (ws) => { void openChatWebSocket(ws); },
+    message: (ws, message) => {
+      const state = openStates.get(ws);
+      if (!state?.viewerId) return;
+      broadcastChat(state.slug, state.viewerId, parseChatText(message));
+    },
+    close: (ws) => {
+      const state = openStates.get(ws);
+      if (!state) return;
+      state.closing = true;
+      openStates.delete(ws);
+      if (state.viewerId) leaveChat(state.slug, state.viewerId);
+    },
+  });
+  return { ok: true };
+}

--- a/src/vendor/mpr-plugins/share-chat/plugin.json
+++ b/src/vendor/mpr-plugins/share-chat/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "share-chat",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Opt-in ephemeral web-viewer chat relay for maw share.",
+  "tier": "extra",
+  "hooks": {
+    "serve": {
+      "script": "./index.ts",
+      "handler": "serve",
+      "policy": "fail-fast"
+    }
+  },
+  "weight": 13,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/src/vendor/mpr-plugins/share/impl.ts
+++ b/src/vendor/mpr-plugins/share/impl.ts
@@ -27,6 +27,7 @@ export interface Share {
   encryptionFrameCounter?: bigint;
   control?: ShareControl;
   presence?: boolean;
+  chat?: boolean;
 }
 
 export interface CreateShareOptions {
@@ -38,6 +39,7 @@ export interface CreateShareOptions {
   encrypted?: boolean;
   control?: boolean;
   presence?: boolean;
+  chat?: boolean;
 }
 
 export interface CreateShareResult {
@@ -242,6 +244,7 @@ export async function createShare(opts: CreateShareOptions): Promise<CreateShare
     encrypted,
     encryptionFrameCounter: 0n,
     ...(opts.presence === true ? { presence: true } : {}),
+    ...(opts.chat === true ? { chat: true } : {}),
   };
   const token = await authHandler.mint(share, slug);
   share.tokenHash = hashToken(token);

--- a/src/vendor/mpr-plugins/share/index.ts
+++ b/src/vendor/mpr-plugins/share/index.ts
@@ -14,7 +14,7 @@ export const command = {
   description: "Share a live read-only tmux session/pane in a browser via a temporary link.",
 };
 
-const SHARE_USAGE = "usage: maw share <session-or-pane> [additional-pane ...] [--read-only] [--control] [--presence] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]";
+const SHARE_USAGE = "usage: maw share <session-or-pane> [additional-pane ...] [--read-only] [--control] [--presence] [--chat] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]";
 const DEFAULT_TTL_SECONDS = 3600;
 const DEFAULT_READ_ONLY = true;
 
@@ -55,6 +55,7 @@ type ShareMetadata = {
   auth: string;
   control?: boolean;
   presence?: boolean;
+  chat?: boolean;
 };
 
 type CreateShareRequest = {
@@ -66,6 +67,7 @@ type CreateShareRequest = {
   encrypted?: unknown;
   control?: unknown;
   presence?: unknown;
+  chat?: unknown;
 };
 
 const viewerHtml = (() => {
@@ -211,6 +213,7 @@ async function routeCreateShare(req: Request): Promise<Response> {
       encrypted: body.encrypted === true || body.auth === "encrypted",
       control: body.control === true,
       presence: body.presence === true,
+      chat: body.chat === true,
     });
     const payload = {
       slug: created.slug,
@@ -274,6 +277,7 @@ async function routeShareMetadata(req: Request): Promise<Response> {
     auth: share.auth,
     ...(share.control ? { control: true } : {}),
     ...(share.presence ? { presence: true } : {}),
+    ...(share.chat ? { chat: true } : {}),
   };
 
   return new Response(JSON.stringify(payload), {
@@ -428,6 +432,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       "--encrypt": Boolean,
       "--control": Boolean,
       "--presence": Boolean,
+      "--chat": Boolean,
     }, 0);
 
     const targets = flags._;
@@ -449,6 +454,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     const control = flags["--control"] === true;
     const presence = flags["--presence"] === true;
+    const chat = flags["--chat"] === true;
     const readOnly = control ? false : (flags["--read-only"] === undefined ? DEFAULT_READ_ONLY : Boolean(flags["--read-only"]));
     const ttl = typeof flags["--ttl"] === "number" && Number.isFinite(flags["--ttl"]) ? flags["--ttl"] : DEFAULT_TTL_SECONDS;
     const encrypted = flags["--encrypt"] === true || flags["--auth"] === "encrypted";
@@ -462,6 +468,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       auth,
       ...(control ? { control: true } : {}),
       ...(presence ? { presence: true } : {}),
+      ...(chat ? { chat: true } : {}),
     };
     if (encrypted) request.encrypted = true;
 

--- a/src/vendor/mpr-plugins/share/plugin.json
+++ b/src/vendor/mpr-plugins/share/plugin.json
@@ -6,7 +6,7 @@
   "description": "Share a tmux session/pane as a read-only web stream.",
   "cli": {
     "command": "share",
-    "help": "maw share <session-or-pane> [--read-only] [--control] [--presence] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]",
+    "help": "maw share <session-or-pane> [--read-only] [--control] [--presence] [--chat] [--ttl <seconds>] [--port <number>] [--auth token|federation|none|encrypted] [--encrypt]",
     "flags": {
       "--read-only": "boolean",
       "--ttl": "number",
@@ -14,7 +14,8 @@
       "--auth": "string",
       "--encrypt": "boolean",
       "--control": "boolean",
-      "--presence": "boolean"
+      "--presence": "boolean",
+      "--chat": "boolean"
     }
   },
   "weight": 10,

--- a/test/isolated/plugin-share-chat-standalone.test.ts
+++ b/test/isolated/plugin-share-chat-standalone.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expectStandalonePluginBoundary } from "./helpers/plugin-standalone-boundary";
+
+const root = join(import.meta.dir, "../..");
+
+describe("share-chat standalone boundary (#2752)", () => {
+  test("manifest keeps share-chat opt-in, serve-only, and out of default-active", () => {
+    expectStandalonePluginBoundary({
+      plugin: "share-chat",
+      requireSdk: false,
+      allowRelative: [
+        "../../../core/serve-route-registry",
+        "../../../core/serve-ws-registry",
+        "../share/impl",
+      ],
+    });
+
+    const manifest = JSON.parse(readFileSync(join(root, "src/vendor/mpr-plugins/share-chat/plugin.json"), "utf8"));
+    expect(manifest.name).toBe("share-chat");
+    expect(manifest.tier).toBe("extra");
+    expect(manifest.hooks.serve.handler).toBe("serve");
+    expect(manifest.cli).toBeUndefined();
+    const defaults = readFileSync(join(root, "src/plugin/default-active.ts"), "utf8");
+    expect(defaults).not.toContain('"share-chat"');
+  });
+
+  test("source is pure ephemeral chat relay without tmux or write verbs", () => {
+    const source = readFileSync(join(root, "src/vendor/mpr-plugins/share-chat/index.ts"), "utf8");
+    expect(source.toLowerCase()).not.toContain("tmux");
+    expect(source).not.toContain("sendKeys");
+    expect(source).not.toContain("killPane");
+    expect(source).not.toContain("resizePane");
+    expect(source).toContain('ctx.ws.route("/ws/share/:slug/chat"');
+    expect(source).toContain("verifyShare(slug");
+    expect(source).toContain("share.chat !== true");
+    expect(source).not.toContain("writeFile");
+  });
+});

--- a/test/isolated/plugin-share-standalone.test.ts
+++ b/test/isolated/plugin-share-standalone.test.ts
@@ -100,6 +100,7 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(manifest.hooks.serve.handler).toBe("serve");
     expect(manifest.cli.flags["--control"]).toBe("boolean");
     expect(manifest.cli.flags["--presence"]).toBe("boolean");
+    expect(manifest.cli.flags["--chat"]).toBe("boolean");
 
     const index = readFileSync(join(root, "src/vendor/mpr-plugins/share/index.ts"), "utf8");
     expect(index).toContain("export async function serve");
@@ -110,7 +111,9 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
     expect(index).toContain("export default async function handler");
     expect(index).toContain('"--control": Boolean');
     expect(index).toContain('"--presence": Boolean');
+    expect(index).toContain('"--chat": Boolean');
     expect(index).toContain("presence: body.presence === true");
+    expect(index).toContain("chat: body.chat === true");
     expect(index).toContain("controlToken");
 
     const stream = readFileSync(join(root, "src/vendor/mpr-plugins/share/stream.ts"), "utf8");
@@ -310,6 +313,41 @@ describe("share plugin standalone boundary (#2685/#2703)", () => {
       const metadata = await metadataRoute.handler(new Request(`http://127.0.0.1:4567/api/share/${slug}?token=${encodeURIComponent(token)}`));
       expect(metadata.status).toBe(200);
       await expect(metadata.json()).resolves.toMatchObject({ presence: true, readOnly: true });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("share --chat posts daemon flag and exposes read-only metadata", async () => {
+    const { httpRoutes } = await makeServeHarness();
+    const createRoute = httpRoutes.find((route) => route.method === "POST" && route.path === "/api/share")!;
+    const metadataRoute = httpRoutes.find((route) => route.method === "GET" && route.path === "/api/share/:slug")!;
+    const originalFetch = globalThis.fetch;
+    const postedBodies: unknown[] = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      postedBodies.push(await req.clone().json());
+      return createRoute.handler(req);
+    }) as typeof fetch;
+
+    try {
+      const result = await shareHandler({
+        source: "cli",
+        args: ["neo:1", "--chat", "--ttl", "42", "--port", "4567"],
+      } as any);
+
+      expect(result.ok).toBe(true);
+      expect(postedBodies).toEqual([{ target: "neo:1:resolved", readOnly: true, ttl: 42, auth: "token", chat: true }]);
+      const { slug, token } = parseShareOutput(result.output);
+      const share = shareRuntimeImpl.getShare(slug)!;
+      expect(share.chat).toBe(true);
+      expect(share.readOnly).toBe(true);
+      expect(share.control).toBeUndefined();
+
+      const metadata = await metadataRoute.handler(new Request(`http://127.0.0.1:4567/api/share/${slug}?token=${encodeURIComponent(token)}`));
+      expect(metadata.status).toBe(200);
+      await expect(metadata.json()).resolves.toMatchObject({ chat: true, readOnly: true });
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/test/vendor-share-chat-unit.test.ts
+++ b/test/vendor-share-chat-unit.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  chatViewerCount,
+  clearChatRegistryForTests,
+  openChatStateCountForTests,
+  sanitizeChatName,
+  sanitizeChatText,
+  serve,
+  setChatDepsForTests,
+} from "../src/vendor/mpr-plugins/share-chat/index";
+import { clearShareRegistry, createShare } from "../src/vendor/mpr-plugins/share/impl";
+
+function last(sent: string[]) {
+  return JSON.parse(sent.at(-1) ?? "{}");
+}
+
+describe("share-chat relay", () => {
+  beforeEach(() => {
+    clearChatRegistryForTests();
+    clearShareRegistry();
+  });
+
+  test("sanitizes viewer names and chat text with length caps", () => {
+    expect(sanitizeChatName("\0 Nat\n Viewer\t ")).toBe("Nat Viewer");
+    expect(sanitizeChatName("\x01\x7F")).toBe("anonymous");
+    expect([...sanitizeChatName("x".repeat(80))]).toHaveLength(48);
+    expect(sanitizeChatText("\0 hello\nthere \x07")).toBe("hello\nthere");
+    expect([...sanitizeChatText("x".repeat(2_100))]).toHaveLength(2_000);
+  });
+
+  test("verifies share tokens, requires --chat, and broadcasts ephemeral messages", async () => {
+    const created = await createShare({ target: "%1", auth: "token", ttl: 60, chat: true });
+    setChatDepsForTests({ now: () => 1234 });
+
+    let handlers: { open: (ws: any) => void; message: (ws: any, message: unknown) => void; close: (ws: any) => void } | null = null;
+    await serve({
+      ws: { route: (_pattern: string, _data: unknown, next: typeof handlers) => { handlers = next; } },
+    } as any);
+    if (!handlers) throw new Error("chat ws handlers were not registered");
+
+    const aliceSent: string[] = [];
+    const bobSent: string[] = [];
+    const alice = {
+      data: { params: { slug: created.slug }, shareSlug: created.slug, shareToken: created.token, viewerName: "Alice" },
+      send: (payload: string) => { aliceSent.push(payload); },
+      close: () => undefined,
+    };
+    const bob = {
+      data: { params: { slug: created.slug }, shareSlug: created.slug, shareToken: created.token, viewerName: "Bob" },
+      send: (payload: string) => { bobSent.push(payload); },
+      close: () => undefined,
+    };
+
+    handlers.open(alice);
+    handlers.open(bob);
+    await Bun.sleep(0);
+
+    expect(last(aliceSent)).toMatchObject({ type: "chat-ready", slug: created.slug, name: "Alice" });
+    expect(last(bobSent)).toMatchObject({ type: "chat-ready", slug: created.slug, name: "Bob" });
+    expect(chatViewerCount(created.slug)).toBe(2);
+
+    handlers.message(alice, JSON.stringify({ type: "chat", text: " hi swarm \x07 " }));
+    expect(last(aliceSent)).toMatchObject({ type: "chat", slug: created.slug, name: "Alice", text: "hi swarm", sentAt: 1234 });
+    expect(last(bobSent)).toMatchObject({ type: "chat", slug: created.slug, name: "Alice", text: "hi swarm", sentAt: 1234 });
+    expect(last(aliceSent).id).toMatch(/^m_/);
+    expect(last(aliceSent).viewerId).toMatch(/^c_/);
+
+    handlers.close(bob);
+    expect(chatViewerCount(created.slug)).toBe(1);
+    handlers.close(alice);
+    expect(chatViewerCount(created.slug)).toBe(0);
+  });
+
+  test("rejects valid shares that did not opt into chat", async () => {
+    const created = await createShare({ target: "%1", auth: "token", ttl: 60 });
+    let handlers: { open: (ws: any) => void } | null = null;
+    await serve({ ws: { route: (_pattern: string, _data: unknown, next: typeof handlers) => { handlers = next; } } } as any);
+    if (!handlers) throw new Error("chat ws handlers were not registered");
+
+    const closed: Array<{ code: number; reason: string }> = [];
+    const ws = {
+      data: { params: { slug: created.slug }, shareSlug: created.slug, shareToken: created.token, viewerName: "blocked" },
+      send: () => undefined,
+      close: (code: number, reason: string) => { closed.push({ code, reason }); },
+    };
+
+    handlers.open(ws);
+    await Bun.sleep(0);
+    expect(closed).toEqual([{ code: 1008, reason: "share chat not enabled" }]);
+    expect(chatViewerCount(created.slug)).toBe(0);
+  });
+
+  test("closing while token validation is pending leaves no chat state or viewer", async () => {
+    const created = await createShare({ target: "%1", auth: "token", ttl: 60, chat: true });
+    let resolveVerify: ((ok: boolean) => void) | null = null;
+    setChatDepsForTests({ verifyShare: () => new Promise<boolean>((resolve) => { resolveVerify = resolve; }) });
+
+    let handlers: { open: (ws: any) => void; close: (ws: any) => void } | null = null;
+    await serve({ ws: { route: (_pattern: string, _data: unknown, next: typeof handlers) => { handlers = next; } } } as any);
+    if (!handlers) throw new Error("chat ws handlers were not registered");
+
+    const sent: string[] = [];
+    const closed: Array<{ code: number; reason: string }> = [];
+    const ws = {
+      data: { params: { slug: created.slug }, shareSlug: created.slug, shareToken: created.token, viewerName: "race" },
+      send: (payload: string) => { sent.push(payload); },
+      close: (code: number, reason: string) => { closed.push({ code, reason }); },
+    };
+
+    handlers.open(ws);
+    expect(openChatStateCountForTests()).toBe(1);
+    handlers.close(ws);
+    expect(openChatStateCountForTests()).toBe(0);
+    expect(chatViewerCount(created.slug)).toBe(0);
+
+    resolveVerify?.(true);
+    await Bun.sleep(0);
+
+    expect(openChatStateCountForTests()).toBe(0);
+    expect(chatViewerCount(created.slug)).toBe(0);
+    expect(sent).toEqual([]);
+    expect(closed).toEqual([]);
+  });
+
+  test("share-chat plugin remains read-only and tmux-free", () => {
+    const source = readFileSync(join(import.meta.dir, "../src/vendor/mpr-plugins/share-chat/index.ts"), "utf8");
+    expect(source.toLowerCase()).not.toContain("tmux");
+    expect(source).not.toContain("sendKeys");
+    expect(source).not.toContain("killPane");
+    expect(source).not.toContain("resizePane");
+  });
+});


### PR DESCRIPTION
## Summary
- document the #2752 sshx-parity add-on roadmap
- add opt-in maw share --chat metadata support
- add extra-tier share-chat serve-hook WebSocket relay for ephemeral viewer chat

Closes #2752

## Verification
- bun test test/vendor-share-chat-unit.test.ts test/isolated/plugin-share-chat-standalone.test.ts test/isolated/plugin-share-standalone.test.ts
- bun run test:isolated
- bun run test:default:safe
- bun run build