### PR TITLE
release: v26.6.14-alpha.1754

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.14-alpha.830",
+  "version": "26.6.14-alpha.1754",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Re-cut alpha after #2830 fixed the release-gate isolated test (#2829).

- Bumps package.json → `26.6.14-alpha.1754`
- On merge to alpha → calver-release.yml cuts `v26.6.14-alpha.1754` (tag + GH release + dist/maw)
- This publishes the loaded-config dual-module-instance fix (stuck since Jun 13 because the CalVer Release gate was red on `core-server-more-coverage-2.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)