### PR TITLE
Add file-based maw scheduler script

### DIFF
--- a/src/commands/plugins/scheduler/daemon.ts
+++ b/src/commands/plugins/scheduler/daemon.ts
@@ -1,0 +1,68 @@
+import type { InvokeContext } from "../../../plugin/types";
+import { defaultMawHey, runHook, type HookDeps } from "./hooks";
+import { isDue, loadJobs, markDone, markStarted, readState, schedulerPaths, validateJobPrompt, type SchedulerJob } from "./jobs";
+
+type TimerHandle = { unref?: () => void };
+type SetIntervalFn = (handler: () => void, timeout: number) => TimerHandle;
+
+type ServeLog = { info?: (...args: unknown[]) => void; error?: (...args: unknown[]) => void };
+
+export interface SchedulerDaemonDeps extends HookDeps {
+  cwd?: string;
+  error?: (...args: unknown[]) => void;
+  tickMs?: number;
+  now?: () => number;
+  setInterval?: SetIntervalFn;
+  paths?: ReturnType<typeof schedulerPaths>;
+}
+
+function unrefTimer(timer: TimerHandle): void {
+  timer.unref?.();
+}
+
+async function runJob(job: SchedulerJob, stateFile: string, deps: SchedulerDaemonDeps = {}): Promise<void> {
+  validateJobPrompt(job.prompt);
+  markStarted(stateFile, job.name, deps.now?.() ?? Date.now());
+  for (const hook of job.hooks?.before ?? []) await runHook(hook, job, deps);
+  const code = await (deps.mawHey ?? defaultMawHey)(job.target, job.prompt);
+  if (code !== 0) throw new Error(`maw hey failed for '${job.name}' with exit code ${code}`);
+  markDone(stateFile, job.name, deps.now?.() ?? Date.now());
+  for (const hook of job.hooks?.after ?? []) await runHook(hook, job, deps);
+}
+
+export async function schedulerTick(deps: SchedulerDaemonDeps = {}): Promise<{ ran: string[]; skipped: string[]; disabled: boolean; errors: string[] }> {
+  const paths = deps.paths ?? schedulerPaths(deps.cwd ?? process.cwd());
+  const state = readState(paths.stateFile);
+  if (state.enabled === false) return { ran: [], skipped: [], disabled: true, errors: [] };
+  const jobs = loadJobs(paths.jobsFile).jobs;
+  const ran: string[] = [];
+  const skipped: string[] = [];
+  const errors: string[] = [];
+  for (const job of jobs) {
+    if (!isDue(job, state, deps.now?.() ?? Date.now())) {
+      skipped.push(job.name);
+      continue;
+    }
+    try {
+      await runJob(job, paths.stateFile, deps);
+      ran.push(job.name);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push(message);
+      (deps.error ?? console.error)(`[scheduler] ${message}`);
+    }
+  }
+  return { ran, skipped, disabled: false, errors };
+}
+
+export function serve(ctx: Pick<InvokeContext, "source"> & { log?: ServeLog } = { source: "api" }, deps: SchedulerDaemonDeps = {}): { ok: true; timers: TimerHandle[] } {
+  const setIntervalFn = deps.setInterval ?? ((handler, timeout) => setInterval(handler, timeout) as TimerHandle);
+  const timer = setIntervalFn(() => {
+    schedulerTick(deps).catch((err) => ctx.log?.error?.("[scheduler] tick failed:", err));
+  }, deps.tickMs ?? 10_000);
+  unrefTimer(timer);
+  ctx.log?.info?.("[scheduler] serve hook started");
+  return { ok: true, timers: [timer] };
+}
+
+export default serve;

