### PR TITLE
Fix duplicate scheduler status output

### DIFF
--- a/src/commands/plugins/scheduler/index.ts
+++ b/src/commands/plugins/scheduler/index.ts
@@ -48,7 +48,15 @@ async function runJobNow(job: SchedulerJob, stateFile: string, deps: SchedulerCl
 
 export async function handleScheduler(ctx: InvokeContext, deps: SchedulerCliDeps = {}): Promise<InvokeResult> {
   const logs: string[] = [];
-  const write = (...args: unknown[]) => ctx.writer?.(...args) ?? logs.push(args.map(String).join(" "));
+  let wroteToWriter = false;
+  const write = (...args: unknown[]) => {
+    if (ctx.writer) {
+      wroteToWriter = true;
+      ctx.writer(...args);
+      return;
+    }
+    logs.push(args.map(String).join(" "));
+  };
   const args = argsFrom(ctx);
   const sub = args[0] ?? "status";
   const paths = deps.paths ?? schedulerPaths(deps.cwd ?? process.cwd());
@@ -88,9 +96,9 @@ export async function handleScheduler(ctx: InvokeContext, deps: SchedulerCliDeps
     } else {
       return { ok: false, error: `unknown scheduler subcommand: ${sub}\nusage: maw scheduler <start|stop|status|list|run> [--name <job>] [--json]` };
     }
-    return { ok: true, output: logs.join("\n") || undefined };
+    return { ok: true, output: wroteToWriter ? undefined : logs.join("\n") || undefined };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err), output: logs.join("\n") || undefined };
+    return { ok: false, error: err instanceof Error ? err.message : String(err), output: wroteToWriter ? undefined : logs.join("\n") || undefined };
   }
 }
 

--- a/test/isolated/scheduler-plugin.test.ts
+++ b/test/isolated/scheduler-plugin.test.ts
@@ -177,6 +177,28 @@ jobs:
     expect((await handleScheduler({ source: "cli", args: ["start"], flags: {}, matchedName: "scheduler" }, { paths })).output).toContain("enabled");
   });
 
+  test("CLI status with writer does not also return buffered duplicate output (#2822)", async () => {
+    const { paths } = tempRoot();
+    writeJobs(paths.jobsFile, `
+jobs:
+  - name: codex-monitor
+    every: 2m
+    target: mawjs-oracle
+    prompt: /codex-monitor
+`);
+    const written: string[] = [];
+    const result = await handleScheduler({
+      source: "cli",
+      args: ["status"],
+      flags: {},
+      matchedName: "scheduler",
+      writer: (...args) => written.push(args.map(String).join(" ")),
+    }, { paths });
+    expect(result).toEqual({ ok: true, output: undefined });
+    expect(written.filter((line) => line.includes("codex-monitor"))).toHaveLength(1);
+    expect(written.join("\n").match(/codex-monitor/g)).toHaveLength(1);
+  });
+
   test("loadJobs returns empty config when jobs.yaml is absent", () => {
     const { paths } = tempRoot();
     expect(loadJobs(paths.jobsFile)).toEqual({ jobs: [] });


### PR DESCRIPTION
Closes #2822

## Summary
- make scheduler CLI writes branch explicitly between ctx.writer and buffered logs
- return undefined output when writer streaming is active so dispatch cannot print lines twice
- add regression for scheduler status with a void writer emitting exactly one job line

## Tests
- bash scripts/test-isolated.sh test/isolated/scheduler-plugin.test.ts
- bun scripts/check-plugin-coverage-gate.ts origin/alpha
- bun run test:plugin
- bun run test:mock-smoke
- bun run build