### PR TITLE
Bootstrap standard plugins from bare maw binaries

### DIFF
--- a/src/cli/cmd-update.ts
+++ b/src/cli/cmd-update.ts
@@ -100,6 +100,20 @@ export function healBrokenPluginSymlinks(pluginDir: string, roots: string[]): { 
   return { healed, pruned };
 }
 
+
+/** @internal exported for default-run coverage tests. */
+export async function installStandardPluginsAfterUpdate(ref: string): Promise<void> {
+  console.log(`\n  🔌 ensuring standard plugins`);
+  const proc = Bun.spawn(["maw", "plugin", "install", "--standard", "--ref", ref], {
+    stdio: ["inherit", "inherit", "inherit"],
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    console.error(`\x1b[31merror\x1b[0m: standard plugin bootstrap failed after update`);
+    process.exit(code);
+  }
+}
+
 export async function runUpdate(args: string[]): Promise<void> {
   const { repository } = require("../../package.json");
   // args[0] is "update"; first non-flag positional is the ref.
@@ -432,6 +446,8 @@ export async function runUpdate(args: string[]): Promise<void> {
         }
       }
     } catch {}
+
+    await installStandardPluginsAfterUpdate(ref);
 
     // Arrow confirmation — "before → after" mirrors the header but with the
     // actual resolved version (in case ref was 'main' or channel shortcut).

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -247,6 +247,14 @@ async function dispatchPluginRegistry(cmd: string, args: string[]): Promise<void
       } else {
         console.error(`  run 'maw --help' to see available commands`);
       }
+      try {
+        const { inspectStandardPluginHealth, standardPluginHealthMessage, formatStandardPluginHint } = await import("../commands/shared/standard-plugins");
+        const msg = standardPluginHealthMessage(inspectStandardPluginHealth());
+        if (msg) {
+          console.error(`  ${msg}`);
+          console.error(`  ${formatStandardPluginHint()}`);
+        }
+      } catch {}
       // UserError: output already printed above; top-level catch just
       // exits 1 without bun's default stack trace (alpha.66 polish).
       throw new UserError(`unknown command: ${args[0]}`);

