### PR TITLE
Fix duplicate loaded config banner

### DIFF
--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -39,6 +39,7 @@ const DEFAULTS: Pick<MawConfig, "host" | "port" | "oracleUrl" | "env" | "session
 let warnedGhqRoot = false;
 let warnedHostMigrated = false;
 let warnedHostNodeConflated = false;
+let loadedConfigPrinted = false;
 
 let cached: MawConfig | null = null;
 let cachedKey = "";
@@ -539,6 +540,8 @@ export function loadConfig(opts: LoadConfigOptions = {}): MawConfig {
   }
   // One-shot startup summary — fires unless --quiet/--silent (verbose-by-default).
   verbose(() => {
+    if (loadedConfigPrinted) return;
+    loadedConfigPrinted = true;
     const nT = cached!.triggers?.length ?? 0;
     const nP = cached!.pluginSources?.length ?? 0;
     const nPeers = (cached!.peers?.length ?? 0) + (cached!.namedPeers?.length ?? 0);
@@ -567,6 +570,7 @@ export function resetConfig() {
   warnedGhqRoot = false;
   warnedHostMigrated = false;
   warnedHostNodeConflated = false;
+  loadedConfigPrinted = false;
 }
 
 /**

--- a/test/isolated/config-load-second-pass.test.ts
+++ b/test/isolated/config-load-second-pass.test.ts
@@ -172,6 +172,29 @@ describe("config load second pass coverage", () => {
     expect(stderrWrites.filter((line) => line.includes("config.ghqRoot is deprecated"))).toHaveLength(2);
   });
 
+  test("loaded config banner is one-shot across default and cwd loads until reset (#2825)", () => {
+    rawConfigText = JSON.stringify({ unused: true });
+    validatedConfig = {
+      triggers: [{ id: "t1" }],
+      pluginSources: [{ name: "plugins-a" }],
+      peers: [{ name: "peer-a" }],
+    };
+
+    config.loadConfig();
+    config.loadConfig({ cwd: "/tmp/alternate-cwd" });
+
+    expect(infoMessages).toEqual([
+      "loaded config: 1 trigger, 1 declared plugin, 1 peer",
+    ]);
+
+    config.resetConfig();
+    config.loadConfig();
+    expect(infoMessages).toEqual([
+      "loaded config: 1 trigger, 1 declared plugin, 1 peer",
+      "loaded config: 1 trigger, 1 declared plugin, 1 peer",
+    ]);
+  });
+
   test("bind-address migration preserves an existing bind and ignores empty fleet merge results", () => {
     verboseEnabled = false;
     rawConfigText = JSON.stringify({ host: "127.0.0.1" });


### PR DESCRIPTION
Closes #2825

## Summary
- add a one-shot guard around the loaded config startup summary
- reset the guard from resetConfig so tests and hot reloads re-arm the banner
- cover default plus cwd load calls printing the banner only once until reset

## Tests
- bun src/cli.ts fleet ls 2>&1 | grep 'loaded config' | wc -l  # 1\n- bash scripts/test-isolated.sh test/isolated/config-load-second-pass.test.ts\n- bun scripts/check-plugin-coverage-gate.ts origin/alpha\n- bun run build