### PR TITLE
release: v26.6.14-alpha.2024

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.14-alpha.1754",
+  "version": "26.6.14-alpha.2024",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Re-cut alpha publishing the standard-plugin bootstrap (#2833 / #2832).

- `maw plugin install --standard` (core, bare-binary bootstrap)
- `maw update <channel>` now heals plugin-less hosts in one command
- `maw wtf` / `--fix` / preflight detect missing standard plugins
- On merge → calver-release.yml cuts `v26.6.14-alpha.2024`

🤖 Generated with [Claude Code](https://claude.com/claude-code)