--- a/src/commands/plugins/scheduler/hooks.ts
+++ b/src/commands/plugins/scheduler/hooks.ts
@@ -1,0 +1,48 @@
+import { mkdirSync, writeFileSync } from "fs";
+import { dirname } from "path";
+import type { Hook, SchedulerJob } from "./jobs";
+
+export interface HookDeps {
+  now?: () => number;
+  log?: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+  schedulerName?: string;
+  runShell?: (command: string) => Promise<number>;
+  mawHey?: (target: string, message: string) => Promise<number>;
+}
+
+async function defaultRunShell(command: string): Promise<number> {
+  const proc = Bun.spawn(["sh", "-c", command], { stdout: "inherit", stderr: "inherit" });
+  return await proc.exited;
+}
+
+export async function defaultMawHey(target: string, message: string): Promise<number> {
+  const proc = Bun.spawn(["maw", "hey", target, message], { stdout: "inherit", stderr: "inherit" });
+  return await proc.exited;
+}
+
+export async function runHook(hook: Hook, job: SchedulerJob, deps: HookDeps = {}): Promise<void> {
+  if ("run" in hook) {
+    const code = await (deps.runShell ?? defaultRunShell)(hook.run);
+    if (code !== 0) throw new Error(`hook run failed for '${job.name}' with exit code ${code}`);
+    return;
+  }
+  if ("log" in hook) {
+    (deps.log ?? console.log)(`[scheduler] ${hook.log}`);
+    return;
+  }
+  if ("publish" in hook) {
+    mkdirSync(dirname(hook.publish), { recursive: true });
+    writeFileSync(hook.publish, JSON.stringify({ ts: deps.now?.() ?? Date.now(), job: job.name }, null, 2));
+    return;
+  }
+  if ("maw-hey" in hook) {
+    const schedulerName = deps.schedulerName ?? "mawjs-scheduler";
+    if (hook["maw-hey"].target === schedulerName) {
+      (deps.warn ?? console.warn)(`[scheduler] skipping recursive maw-hey hook for ${job.name}: target ${schedulerName}`);
+      return;
+    }
+    const code = await (deps.mawHey ?? defaultMawHey)(hook["maw-hey"].target, hook["maw-hey"].message);
+    if (code !== 0) throw new Error(`maw-hey hook failed for '${job.name}' with exit code ${code}`);
+  }
+}

--- a/src/commands/plugins/scheduler/index.ts
+++ b/src/commands/plugins/scheduler/index.ts
@@ -1,0 +1,97 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { defaultMawHey, runHook, type HookDeps } from "./hooks";
+import { isDue, loadJobs, markDone, markStarted, nextDueAt, parseEvery, readState, schedulerPaths, setEnabled, validateJobPrompt, type SchedulerJob } from "./jobs";
+
+export const command = {
+  name: "scheduler",
+  description: "File-based job scheduler — dispatch maw hey on a timer",
+};
+
+type SchedulerCliDeps = HookDeps & {
+  cwd?: string;
+  paths?: ReturnType<typeof schedulerPaths>;
+  now?: () => number;
+};
+
+function argsFrom(ctx: InvokeContext): string[] {
+  return Array.isArray(ctx.args) ? ctx.args : [];
+}
+
+function flagValue(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+function jsonFlag(args: string[], ctx: InvokeContext): boolean {
+  return args.includes("--json") || ctx.flags?.json === true;
+}
+
+function jobName(args: string[], ctx: InvokeContext): string | undefined {
+  return flagValue(args, "--name") ?? (typeof ctx.flags?.name === "string" ? ctx.flags.name : undefined) ?? args.find((arg, idx) => idx > 0 && !arg.startsWith("-"));
+}
+
+function formatTime(ts: number | null | undefined): string {
+  if (!ts) return "never";
+  return new Date(ts).toISOString();
+}
+
+async function runJobNow(job: SchedulerJob, stateFile: string, deps: SchedulerCliDeps = {}, dryRun = false): Promise<void> {
+  validateJobPrompt(job.prompt);
+  if (dryRun) return;
+  markStarted(stateFile, job.name, deps.now?.() ?? Date.now());
+  for (const hook of job.hooks?.before ?? []) await runHook(hook, job, deps);
+  const code = await (deps.mawHey ?? defaultMawHey)(job.target, job.prompt);
+  if (code !== 0) throw new Error(`maw hey failed for '${job.name}' with exit code ${code}`);
+  markDone(stateFile, job.name, deps.now?.() ?? Date.now());
+  for (const hook of job.hooks?.after ?? []) await runHook(hook, job, deps);
+}
+
+export async function handleScheduler(ctx: InvokeContext, deps: SchedulerCliDeps = {}): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const write = (...args: unknown[]) => ctx.writer?.(...args) ?? logs.push(args.map(String).join(" "));
+  const args = argsFrom(ctx);
+  const sub = args[0] ?? "status";
+  const paths = deps.paths ?? schedulerPaths(deps.cwd ?? process.cwd());
+  const state = readState(paths.stateFile);
+
+  try {
+    if (sub === "start") {
+      const next = setEnabled(paths.stateFile, true);
+      if (jsonFlag(args, ctx)) write(JSON.stringify({ enabled: next.enabled }, null, 2));
+      else write("scheduler enabled");
+    } else if (sub === "stop") {
+      const next = setEnabled(paths.stateFile, false);
+      if (jsonFlag(args, ctx)) write(JSON.stringify({ enabled: next.enabled }, null, 2));
+      else write("scheduler disabled");
+    } else if (sub === "list" || sub === "status") {
+      const jobs = loadJobs(paths.jobsFile).jobs;
+      const rows = jobs.map((job) => {
+        const record = state.jobs?.[job.name] ?? {};
+        return { name: job.name, every: job.every, target: job.target, prompt: job.prompt, lastRun: record.lastRun ?? null, nextDue: nextDueAt(job, state), due: isDue(job, state, deps.now?.() ?? Date.now()) };
+      });
+      if (jsonFlag(args, ctx)) write(JSON.stringify({ enabled: state.enabled !== false, jobs: rows }, null, 2));
+      else if (rows.length === 0) write("no scheduler jobs configured");
+      else {
+        write(`scheduler ${state.enabled === false ? "disabled" : "enabled"} — ${rows.length} job(s)`);
+        for (const row of rows) write(`${row.name} every=${row.every} target=${row.target} last=${formatTime(row.lastRun)} next=${formatTime(row.nextDue)} due=${row.due}`);
+      }
+    } else if (sub === "run") {
+      const name = jobName(args, ctx);
+      if (!name) return { ok: false, error: "usage: maw scheduler run <name> [--dry-run]" };
+      const jobs = loadJobs(paths.jobsFile).jobs;
+      const job = jobs.find((item) => item.name === name);
+      if (!job) return { ok: false, error: `scheduler job not found: ${name}` };
+      await runJobNow(job, paths.stateFile, deps, args.includes("--dry-run") || ctx.flags?.["dry-run"] === true);
+      write(`${args.includes("--dry-run") ? "would run" : "ran"} scheduler job '${name}'`);
+    } else if (sub === "parse-every") {
+      write(String(parseEvery(args[1] ?? "")));
+    } else {
+      return { ok: false, error: `unknown scheduler subcommand: ${sub}\nusage: maw scheduler <start|stop|status|list|run> [--name <job>] [--json]` };
+    }
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err), output: logs.join("\n") || undefined };
+  }
+}
+
+export default handleScheduler;

