### PR TITLE
Fix loaded config banner across bundle instances

### DIFF
--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -39,7 +39,6 @@ const DEFAULTS: Pick<MawConfig, "host" | "port" | "oracleUrl" | "env" | "session
 let warnedGhqRoot = false;
 let warnedHostMigrated = false;
 let warnedHostNodeConflated = false;
-let loadedConfigPrinted = false;
 
 let cached: MawConfig | null = null;
 let cachedKey = "";
@@ -540,8 +539,9 @@ export function loadConfig(opts: LoadConfigOptions = {}): MawConfig {
   }
   // One-shot startup summary — fires unless --quiet/--silent (verbose-by-default).
   verbose(() => {
-    if (loadedConfigPrinted) return;
-    loadedConfigPrinted = true;
+    const BANNER_KEY = Symbol.for("maw:loadedConfigPrinted");
+    if ((process as any)[BANNER_KEY]) return;
+    (process as any)[BANNER_KEY] = true;
     const nT = cached!.triggers?.length ?? 0;
     const nP = cached!.pluginSources?.length ?? 0;
     const nPeers = (cached!.peers?.length ?? 0) + (cached!.namedPeers?.length ?? 0);
@@ -570,7 +570,7 @@ export function resetConfig() {
   warnedGhqRoot = false;
   warnedHostMigrated = false;
   warnedHostNodeConflated = false;
-  loadedConfigPrinted = false;
+  delete (process as any)[Symbol.for("maw:loadedConfigPrinted")];
 }
 
 /**


### PR DESCRIPTION
Closes #2825

## Summary
- replace the module-local loaded config banner flag with a process-global Symbol.for sentinel
- clear the process-global sentinel from resetConfig for tests and hot reloads
- keeps the #2825 regression test from PR #2826 while fixing compiled Bun binary behavior

## Tests
- bash scripts/test-isolated.sh test/isolated/config-load-second-pass.test.ts
- bun run build
- cp dist/maw /Users/nat/.local/bin/maw
- maw fleet ls 2>&1 | grep -c 'loaded config'  # 1\n- maw scheduler status 2>&1 | grep -c 'loaded config'  # 1\n- bun scripts/check-plugin-coverage-gate.ts origin/alpha