--- a/src/cli/route-tools.ts
+++ b/src/cli/route-tools.ts
@@ -10,7 +10,7 @@ import { mawDataPath } from "../core/xdg";
 // `maw plugin list --help` / `maw agents --help` from running real work.
 const CORE_HELP: Record<string, string> = {
   plugins: "usage: maw plugins [ls|info <name>|remove <name>|lean|standard|full|nuke|enable <name...>|disable <name>] [--json] [--all] [-v|--verbose] [--core|--standard|--extra|--api] [--force]",
-  plugin: "usage: maw plugin <init|build|install|create|ls|info|remove|enable <name...>|disable> [args]\n  ls: compact by default; use -v for full table; filters: --core --standard --extra --api",
+  plugin: "usage: maw plugin <init|build|install|create|ls|info|remove|enable <name...>|disable> [args]\n  install --standard: bootstrap standard plugins from a bare binary\n  ls: compact by default; use -v for full table; filters: --core --standard --extra --api",
   artifacts: "usage: maw artifacts [ls|get] [team] [task-id] [--json]",
   artifact: "usage: maw artifact [ls|get] [team] [task-id] [--json]",
   agents: "usage: maw agents [--json] [--all] [--node <node>]",
@@ -247,6 +247,26 @@ export async function routeToolsWithDeps(cmd: string, args: string[], deps: Rout
   }
   if (cmd === "plugin") {
     const sub = args[1]?.toLowerCase();
+    if (sub === "install" && (args.includes("--standard") || args[2] === "standard")) {
+      const { parseFlags } = await import("./parse-args");
+      const { installStandardPlugins } = await import("../commands/shared/standard-plugins");
+      const flags = parseFlags(args, {
+        "--standard": Boolean,
+        "--force": Boolean,
+        "--dry-run": Boolean,
+        "--source-root": String,
+        "--ref": String,
+      }, 1);
+      const unsupported = (flags._ as string[]).filter((arg) => arg !== "install" && arg !== "standard");
+      if (unsupported.length > 0) throw new UserError(`plugin install --standard: unexpected argument ${unsupported[0]}`);
+      await installStandardPlugins({
+        force: Boolean(flags["--force"]),
+        dryRun: Boolean(flags["--dry-run"]),
+        sourceRoot: flags["--source-root"] as string | undefined,
+        ref: flags["--ref"] as string | undefined,
+      });
+      return true;
+    }
     // "maw plugin init|build|install|search|registry|pin|unpin|dev" →
     // forward to the plugin-lifecycle plugin (marketplace pipeline).
     const lifecycleSubs = new Set(["init", "build", "install", "search", "registry", "pin", "unpin", "dev"]);

--- a/src/commands/plugins/team/team-wtf-fix.ts
+++ b/src/commands/plugins/team/team-wtf-fix.ts
@@ -1,1 +1,31 @@
+import {
+  cmdTeamWtfFix as vendorCmdTeamWtfFix,
+  type WtfFixApplyDeps,
+  type WtfFixPlanResult,
+} from "../../../vendor/mpr-plugins/team/team-wtf-fix";
+import { installStandardPlugins, inspectStandardPluginHealth, standardPluginHealthMessage } from "../../shared/standard-plugins";
+
 export * from "../../../vendor/mpr-plugins/team/team-wtf-fix";
+
+function standardPluginsNeedFix(): boolean {
+  return Boolean(standardPluginHealthMessage(inspectStandardPluginHealth()));
+}
+
+export async function cmdTeamWtfFix(teamArg: string | undefined, opts: { json?: boolean; session?: string; cwd?: string; confirm?: string; dryRun?: boolean } = {}, deps: WtfFixApplyDeps & any = {}): Promise<WtfFixPlanResult> {
+  if (standardPluginsNeedFix()) {
+    const command = "maw plugin install --standard";
+    const plan: WtfFixPlanResult = {
+      transactions: [{ kind: "team-up", command, check: "plugins:standard-set" } as any],
+      denied: [],
+      commands: [command],
+    };
+    if (opts.json) console.log(JSON.stringify(plan, null, 2));
+    else {
+      console.log("maw wtf --fix plan");
+      console.log(`  + ${command}`);
+    }
+    if (!opts.dryRun) await installStandardPlugins();
+    return plan;
+  }
+  return vendorCmdTeamWtfFix(teamArg, opts, deps);
+}

--- a/src/commands/plugins/team/team-wtf.ts
+++ b/src/commands/plugins/team/team-wtf.ts
@@ -1,1 +1,61 @@
+import type { DoctorCheck } from "../../../vendor/mpr-plugins/doctor/impl";
+import {
+  cmdTeamWtf as vendorCmdTeamWtf,
+  inspectTeamWtf as vendorInspectTeamWtf,
+  type TeamWtfDeps,
+  type TeamWtfOptions,
+  type TeamWtfResult,
+} from "../../../vendor/mpr-plugins/team/team-wtf";
+import { formatStandardPluginHint, inspectStandardPluginHealth, standardPluginHealthMessage } from "../../shared/standard-plugins";
+
 export * from "../../../vendor/mpr-plugins/team/team-wtf";
+
+function pluginHealthCheck(): DoctorCheck | undefined {
+  const health = inspectStandardPluginHealth();
+  const message = standardPluginHealthMessage(health);
+  if (!message) return undefined;
+  return {
+    name: "plugins:standard-set",
+    ok: false,
+    severity: health.status === "missing" ? "error" : "warn",
+    message,
+    fix: ["maw plugin install --standard"],
+    details: { ...health, verb: "install-standard" },
+  };
+}
+
+function renderPluginCheck(check: DoctorCheck): void {
+  const icon = check.severity === "error" ? "❌" : "⚠️";
+  console.log(`${icon} ${check.name.padEnd(26)} ${check.message}`);
+  console.log(`   → ${formatStandardPluginHint()}`);
+}
+
+function pluginOnlyResult(check: DoctorCheck): TeamWtfResult {
+  return {
+    ok: false,
+    team: "plugins",
+    session: "plugin-bootstrap",
+    charterPath: "(standard plugin set)",
+    checks: [check],
+  };
+}
+
+export async function inspectTeamWtf(teamArg: string | undefined, opts: TeamWtfOptions = {}, deps: TeamWtfDeps = {}): Promise<TeamWtfResult> {
+  const check = pluginHealthCheck();
+  if (check && !teamArg) return pluginOnlyResult(check);
+  const result = await vendorInspectTeamWtf(teamArg, opts, deps);
+  return check ? { ...result, ok: false, checks: [check, ...result.checks] } : result;
+}
+
+export async function cmdTeamWtf(teamArg?: string, opts: TeamWtfOptions = {}, deps: TeamWtfDeps = {}): Promise<TeamWtfResult> {
+  const check = pluginHealthCheck();
+  if (check && !teamArg) {
+    const result = pluginOnlyResult(check);
+    if (opts.json) console.log(JSON.stringify({ ok: false, checks: result.checks }, null, 2));
+    else renderPluginCheck(check);
+    return result;
+  }
+  if (check && !opts.json) renderPluginCheck(check);
+  const result = await vendorCmdTeamWtf(teamArg, opts, deps);
+  return check ? { ...result, ok: false, checks: [check, ...result.checks] } : result;
+}

--- a/src/commands/shared/preflight.ts
+++ b/src/commands/shared/preflight.ts
@@ -2,6 +2,7 @@ import { listSessions, getPaneInfos, isAgentCommand } from "../../sdk";
 import { buildCommandInDir, loadConfig } from "../../config";
 import { Tmux } from "../../core/transport/tmux";
 import { enginePatternKeysForConfig } from "../../config/engine-registry";
+import { STANDARD_PLUGIN_MIN_COUNT, standardPluginHealthMessage } from "./standard-plugins";
 
 export interface PreflightFs {
   readdirSync: typeof import("fs").readdirSync;
@@ -23,6 +24,7 @@ export interface PreflightDeps {
   loadConfig: typeof loadConfig;
   tmux: Pick<Tmux, "sendText">;
   log: (...args: unknown[]) => void;
+  standardPluginMinimum: number;
 }
 
 export function preflightDeps(overrides: Partial<PreflightDeps> = {}): PreflightDeps {
@@ -31,7 +33,7 @@ export function preflightDeps(overrides: Partial<PreflightDeps> = {}): Preflight
     packageVersion: () => require("../../../package.json").version,
     pluginDir: () => {
       const { mawDataPath } = require("../../core/xdg") as typeof import("../../core/xdg");
-      return mawDataPath("plugins");
+      return process.env.MAW_PLUGINS_DIR || mawDataPath("plugins");
     },
     fs: async () => await import("fs"),
     join: (...parts: string[]) => {
@@ -45,6 +47,7 @@ export function preflightDeps(overrides: Partial<PreflightDeps> = {}): Preflight
     loadConfig,
     tmux: new Tmux(),
     log: (...args: unknown[]) => console.log(...args),
+    standardPluginMinimum: STANDARD_PLUGIN_MIN_COUNT,
     ...overrides,
   };
 }
@@ -72,14 +75,30 @@ export async function cmdPreflight(opts: { fix?: boolean } = {}, deps: Partial<P
       const p = io.join(pluginDir, e);
       try { if (lstatSync(p).isSymbolicLink() && !existsSync(p)) broken.push(e); } catch {}
     }
-    if (broken.length > 0) {
-      if (opts.fix) {
-        for (const b of broken) { try { unlinkSync(io.join(pluginDir, b)); fixed++; } catch {} }
-        io.log(`  \x1b[33m⚠\x1b[0m plugins: ${entries.length} loaded, ${broken.length} broken symlinks fixed`);
-      } else {
-        io.log(`  \x1b[31m✗\x1b[0m plugins: ${entries.length} loaded, ${broken.length} broken symlinks`);
+    const count = entries.length - broken.length;
+    const health = {
+      pluginDir,
+      count,
+      broken,
+      status: count === 0 ? "missing" as const : count < io.standardPluginMinimum ? "low" as const : "ok" as const,
+      minExpected: io.standardPluginMinimum,
+    };
+    const healthMessage = standardPluginHealthMessage(health);
+    if (broken.length > 0 && opts.fix) {
+      for (const b of broken) { try { unlinkSync(io.join(pluginDir, b)); fixed++; } catch {} }
+      io.log(`  \x1b[33m⚠\x1b[0m plugins: ${entries.length} loaded, ${broken.length} broken symlinks fixed`);
+      if (count < io.standardPluginMinimum) {
+        io.log(`      ${healthMessage}`);
+        io.log(`      run: maw plugin install --standard`);
         fail++;
       }
+    } else if (broken.length > 0) {
+      io.log(`  \x1b[31m✗\x1b[0m plugins: ${entries.length} loaded, ${broken.length} broken symlinks`);
+      fail++;
+    } else if (healthMessage) {
+      io.log(`  \x1b[31m✗\x1b[0m plugins: ${healthMessage}`);
+      io.log(`      run: maw plugin install --standard`);
+      fail++;
     } else {
       io.log(`  \x1b[32m✓\x1b[0m plugins: ${entries.length} loaded, 0 broken`);
       pass++;

--- a/src/commands/shared/standard-plugins.ts
+++ b/src/commands/shared/standard-plugins.ts
@@ -1,0 +1,248 @@
+import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, readdirSync, symlinkSync, unlinkSync } from "fs";
+import { dirname, join, relative, resolve } from "path";
+import pkg from "../../../package.json" with { type: "json" };
+import { mawDataPath } from "../../core/xdg";
+
+export const STANDARD_PLUGIN_MIN_COUNT = 50;
+export const STANDARD_PLUGIN_CRITICAL_COUNT = 10;
+
+export interface StandardPluginHealth {
+  pluginDir: string;
+  count: number;
+  broken: string[];
+  status: "ok" | "missing" | "low";
+  minExpected: number;
+}
+
+export interface StandardPluginInstallOptions {
+  pluginDir?: string;
+  sourceRoot?: string;
+  ref?: string;
+  force?: boolean;
+  dryRun?: boolean;
+  log?: (line: string) => void;
+  fetch?: boolean;
+}
+
+export interface StandardPluginInstallResult {
+  pluginDir: string;
+  sourceRoot: string;
+  installed: number;
+  replaced: number;
+  skipped: number;
+  totalStandard: number;
+  dryRun: boolean;
+}
+
+type PluginCandidate = { name: string; dir: string };
+
+function defaultPluginDir(): string {
+  return process.env.MAW_PLUGINS_DIR || mawDataPath("plugins");
+}
+
+function readJson(path: string): any | undefined {
+  try { return JSON.parse(readFileSync(path, "utf8")); } catch { return undefined; }
+}
+
+function isMawJsRoot(root: string | undefined): boolean {
+  if (!root) return false;
+  const manifest = readJson(join(root, "package.json"));
+  return manifest?.name === "maw-js";
+}
+
+function standardRoots(root: string): string[] {
+  return [
+    join(root, "src", "commands", "plugins"),
+    join(root, "src", "vendor", "mpr-plugins"),
+    join(root, "src", "vendor-plugins"),
+  ].filter((dir) => existsSync(dir));
+}
+
+function refLooksVersioned(ref: string | undefined): boolean {
+  return Boolean(ref && /^v?\d+\.\d+\.\d+/.test(ref));
+}
+
+function sourceMatchesRef(root: string, ref: string | undefined): boolean {
+  if (!refLooksVersioned(ref)) return true;
+  const manifest = readJson(join(root, "package.json"));
+  const version = typeof manifest?.version === "string" ? manifest.version : "";
+  return version === ref!.replace(/^v/, "");
+}
+
+function hasStandardPluginSources(root: string | undefined, ref?: string): root is string {
+  if (!root || !isMawJsRoot(root)) return false;
+  if (!sourceMatchesRef(root, ref)) return false;
+  return collectStandardPlugins(root).length >= STANDARD_PLUGIN_MIN_COUNT;
+}
+
+function rootFromCliPath(path: string): string | undefined {
+  const real = realpathSync(path);
+  const normalized = real.replace(/\\/g, "/");
+  if (normalized.endsWith("/src/cli.ts")) return dirname(dirname(real));
+  if (normalized.endsWith("/dist/maw")) return dirname(dirname(real));
+  return undefined;
+}
+
+function bunGlobalRoot(): string | undefined {
+  try {
+    const proc = Bun.spawnSync(["bun", "pm", "bin", "-g"], { stdout: "pipe", stderr: "pipe" });
+    if (proc.exitCode !== 0) return undefined;
+    const bin = new TextDecoder().decode(proc.stdout).trim();
+    if (!bin) return undefined;
+    const mawBin = join(bin, "maw");
+    if (!existsSync(mawBin)) return undefined;
+    return rootFromCliPath(mawBin);
+  } catch {
+    return undefined;
+  }
+}
+
+function candidateSourceRoots(explicit?: string): string[] {
+  const roots = [
+    explicit,
+    process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT,
+    process.env.MAW_JS_PATH,
+    resolve(import.meta.dir, "..", "..", ".."),
+    bunGlobalRoot(),
+    join(process.env.HOME || "", ".bun", "install", "global", "node_modules", "maw-js"),
+  ].filter(Boolean) as string[];
+  return [...new Set(roots.map((root) => resolve(root)))];
+}
+
+function defaultRef(): string {
+  return process.env.MAW_STANDARD_PLUGIN_REF || `v${pkg.version}`;
+}
+
+function fetchMawJsSource(ref: string, log: (line: string) => void): void {
+  const candidates = [ref, "alpha"].filter((value, index, arr) => value && arr.indexOf(value) === index);
+  let last = "";
+  for (const candidate of candidates) {
+    const spec = `github:Soul-Brews-Studio/maw-js#${candidate}`;
+    log(`→ fetching standard plugin source: bun add -g ${spec}`);
+    const proc = Bun.spawnSync(["bun", "add", "-g", spec], { stdout: "pipe", stderr: "pipe" });
+    if (proc.exitCode === 0) return;
+    const stderr = new TextDecoder().decode(proc.stderr).trim();
+    const stdout = new TextDecoder().decode(proc.stdout).trim();
+    last = stderr || stdout || `bun add -g exited ${proc.exitCode}`;
+    log(`  ! fetch failed for ${candidate}: ${last}`);
+  }
+  throw new Error(`failed to fetch maw-js standard plugin source (${last || "unknown error"})`);
+}
+
+export function resolveStandardPluginSourceRoot(options: { sourceRoot?: string; ref?: string; fetch?: boolean; log?: (line: string) => void } = {}): string {
+  for (const root of candidateSourceRoots(options.sourceRoot)) {
+    if (hasStandardPluginSources(root, options.ref)) return root;
+  }
+  if (options.fetch === false) {
+    throw new Error("standard plugin source not found; run from a maw-js checkout or allow fetching with bun add -g");
+  }
+  fetchMawJsSource(options.ref || defaultRef(), options.log ?? console.log);
+  for (const root of candidateSourceRoots(options.sourceRoot)) {
+    if (hasStandardPluginSources(root, options.ref)) return root;
+  }
+  throw new Error("standard plugin source fetch completed, but no maw-js plugin sources were found");
+}
+
+export function collectStandardPlugins(sourceRoot: string): PluginCandidate[] {
+  const plugins: PluginCandidate[] = [];
+  const seen = new Set<string>();
+  for (const root of standardRoots(sourceRoot)) {
+    for (const entry of readdirSync(root)) {
+      const dir = join(root, entry);
+      const manifest = readJson(join(dir, "plugin.json"));
+      const name = typeof manifest?.name === "string" ? manifest.name : undefined;
+      if (!name || seen.has(name)) continue;
+      seen.add(name);
+      plugins.push({ name, dir });
+    }
+  }
+  return plugins.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function isBrokenSymlink(path: string): boolean {
+  try { return lstatSync(path).isSymbolicLink() && !existsSync(path); } catch { return false; }
+}
+
+function pathExistsOrSymlink(path: string): boolean {
+  try { lstatSync(path); return true; } catch { return false; }
+}
+
+function validInstalledPlugin(path: string): boolean {
+  return existsSync(join(path, "plugin.json"));
+}
+
+function relativeSymlinkTarget(dest: string, src: string): string {
+  let base = dirname(dest);
+  try { base = realpathSync(base); } catch {}
+  const rel = relative(base, src);
+  return rel || ".";
+}
+
+export function inspectStandardPluginHealth(pluginDir = defaultPluginDir(), minExpected = STANDARD_PLUGIN_MIN_COUNT): StandardPluginHealth {
+  try {
+    const entries = readdirSync(pluginDir).filter((entry) => !entry.startsWith("."));
+    const broken = entries.filter((entry) => isBrokenSymlink(join(pluginDir, entry)));
+    const count = entries.filter((entry) => validInstalledPlugin(join(pluginDir, entry))).length;
+    const status = count === 0 ? "missing" : count < minExpected ? "low" : "ok";
+    return { pluginDir, count, broken, status, minExpected };
+  } catch {
+    return { pluginDir, count: 0, broken: [], status: "missing", minExpected };
+  }
+}
+
+export function standardPluginHealthMessage(health: StandardPluginHealth): string | undefined {
+  if (health.status === "ok" && health.broken.length === 0) return undefined;
+  const loaded = `${health.count} loaded`;
+  const expected = `expected at least ${health.minExpected}`;
+  const broken = health.broken.length ? `, ${health.broken.length} broken symlink${health.broken.length === 1 ? "" : "s"}` : "";
+  return `standard plugins ${health.status === "missing" ? "missing" : "low"}: ${loaded}${broken} (${expected})`;
+}
+
+export async function installStandardPlugins(options: StandardPluginInstallOptions = {}): Promise<StandardPluginInstallResult> {
+  const pluginDir = options.pluginDir || defaultPluginDir();
+  const log = options.log ?? console.log;
+  const sourceRoot = resolveStandardPluginSourceRoot({ sourceRoot: options.sourceRoot, ref: options.ref, fetch: options.fetch, log });
+  const plugins = collectStandardPlugins(sourceRoot);
+  if (plugins.length < STANDARD_PLUGIN_MIN_COUNT) {
+    throw new Error(`standard plugin source is incomplete: found ${plugins.length}, expected at least ${STANDARD_PLUGIN_MIN_COUNT}`);
+  }
+
+  let installed = 0;
+  let replaced = 0;
+  let skipped = 0;
+  if (!options.dryRun) mkdirSync(pluginDir, { recursive: true });
+
+  for (const plugin of plugins) {
+    const dest = join(pluginDir, plugin.name);
+    let replace = false;
+    if (pathExistsOrSymlink(dest)) {
+      if (isBrokenSymlink(dest) || !validInstalledPlugin(dest)) replace = true;
+      else if (options.force && lstatSync(dest).isSymbolicLink()) replace = true;
+      else {
+        skipped++;
+        continue;
+      }
+    }
+    if (options.dryRun) {
+      if (replace) replaced++; else installed++;
+      continue;
+    }
+    if (replace) {
+      try { unlinkSync(dest); } catch {
+        throw new Error(`cannot replace existing non-symlink plugin '${plugin.name}' at ${dest}; remove it or pass a clean plugin dir`);
+      }
+      replaced++;
+    } else {
+      installed++;
+    }
+    symlinkSync(relativeSymlinkTarget(dest, plugin.dir), dest, "dir");
+  }
+
+  log(`${options.dryRun ? "would install" : "installed"} standard plugins: ${installed} new, ${replaced} replaced, ${skipped} kept → ${pluginDir}`);
+  log(`source: ${sourceRoot}`);
+  return { pluginDir, sourceRoot, installed, replaced, skipped, totalStandard: plugins.length, dryRun: !!options.dryRun };
+}
+
+export function formatStandardPluginHint(): string {
+  return "Run: maw plugin install --standard  (or: maw wtf --fix)";
+}

--- a/test/cmd-update-runtime-coverage.test.ts
+++ b/test/cmd-update-runtime-coverage.test.ts
@@ -290,6 +290,7 @@ describe("cmd-update runtime coverage", () => {
       ["curl", "-fsSL", "-o", mawBin, "https://github.com/Soul-Brews-Studio/maw-js/releases/download/v26.5.16-alpha.1053/maw"],
       ["chmod", "+x", mawBin],
       ["maw", "--version"],
+      ["maw", "plugin", "install", "--standard", "--ref", "v26.5.16-alpha.1053"],
     ]);
     expect(execSyncCalls).toContain(`cd ${cloneDir} && bun link`);
     expect(execSyncCalls).toContain(`cd ${join(homeDir, ".maw", "oracle-plugins")} && bun link maw`);

--- a/test/isolated/cmd-update-fifth-pass-coverage.test.ts
+++ b/test/isolated/cmd-update-fifth-pass-coverage.test.ts
@@ -339,6 +339,7 @@ describe("cmd-update fifth-pass runtime branches", () => {
       ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#main"],
       ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#main"],
       ["maw", "--version"],
+      ["maw", "plugin", "install", "--standard", "--ref", "main"],
     ]);
     const crashStashes = _fs.readdirSync(dirname(mawBin)).filter((entry) => entry.startsWith("maw.prev.crash."));
     expect(crashStashes).toHaveLength(1);
@@ -361,6 +362,7 @@ describe("cmd-update fifth-pass runtime branches", () => {
       ["curl", "-fsSL", "-o", mawBin, "https://github.com/Soul-Brews-Studio/maw-js/releases/download/v26.5.16-alpha.1053/maw"],
       ["chmod", "+x", mawBin],
       ["maw", "--version"],
+      ["maw", "plugin", "install", "--standard", "--ref", "v26.5.16-alpha.1053"],
     ]);
     expect(res.stderr).not.toContain("first install attempt failed");
     expect(res.stdout).toContain("installed release binary");
@@ -404,6 +406,7 @@ describe("cmd-update fifth-pass runtime branches", () => {
     expect(res.code).toBeUndefined();
     expect(spawnCalls).toEqual([
       ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#main"],
+      ["maw", "plugin", "install", "--standard", "--ref", "main"],
     ]);
     expect(execSyncCalls).toContain("maw --version");
     expect(res.stdout).toContain("✅ done");

--- a/test/isolated/cmd-update-seventh-pass-coverage.test.ts
+++ b/test/isolated/cmd-update-seventh-pass-coverage.test.ts
@@ -345,6 +345,7 @@ describe("cmd-update seventh-pass focused branch coverage", () => {
       ["curl", "-fsSL", "-o", mawBin, "https://github.com/Soul-Brews-Studio/maw-js/releases/download/v26.5.16-alpha.1053/maw"],
       ["chmod", "+x", mawBin],
       ["maw", "--version"],
+      ["maw", "plugin", "install", "--standard", "--ref", "v26.5.16-alpha.1053"],
     ]);
     expect(execSyncCalls).toContain(`cd ${cloneDir} && bun link`);
     expect(execSyncCalls).toContain(`cd ${join(homeDir, ".maw", "oracle-plugins")} && bun link maw`);

--- a/test/isolated/cmd-update-sixth-pass-coverage.test.ts
+++ b/test/isolated/cmd-update-sixth-pass-coverage.test.ts
@@ -233,6 +233,7 @@ describe("cmd-update sixth-pass retry cleanup coverage", () => {
       ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#main"],
       ["bun", "add", "-g", "github:Soul-Brews-Studio/maw-js#main"],
       ["maw", "--version"],
+      ["maw", "plugin", "install", "--standard", "--ref", "main"],
     ]);
     expect(execSyncCalls).toContain("maw --version");
     expect(res.stderr).toContain("first install attempt failed");

--- a/test/preflight-default.test.ts
+++ b/test/preflight-default.test.ts
@@ -16,6 +16,7 @@ interface HarnessOptions {
   paneInfos?: Record<string, { command: string; cwd?: string }>;
   config?: Partial<MawConfig>;
   agentCommands?: Set<string>;
+  standardPluginMinimum?: number;
 }
 
 function makeHarness(options: HarnessOptions = {}) {
@@ -71,6 +72,7 @@ function makeHarness(options: HarnessOptions = {}) {
       },
     },
     log: (...args: unknown[]) => { logs.push(args.map(String).join(" ")); },
+    standardPluginMinimum: options.standardPluginMinimum ?? 0,
   });
 
   async function run(fix = false) {
@@ -148,6 +150,24 @@ describe("cmdPreflight", () => {
     expect(text).toContain("sessions: 1 (1 agents alive)");
     expect(text).toContain("config: node=m5, engines=[codex]");
     expect(text).toContain("4 pass, 0 fail");
+  });
+
+
+  test("suspiciously low standard plugin count is not green", async () => {
+    const h = makeHarness({
+      entries: ["paperclip-assign"],
+      symlinks: { "paperclip-assign": false },
+      exists: { "paperclip-assign": true },
+      config: {},
+      standardPluginMinimum: 50,
+    });
+
+    await h.run(false);
+
+    const text = out(h.logs);
+    expect(text).toContain("standard plugins low: 1 loaded");
+    expect(text).toContain("maw plugin install --standard");
+    expect(text).toContain("2 pass, 1 fail");
   });
 
   test("missing plugin directory and no sessions produce fail-soft summary", async () => {

--- a/test/route-tools-default.test.ts
+++ b/test/route-tools-default.test.ts
@@ -218,6 +218,37 @@ describe("routeTools default-suite seams", () => {
     expect(h.calls.audits).toEqual([["5"]]);
   });
 
+  test("plugin install --standard is handled as a bare-binary core bootstrap", async () => {
+    const h = harness({ lifecycleExists: "none" });
+    const original = process.env.MAW_PLUGINS_DIR;
+    const originalSource = process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT;
+    const root = await import("fs").then(({ mkdtempSync }) => mkdtempSync("/tmp/maw-route-standard-"));
+    try {
+      const { mkdirSync, writeFileSync, rmSync, readdirSync } = await import("fs");
+      const { join } = await import("path");
+      const sourceRoot = join(root, "maw-js");
+      const pluginDir = join(root, "plugins");
+      mkdirSync(join(sourceRoot, "src", "vendor", "mpr-plugins"), { recursive: true });
+      writeFileSync(join(sourceRoot, "package.json"), JSON.stringify({ name: "maw-js" }));
+      for (let i = 0; i < 50; i++) {
+        const name = `std-${i}`;
+        const dir = join(sourceRoot, "src", "vendor", "mpr-plugins", name);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "plugin.json"), JSON.stringify({ name, version: "1.0.0", sdk: "^1.0.0" }));
+        writeFileSync(join(dir, "index.ts"), "export default async () => ({ ok: true });\n");
+      }
+      process.env.MAW_PLUGINS_DIR = pluginDir;
+      process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT = sourceRoot;
+      expect(await routeToolsWithDeps("plugin", ["plugin", "install", "--standard"], h.deps)).toBe(true);
+      expect(readdirSync(pluginDir).length).toBe(50);
+      expect(h.calls.invokes).toEqual([]);
+      rmSync(root, { recursive: true, force: true });
+    } finally {
+      if (original === undefined) delete process.env.MAW_PLUGINS_DIR; else process.env.MAW_PLUGINS_DIR = original;
+      if (originalSource === undefined) delete process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT; else process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT = originalSource;
+    }
+  });
+
   test("plugin lifecycle dispatch uses dev/home candidates, logs output, and fails loudly", async () => {
     const dev = harness({ lifecycleExists: "dev" });
     expect(await routeToolsWithDeps("plugin", ["plugin", "install", "demo"], dev.deps)).toBe(true);

--- a/test/standard-plugins-default.test.ts
+++ b/test/standard-plugins-default.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readlinkSync, rmSync, symlinkSync, writeFileSync, lstatSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { collectStandardPlugins, inspectStandardPluginHealth, installStandardPlugins, STANDARD_PLUGIN_MIN_COUNT } from "../src/commands/shared/standard-plugins";
+
+let root = "";
+let srcRoot = "";
+let pluginDir = "";
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "maw-standard-plugins-"));
+  srcRoot = join(root, "maw-js");
+  pluginDir = join(root, "plugins");
+  mkdirSync(join(srcRoot, "src", "commands", "plugins"), { recursive: true });
+  mkdirSync(join(srcRoot, "src", "vendor", "mpr-plugins"), { recursive: true });
+  mkdirSync(join(srcRoot, "src", "vendor-plugins"), { recursive: true });
+  writeFileSync(join(srcRoot, "package.json"), JSON.stringify({ name: "maw-js", version: "0.0.0-test" }));
+  for (let i = 0; i < STANDARD_PLUGIN_MIN_COUNT; i++) {
+    const lane = i % 3 === 0 ? ["src", "commands", "plugins"] : i % 3 === 1 ? ["src", "vendor", "mpr-plugins"] : ["src", "vendor-plugins"];
+    const name = `standard-${String(i).padStart(2, "0")}`;
+    const dir = join(srcRoot, ...lane, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "plugin.json"), JSON.stringify({ name, version: "1.0.0", sdk: "^1.0.0" }));
+    writeFileSync(join(dir, "index.ts"), "export default async () => ({ ok: true });\n");
+  }
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("standard plugin bootstrap", () => {
+  test("collects canonical standard plugins from all maw-js source lanes", () => {
+    const plugins = collectStandardPlugins(srcRoot);
+    expect(plugins).toHaveLength(STANDARD_PLUGIN_MIN_COUNT);
+    expect(plugins[0]?.name).toBe("standard-00");
+  });
+
+  test("installs relative symlinks into an empty plugin dir", async () => {
+    const logs: string[] = [];
+    const result = await installStandardPlugins({ sourceRoot: srcRoot, pluginDir, fetch: false, log: (line) => logs.push(line) });
+
+    expect(result.installed).toBe(STANDARD_PLUGIN_MIN_COUNT);
+    expect(result.replaced).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(inspectStandardPluginHealth(pluginDir).status).toBe("ok");
+    const link = join(pluginDir, "standard-00");
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(link).startsWith("/")).toBe(false);
+    expect(existsSync(join(link, "plugin.json"))).toBe(true);
+    expect(logs.join("\n")).toContain("installed standard plugins");
+  });
+
+  test("replaces dangling symlinks and keeps valid plugins by default", async () => {
+    mkdirSync(pluginDir, { recursive: true });
+    symlinkSync("/foreign/m5/path/standard-00", join(pluginDir, "standard-00"), "dir");
+    const valid = join(srcRoot, "src", "commands", "plugins", "standard-03");
+    symlinkSync(valid, join(pluginDir, "standard-03"), "dir");
+
+    const result = await installStandardPlugins({ sourceRoot: srcRoot, pluginDir, fetch: false, log: () => {} });
+
+    expect(result.replaced).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(existsSync(join(pluginDir, "standard-00", "plugin.json"))).toBe(true);
+    expect(readlinkSync(join(pluginDir, "standard-00")).startsWith("/")).toBe(false);
+  });
+
+  test("health flags missing and low plugin directories", () => {
+    expect(inspectStandardPluginHealth(join(root, "missing")).status).toBe("missing");
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(join(pluginDir, "one"), "not a plugin");
+    const health = inspectStandardPluginHealth(pluginDir);
+    expect(health.status).toBe("missing");
+    expect(health.count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add core bare-binary `maw plugin install --standard` bootstrap that resolves/fetches maw-js source and installs portable relative standard-plugin symlinks
- wire `maw update <ref|channel>` to run `maw plugin install --standard --ref <resolved-ref>` after the binary install so one command heals plugin-less hosts
- make `maw wtf`, `maw wtf --fix`, preflight, and unknown-command UX detect missing/low standard plugins
- repair dangling/foreign plugin symlinks without carrying absolute cross-machine paths forward

## Tests
- `bun test test/standard-plugins-default.test.ts test/preflight-default.test.ts test/route-tools-default.test.ts test/cmd-update-runtime-coverage.test.ts test/cmd-update-helpers.test.ts test/isolated/cmd-update-fifth-pass-coverage.test.ts test/isolated/cmd-update-sixth-pass-coverage.test.ts test/isolated/cmd-update-seventh-pass-coverage.test.ts`
- temp checkout-less-style `MAW_PLUGINS_DIR` smoke with `dist/maw plugin install --standard` restoring `attach`/`doctor`
- temp `installStandardPluginsAfterUpdate()` smoke through `dist/maw`
- `bun run test:default:safe`
- `bun run test:isolated`
- `bun run build`

Closes #2832