--- a/src/commands/plugins/scheduler/jobs.ts
+++ b/src/commands/plugins/scheduler/jobs.ts
@@ -1,0 +1,225 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { mawDataPath } from "../../../sdk";
+
+export type Hook =
+  | { run: string }
+  | { publish: string }
+  | { log: string }
+  | { "maw-hey": { target: string; message: string } };
+
+export interface SchedulerJob {
+  name: string;
+  every: string;
+  target: string;
+  prompt: string;
+  hooks?: {
+    before?: Hook[];
+    after?: Hook[];
+  };
+}
+
+export interface SchedulerJobsFile {
+  name?: string;
+  jobs: SchedulerJob[];
+}
+
+export type SchedulerState = {
+  enabled?: boolean;
+  jobs?: Record<string, { lastRun?: number; startedAt?: number; status?: "running" | "done" }>;
+};
+
+export interface SchedulerPaths {
+  jobsFile: string;
+  stateDir: string;
+  stateFile: string;
+}
+
+export function schedulerPaths(root = process.cwd(), dataPath: (...parts: string[]) => string = mawDataPath): SchedulerPaths {
+  const stateDir = dataPath("scheduler");
+  return {
+    jobsFile: join(root, ".maw", "scheduler", "jobs.yaml"),
+    stateDir,
+    stateFile: join(stateDir, "state.json"),
+  };
+}
+
+function stripComment(line: string): string {
+  let quote: string | null = null;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i]!;
+    if ((ch === "\"" || ch === "'") && line[i - 1] !== "\\") quote = quote === ch ? null : quote || ch;
+    if (ch === "#" && !quote) return line.slice(0, i).trimEnd();
+  }
+  return line.trimEnd();
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith("\"") && trimmed.endsWith("\"")) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) return trimmed.slice(1, -1);
+  return trimmed;
+}
+
+function parseHook(lines: string[], index: number, itemIndent: number, first: string): { hook: Hook; next: number } {
+  const inline = first.match(/^([A-Za-z][\w-]*):\s*(.*)$/);
+  if (!inline) throw new Error(`unsupported hook near line ${index + 1}: ${first}`);
+  const key = inline[1]!;
+  const value = inline[2] ?? "";
+  if (key === "run") return { hook: { run: unquote(value) }, next: index + 1 };
+  if (key === "publish") return { hook: { publish: unquote(value) }, next: index + 1 };
+  if (key === "log") return { hook: { log: unquote(value) }, next: index + 1 };
+  if (key !== "maw-hey") throw new Error(`unsupported hook type '${key}' near line ${index + 1}`);
+  if (value.trim()) throw new Error(`maw-hey hook must use a nested mapping near line ${index + 1}`);
+  const config: Record<string, string> = {};
+  index += 1;
+  while (index < lines.length) {
+    const line = stripComment(lines[index]!);
+    if (!line.trim()) { index += 1; continue; }
+    const indent = line.match(/^ */)?.[0].length ?? 0;
+    if (indent <= itemIndent) break;
+    const field = line.trim().match(/^([A-Za-z][\w-]*):\s*(.*)$/);
+    if (!field) throw new Error(`unsupported maw-hey field near line ${index + 1}: ${line.trim()}`);
+    config[field[1]!] = unquote(field[2] ?? "");
+    index += 1;
+  }
+  if (!config.target || !config.message) throw new Error(`maw-hey hook requires target and message near line ${index + 1}`);
+  return { hook: { "maw-hey": { target: config.target, message: config.message } }, next: index };
+}
+
+export function parseJobsYaml(text: string): SchedulerJobsFile {
+  const lines = text.replace(/^\uFEFF/, "").split(/\r?\n/).map(stripComment);
+  const out: SchedulerJobsFile = { jobs: [] };
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    if (!line.trim()) { i += 1; continue; }
+    if (/^name:\s*/.test(line)) {
+      out.name = unquote(line.replace(/^name:\s*/, ""));
+      i += 1;
+      continue;
+    }
+    if (line.trim() === "jobs: []") { i += 1; continue; }
+    if (line.trim() !== "jobs:") throw new Error(`unsupported top-level entry near line ${i + 1}: ${line.trim()}`);
+    i += 1;
+    while (i < lines.length) {
+      let line = lines[i]!;
+      if (!line.trim()) { i += 1; continue; }
+      const item = line.match(/^ {2}-\s*(.*)$/);
+      if (!item) break;
+      const job: Partial<SchedulerJob> = {};
+      const first = item[1] ?? "";
+      if (first.trim()) {
+        const field = first.match(/^([A-Za-z][\w-]*):\s*(.*)$/);
+        if (!field) throw new Error(`unsupported job item near line ${i + 1}: ${first}`);
+        (job as Record<string, unknown>)[field[1]!] = unquote(field[2] ?? "");
+      }
+      i += 1;
+      let section: "before" | "after" | null = null;
+      while (i < lines.length) {
+        line = lines[i]!;
+        if (!line.trim()) { i += 1; continue; }
+        if (/^ {2}-\s*/.test(line) || /^\S/.test(line)) break;
+        const hookItem = line.match(/^ {8}-\s*(.*)$/);
+        if (hookItem && section) {
+          const parsed = parseHook(lines, i, 8, hookItem[1] ?? "");
+          job.hooks ??= {};
+          job.hooks[section] ??= [];
+          job.hooks[section]!.push(parsed.hook);
+          i = parsed.next;
+          continue;
+        }
+        const hookSection = line.match(/^ {6}(before|after):\s*$/);
+        if (hookSection) {
+          section = hookSection[1] as "before" | "after";
+          job.hooks ??= {};
+          job.hooks[section] ??= [];
+          i += 1;
+          continue;
+        }
+        const field = line.match(/^ {4}([A-Za-z][\w-]*):\s*(.*)$/);
+        if (!field) throw new Error(`unsupported job field near line ${i + 1}: ${line.trim()}`);
+        const key = field[1]!;
+        const value = field[2] ?? "";
+        if (key === "hooks") { section = null; i += 1; continue; }
+        (job as Record<string, unknown>)[key] = unquote(value);
+        i += 1;
+      }
+      for (const key of ["name", "every", "target", "prompt"] as const) {
+        if (!job[key]) throw new Error(`job is missing required field '${key}'`);
+      }
+      out.jobs.push(job as SchedulerJob);
+    }
+  }
+  return out;
+}
+
+export function parseEvery(value: string): number {
+  const match = value.trim().match(/^(\d+)([smh])$/);
+  if (!match) throw new Error(`invalid every value '${value}' (expected 10s, 2m, or 1h)`);
+  const amount = Number(match[1]);
+  if (!Number.isSafeInteger(amount) || amount <= 0) throw new Error(`invalid every value '${value}'`);
+  return amount * (match[2] === "s" ? 1_000 : match[2] === "m" ? 60_000 : 3_600_000);
+}
+
+export function loadJobs(file: string): SchedulerJobsFile {
+  if (!existsSync(file)) return { jobs: [] };
+  return parseJobsYaml(readFileSync(file, "utf8"));
+}
+
+export function readState(stateFile: string): SchedulerState {
+  if (!existsSync(stateFile)) return { enabled: true, jobs: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(stateFile, "utf8")) as SchedulerState;
+    return { enabled: parsed.enabled ?? true, jobs: parsed.jobs ?? {} };
+  } catch {
+    return { enabled: true, jobs: {} };
+  }
+}
+
+export function writeState(stateFile: string, state: SchedulerState): void {
+  mkdirSync(dirname(stateFile), { recursive: true });
+  writeFileSync(stateFile, JSON.stringify({ enabled: state.enabled ?? true, jobs: state.jobs ?? {} }, null, 2));
+}
+
+export function setEnabled(stateFile: string, enabled: boolean): SchedulerState {
+  const state = readState(stateFile);
+  state.enabled = enabled;
+  writeState(stateFile, state);
+  return state;
+}
+
+export function isDue(job: SchedulerJob, state: SchedulerState, now = Date.now()): boolean {
+  const record = state.jobs?.[job.name];
+  if (!record?.lastRun && !record?.startedAt) return true;
+  const everyMs = parseEvery(job.every);
+  if (record.status === "running" && record.startedAt && now - record.startedAt < everyMs) return false;
+  if (!record.lastRun) return true;
+  return now - record.lastRun >= everyMs;
+}
+
+export function nextDueAt(job: SchedulerJob, state: SchedulerState): number | null {
+  const lastRun = state.jobs?.[job.name]?.lastRun;
+  return lastRun ? lastRun + parseEvery(job.every) : null;
+}
+
+export function markStarted(stateFile: string, name: string, now = Date.now()): SchedulerState {
+  const state = readState(stateFile);
+  state.jobs ??= {};
+  state.jobs[name] = { status: "running", startedAt: now, lastRun: state.jobs[name]?.lastRun };
+  writeState(stateFile, state);
+  return state;
+}
+
+export function markDone(stateFile: string, name: string, now = Date.now()): SchedulerState {
+  const state = readState(stateFile);
+  state.jobs ??= {};
+  state.jobs[name] = { status: "done", lastRun: now };
+  writeState(stateFile, state);
+  return state;
+}
+
+export function validateJobPrompt(prompt: string): void {
+  if (/[;&|`$<>\n\r]/.test(prompt)) {
+    throw new Error(`unsafe scheduler prompt contains shell metacharacters: ${prompt}`);
+  }
+}

--- a/src/commands/plugins/scheduler/plugin.json
+++ b/src/commands/plugins/scheduler/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "scheduler",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "File-based job scheduler — dispatch maw hey on a timer",
+  "cli": {
+    "command": "scheduler",
+    "help": "maw scheduler <start|stop|status|list|run> [--name <job>] [--json] [--dry-run]",
+    "flags": {
+      "--name": "string",
+      "--json": "boolean",
+      "--dry-run": "boolean"
+    }
+  },
+  "hooks": {
+    "serve": {
+      "script": "./daemon.ts",
+      "handler": "serve",
+      "ensures": ["serve:scheduler"],
+      "policy": "fail-fast"
+    }
+  },
+  "weight": 50,
+  "tier": "standard"
+}

--- a/test/isolated/scheduler-plugin.test.ts
+++ b/test/isolated/scheduler-plugin.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+
+import { schedulerTick, serve } from "../../src/commands/plugins/scheduler/daemon";
+import { runHook } from "../../src/commands/plugins/scheduler/hooks";
+import { handleScheduler } from "../../src/commands/plugins/scheduler/index";
+import {
+  isDue,
+  loadJobs,
+  markDone,
+  parseEvery,
+  parseJobsYaml,
+  readState,
+  schedulerPaths,
+  type SchedulerJob,
+} from "../../src/commands/plugins/scheduler/jobs";
+import manifest from "../../src/commands/plugins/scheduler/plugin.json";
+
+function tempRoot() {
+  const root = mkdtempSync(join(tmpdir(), "maw-scheduler-plugin-"));
+  return { root, paths: schedulerPaths(root, (...parts: string[]) => join(root, ".data", ...parts)) };
+}
+
+function writeJobs(file: string, body: string) {
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, body.startsWith("\n") ? body.slice(1) : body);
+}
+
+const job: SchedulerJob = { name: "codex-monitor", every: "2m", target: "mawjs-oracle", prompt: "/codex-monitor" };
+
+describe("scheduler plugin (#2818)", () => {
+  test("plugin manifest exposes scheduler CLI and serve hook", () => {
+    expect(manifest.cli.command).toBe("scheduler");
+    expect(manifest.hooks.serve).toMatchObject({ script: "./daemon.ts", handler: "serve", policy: "fail-fast" });
+  });
+
+  test("parseEvery handles seconds, minutes, and hours", () => {
+    expect(parseEvery("10s")).toBe(10_000);
+    expect(parseEvery("2m")).toBe(120_000);
+    expect(parseEvery("1h")).toBe(3_600_000);
+    expect(() => parseEvery("1d")).toThrow("invalid every value");
+  });
+
+  test("parseJobsYaml reads hooks", () => {
+    const parsed = parseJobsYaml(`
+name: mawjs-m5
+jobs:
+  - name: codex-monitor
+    every: 2m
+    target: mawjs-oracle
+    prompt: /codex-monitor
+    hooks:
+      before:
+        - run: echo tick
+      after:
+        - log: done
+        - publish: /tmp/scheduler-state.json
+        - maw-hey:
+            target: mawjs-oracle
+            message: scheduler heartbeat complete
+`);
+    expect(parsed.jobs[0]).toMatchObject({ name: "codex-monitor", every: "2m", target: "mawjs-oracle", prompt: "/codex-monitor" });
+    expect(parsed.jobs[0]?.hooks?.before).toEqual([{ run: "echo tick" }]);
+    expect(parsed.jobs[0]?.hooks?.after?.[2]).toEqual({ "maw-hey": { target: "mawjs-oracle", message: "scheduler heartbeat complete" } });
+  });
+
+  test("isDue handles empty, recent, and expired state", () => {
+    const { paths } = tempRoot();
+    let state = readState(paths.stateFile);
+    expect(isDue(job, state, 1_000)).toBe(true);
+    markDone(paths.stateFile, job.name, 10_000);
+    state = readState(paths.stateFile);
+    expect(isDue(job, state, 30_000)).toBe(false);
+    expect(isDue(job, state, 131_000)).toBe(true);
+  });
+
+  test("runHook supports run, publish, log, and maw-hey", async () => {
+    const { root } = tempRoot();
+    const publishFile = join(root, "out", "state.json");
+    const events: string[] = [];
+    await runHook({ run: "echo tick" }, job, { runShell: async (command) => { events.push(`run:${command}`); return 0; } });
+    await runHook({ publish: publishFile }, job, { now: () => 42 });
+    await runHook({ log: "done" }, job, { log: (message) => events.push(String(message)) });
+    await runHook({ "maw-hey": { target: "mawjs-oracle", message: "ok" } }, job, { mawHey: async (target, message) => { events.push(`hey:${target}:${message}`); return 0; } });
+    expect(events).toEqual(["run:echo tick", "[scheduler] done", "hey:mawjs-oracle:ok"]);
+    expect(JSON.parse(readFileSync(publishFile, "utf8"))).toEqual({ ts: 42, job: "codex-monitor" });
+  });
+
+  test("maw-hey hooks cannot recursively target the scheduler itself", async () => {
+    const warnings: string[] = [];
+    const calls: string[] = [];
+    await runHook({ "maw-hey": { target: "mawjs-scheduler", message: "loop" } }, job, {
+      schedulerName: "mawjs-scheduler",
+      warn: (message) => warnings.push(String(message)),
+      mawHey: async (target, message) => { calls.push(`${target}:${message}`); return 0; },
+    });
+    expect(calls).toEqual([]);
+    expect(warnings[0]).toContain("skipping recursive maw-hey hook");
+  });
+
+  test("job prompts reject shell metacharacters before dispatch", async () => {
+    const { paths } = tempRoot();
+    writeJobs(paths.jobsFile, `
+jobs:
+  - name: bad
+    every: 10s
+    target: mawjs-oracle
+    prompt: /codex-monitor; rm -rf /
+`);
+    const result = await schedulerTick({ paths, error: () => {} });
+    expect(result.errors[0]).toContain("unsafe scheduler prompt");
+  });
+
+  test("daemon tick dispatches due jobs and updates mawDataPath-backed state", async () => {
+    const { paths } = tempRoot();
+    writeJobs(paths.jobsFile, `
+jobs:
+  - name: codex-monitor
+    every: 2m
+    target: mawjs-oracle
+    prompt: /codex-monitor
+    hooks:
+      after:
+        - log: done
+`);
+    const events: string[] = [];
+    const result = await schedulerTick({
+      paths,
+      now: () => 100,
+      mawHey: async (target, message) => { events.push(`hey:${target}:${message}`); return 0; },
+      log: (message) => events.push(String(message)),
+    });
+    expect(result).toEqual({ ran: ["codex-monitor"], skipped: [], disabled: false, errors: [] });
+    expect(events).toEqual(["hey:mawjs-oracle:/codex-monitor", "[scheduler] done"]);
+    expect(readState(paths.stateFile).jobs?.["codex-monitor"]?.lastRun).toBe(100);
+  });
+
+  test("serve hook starts an unref'd setInterval timer", () => {
+    let intervalMs = 0;
+    let unrefCalled = false;
+    const result = serve({ source: "api" }, {
+      tickMs: 1234,
+      setInterval: (_handler, ms) => {
+        intervalMs = ms;
+        return { unref: () => { unrefCalled = true; } };
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.timers).toHaveLength(1);
+    expect(intervalMs).toBe(1234);
+    expect(unrefCalled).toBe(true);
+  });
+
+  test("CLI status/list/run/start/stop dispatch through InvokeContext", async () => {
+    const { paths } = tempRoot();
+    writeJobs(paths.jobsFile, `
+jobs:
+  - name: codex-monitor
+    every: 2m
+    target: mawjs-oracle
+    prompt: /codex-monitor
+`);
+    const list = await handleScheduler({ source: "cli", args: ["list"], flags: {}, matchedName: "scheduler" }, { paths });
+    expect(list.ok).toBe(true);
+    expect(list.output).toContain("codex-monitor");
+    const calls: string[] = [];
+    const run = await handleScheduler({ source: "cli", args: ["run", "codex-monitor"], flags: {}, matchedName: "scheduler" }, {
+      paths,
+      mawHey: async (target, message) => { calls.push(`${target}:${message}`); return 0; },
+    });
+    expect(run.ok).toBe(true);
+    expect(calls).toEqual(["mawjs-oracle:/codex-monitor"]);
+    expect((await handleScheduler({ source: "cli", args: ["stop"], flags: {}, matchedName: "scheduler" }, { paths })).output).toContain("disabled");
+    expect(readState(paths.stateFile).enabled).toBe(false);
+    expect((await handleScheduler({ source: "cli", args: ["start"], flags: {}, matchedName: "scheduler" }, { paths })).output).toContain("enabled");
+  });
+
+  test("loadJobs returns empty config when jobs.yaml is absent", () => {
+    const { paths } = tempRoot();
+    expect(loadJobs(paths.jobsFile)).toEqual({ jobs: [] });
+  });
+});


### PR DESCRIPTION
Closes #2818

## Summary
- add src/commands/plugins/scheduler as a maw plugin with plugin.json CLI metadata and hooks.serve daemon entry
- implement jobs.yaml parsing, mawDataPath-backed state, start/stop/status/list/run verbs, and serve setInterval/unref daemon ticks
- support run/publish/log/maw-hey hooks, foreground maw hey dispatch, scheduler self-target recursion blocking, and prompt shell-metacharacter validation

## Tests
- bash scripts/test-isolated.sh test/isolated/scheduler-plugin.test.ts
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun run test:plugin
- bun run test:mock-smoke
- bun run build