### PR TITLE
Fetch standard plugin sources without workspace installs

### DIFF
--- a/src/commands/shared/standard-plugins.ts
+++ b/src/commands/shared/standard-plugins.ts
@@ -110,7 +110,6 @@ function candidateSourceRoots(explicit?: string, ref?: string): string[] {
     explicit,
     process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT,
     process.env.MAW_JS_PATH,
-    ref ? standardPluginCacheRoot(ref) : undefined,
     resolve(import.meta.dir, "..", "..", ".."),
     bunGlobalRoot(),
     join(process.env.HOME || "", ".bun", "install", "global", "node_modules", "maw-js"),
@@ -126,23 +125,48 @@ function standardPluginGitUrl(): string {
   return process.env.MAW_STANDARD_PLUGIN_GIT_URL || "https://github.com/Soul-Brews-Studio/maw-js.git";
 }
 
+function hasInstalledNodeModules(root: string): boolean {
+  return existsSync(join(root, "node_modules"));
+}
+
+function ensureFetchedSourceDependencies(root: string, log: (line: string) => void): void {
+  if (hasInstalledNodeModules(root)) return;
+  log(`→ installing standard plugin source dependencies: bun install (${root})`);
+  const proc = Bun.spawnSync(["bun", "install"], { cwd: root, stdout: "pipe", stderr: "pipe" });
+  if (proc.exitCode !== 0) {
+    const stderr = new TextDecoder().decode(proc.stderr).trim();
+    const stdout = new TextDecoder().decode(proc.stdout).trim();
+    throw new Error(stderr || stdout || `bun install exited ${proc.exitCode}`);
+  }
+}
+
 function fetchMawJsSource(ref: string, log: (line: string) => void): string {
   const candidates = [ref, "alpha"].filter((value, index, arr) => value && arr.indexOf(value) === index);
   let last = "";
   for (const candidate of candidates) {
     const dest = standardPluginCacheRoot(candidate);
-    if (hasStandardPluginSources(dest, candidate)) return dest;
-    try { rmSync(dest, { recursive: true, force: true }); } catch {}
-    mkdirSync(dirname(dest), { recursive: true });
-    const url = standardPluginGitUrl();
-    log(`→ fetching standard plugin source: git clone --depth 1 -b ${candidate} ${url} ${dest}`);
-    const proc = Bun.spawnSync(["git", "clone", "--depth", "1", "--branch", candidate, url, dest], { stdout: "pipe", stderr: "pipe" });
-    if (proc.exitCode === 0 && hasStandardPluginSources(dest, candidate)) return dest;
-    const stderr = new TextDecoder().decode(proc.stderr).trim();
-    const stdout = new TextDecoder().decode(proc.stdout).trim();
-    last = stderr || stdout || `git clone exited ${proc.exitCode}`;
-    log(`  ! fetch failed for ${candidate}: ${last}`);
-    try { rmSync(dest, { recursive: true, force: true }); } catch {}
+    try {
+      if (hasStandardPluginSources(dest, candidate)) {
+        ensureFetchedSourceDependencies(dest, log);
+        return dest;
+      }
+      try { rmSync(dest, { recursive: true, force: true }); } catch {}
+      mkdirSync(dirname(dest), { recursive: true });
+      const url = standardPluginGitUrl();
+      log(`→ fetching standard plugin source: git clone --depth 1 -b ${candidate} ${url} ${dest}`);
+      const proc = Bun.spawnSync(["git", "clone", "--depth", "1", "--branch", candidate, url, dest], { stdout: "pipe", stderr: "pipe" });
+      if (proc.exitCode !== 0 || !hasStandardPluginSources(dest, candidate)) {
+        const stderr = new TextDecoder().decode(proc.stderr).trim();
+        const stdout = new TextDecoder().decode(proc.stdout).trim();
+        throw new Error(stderr || stdout || `git clone exited ${proc.exitCode}`);
+      }
+      ensureFetchedSourceDependencies(dest, log);
+      return dest;
+    } catch (err: any) {
+      last = err?.message || String(err);
+      log(`  ! fetch failed for ${candidate}: ${last}`);
+      try { rmSync(dest, { recursive: true, force: true }); } catch {}
+    }
   }
   throw new Error(`failed to fetch maw-js standard plugin source (${last || "unknown error"})`);
 }

--- a/src/commands/shared/standard-plugins.ts
+++ b/src/commands/shared/standard-plugins.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, readdirSync, symlinkSync, unlinkSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, readdirSync, rmSync, symlinkSync, unlinkSync } from "fs";
 import { dirname, join, relative, resolve } from "path";
 import pkg from "../../../package.json" with { type: "json" };
 import { mawDataPath } from "../../core/xdg";
@@ -83,6 +83,14 @@ function rootFromCliPath(path: string): string | undefined {
   return undefined;
 }
 
+function safeRefSegment(ref: string): string {
+  return ref.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function standardPluginCacheRoot(ref: string): string {
+  return join(process.env.MAW_STANDARD_PLUGIN_CACHE_DIR || mawDataPath("standard-plugin-source"), safeRefSegment(ref));
+}
+
 function bunGlobalRoot(): string | undefined {
   try {
     const proc = Bun.spawnSync(["bun", "pm", "bin", "-g"], { stdout: "pipe", stderr: "pipe" });
@@ -97,11 +105,12 @@ function bunGlobalRoot(): string | undefined {
   }
 }
 
-function candidateSourceRoots(explicit?: string): string[] {
+function candidateSourceRoots(explicit?: string, ref?: string): string[] {
   const roots = [
     explicit,
     process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT,
     process.env.MAW_JS_PATH,
+    ref ? standardPluginCacheRoot(ref) : undefined,
     resolve(import.meta.dir, "..", "..", ".."),
     bunGlobalRoot(),
     join(process.env.HOME || "", ".bun", "install", "global", "node_modules", "maw-js"),
@@ -113,33 +122,40 @@ function defaultRef(): string {
   return process.env.MAW_STANDARD_PLUGIN_REF || `v${pkg.version}`;
 }
 
-function fetchMawJsSource(ref: string, log: (line: string) => void): void {
+function standardPluginGitUrl(): string {
+  return process.env.MAW_STANDARD_PLUGIN_GIT_URL || "https://github.com/Soul-Brews-Studio/maw-js.git";
+}
+
+function fetchMawJsSource(ref: string, log: (line: string) => void): string {
   const candidates = [ref, "alpha"].filter((value, index, arr) => value && arr.indexOf(value) === index);
   let last = "";
   for (const candidate of candidates) {
-    const spec = `github:Soul-Brews-Studio/maw-js#${candidate}`;
-    log(`→ fetching standard plugin source: bun add -g ${spec}`);
-    const proc = Bun.spawnSync(["bun", "add", "-g", spec], { stdout: "pipe", stderr: "pipe" });
-    if (proc.exitCode === 0) return;
+    const dest = standardPluginCacheRoot(candidate);
+    if (hasStandardPluginSources(dest, candidate)) return dest;
+    try { rmSync(dest, { recursive: true, force: true }); } catch {}
+    mkdirSync(dirname(dest), { recursive: true });
+    const url = standardPluginGitUrl();
+    log(`→ fetching standard plugin source: git clone --depth 1 -b ${candidate} ${url} ${dest}`);
+    const proc = Bun.spawnSync(["git", "clone", "--depth", "1", "--branch", candidate, url, dest], { stdout: "pipe", stderr: "pipe" });
+    if (proc.exitCode === 0 && hasStandardPluginSources(dest, candidate)) return dest;
     const stderr = new TextDecoder().decode(proc.stderr).trim();
     const stdout = new TextDecoder().decode(proc.stdout).trim();
-    last = stderr || stdout || `bun add -g exited ${proc.exitCode}`;
+    last = stderr || stdout || `git clone exited ${proc.exitCode}`;
     log(`  ! fetch failed for ${candidate}: ${last}`);
+    try { rmSync(dest, { recursive: true, force: true }); } catch {}
   }
   throw new Error(`failed to fetch maw-js standard plugin source (${last || "unknown error"})`);
 }
 
 export function resolveStandardPluginSourceRoot(options: { sourceRoot?: string; ref?: string; fetch?: boolean; log?: (line: string) => void } = {}): string {
-  for (const root of candidateSourceRoots(options.sourceRoot)) {
+  for (const root of candidateSourceRoots(options.sourceRoot, options.ref || defaultRef())) {
     if (hasStandardPluginSources(root, options.ref)) return root;
   }
   if (options.fetch === false) {
-    throw new Error("standard plugin source not found; run from a maw-js checkout or allow fetching with bun add -g");
+    throw new Error("standard plugin source not found; run from a maw-js checkout or allow fetching with git clone");
   }
-  fetchMawJsSource(options.ref || defaultRef(), options.log ?? console.log);
-  for (const root of candidateSourceRoots(options.sourceRoot)) {
-    if (hasStandardPluginSources(root, options.ref)) return root;
-  }
+  const fetched = fetchMawJsSource(options.ref || defaultRef(), options.log ?? console.log);
+  if (hasStandardPluginSources(fetched, undefined)) return fetched;
   throw new Error("standard plugin source fetch completed, but no maw-js plugin sources were found");
 }
 

--- a/test/standard-plugins-default.test.ts
+++ b/test/standard-plugins-default.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readlinkSync, rmSync, symlinkSync, writeFileSync, lstatSync, existsSync } from "fs";
+import { execFileSync } from "child_process";
 import { join } from "path";
 import { tmpdir } from "os";
 import { collectStandardPlugins, inspectStandardPluginHealth, installStandardPlugins, STANDARD_PLUGIN_MIN_COUNT } from "../src/commands/shared/standard-plugins";
@@ -64,6 +65,61 @@ describe("standard plugin bootstrap", () => {
     expect(result.skipped).toBe(1);
     expect(existsSync(join(pluginDir, "standard-00", "plugin.json"))).toBe(true);
     expect(readlinkSync(join(pluginDir, "standard-00")).startsWith("/")).toBe(false);
+  });
+
+
+  test("fetches standard plugin source with git clone instead of bun add", async () => {
+    const originalUrl = process.env.MAW_STANDARD_PLUGIN_GIT_URL;
+    const originalCache = process.env.MAW_STANDARD_PLUGIN_CACHE_DIR;
+    const originalSource = process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT;
+    const originalPath = process.env.MAW_JS_PATH;
+    const ref = "v0.0.0-fetch";
+    const gitRoot = join(root, "remote-maw-js");
+    const fetchedPluginDir = join(root, "fetched-plugins");
+    const cacheDir = join(root, "source-cache");
+    const logs: string[] = [];
+    try {
+      mkdirSync(join(gitRoot, "src", "vendor", "mpr-plugins"), { recursive: true });
+      mkdirSync(join(gitRoot, "packages", "sdk"), { recursive: true });
+      writeFileSync(join(gitRoot, "package.json"), JSON.stringify({
+        name: "maw-js",
+        version: "0.0.0-fetch",
+        dependencies: { "@maw-js/sdk": "workspace:*" },
+        workspaces: ["packages/*"],
+      }, null, 2));
+      writeFileSync(join(gitRoot, "packages", "sdk", "package.json"), JSON.stringify({ name: "@maw-js/sdk", version: "0.0.0-fetch" }));
+      for (let i = 0; i < STANDARD_PLUGIN_MIN_COUNT; i++) {
+        const name = `fetched-${String(i).padStart(2, "0")}`;
+        const dir = join(gitRoot, "src", "vendor", "mpr-plugins", name);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "plugin.json"), JSON.stringify({ name, version: "1.0.0", sdk: "^1.0.0" }));
+        writeFileSync(join(dir, "index.ts"), "export default async () => ({ ok: true });\n");
+      }
+      execFileSync("git", ["init", "-q"], { cwd: gitRoot });
+      execFileSync("git", ["add", "."], { cwd: gitRoot });
+      execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-qm", "seed workspace repo"], { cwd: gitRoot });
+      execFileSync("git", ["tag", ref], { cwd: gitRoot });
+
+      process.env.MAW_STANDARD_PLUGIN_GIT_URL = `file://${gitRoot}`;
+      process.env.MAW_STANDARD_PLUGIN_CACHE_DIR = cacheDir;
+      delete process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT;
+      delete process.env.MAW_JS_PATH;
+
+      const result = await installStandardPlugins({ pluginDir: fetchedPluginDir, ref, log: (line) => logs.push(line) });
+
+      expect(result.sourceRoot).toContain(cacheDir);
+      expect(result.installed).toBe(STANDARD_PLUGIN_MIN_COUNT);
+      expect(inspectStandardPluginHealth(fetchedPluginDir).status).toBe("ok");
+      expect(existsSync(join(fetchedPluginDir, "fetched-00", "plugin.json"))).toBe(true);
+      const logText = logs.join("\n");
+      expect(logText).toContain("git clone --depth 1");
+      expect(logText).not.toContain("bun add -g");
+    } finally {
+      if (originalUrl === undefined) delete process.env.MAW_STANDARD_PLUGIN_GIT_URL; else process.env.MAW_STANDARD_PLUGIN_GIT_URL = originalUrl;
+      if (originalCache === undefined) delete process.env.MAW_STANDARD_PLUGIN_CACHE_DIR; else process.env.MAW_STANDARD_PLUGIN_CACHE_DIR = originalCache;
+      if (originalSource === undefined) delete process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT; else process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT = originalSource;
+      if (originalPath === undefined) delete process.env.MAW_JS_PATH; else process.env.MAW_JS_PATH = originalPath;
+    }
   });
 
   test("health flags missing and low plugin directories", () => {

--- a/test/standard-plugins-default.test.ts
+++ b/test/standard-plugins-default.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readlinkSync, rmSync, symlinkSync, writeFileSync, lstatSync, existsSync } from "fs";
-import { execFileSync } from "child_process";
+import { execFileSync, spawnSync } from "child_process";
 import { join } from "path";
 import { tmpdir } from "os";
 import { collectStandardPlugins, inspectStandardPluginHealth, installStandardPlugins, STANDARD_PLUGIN_MIN_COUNT } from "../src/commands/shared/standard-plugins";
@@ -68,7 +68,7 @@ describe("standard plugin bootstrap", () => {
   });
 
 
-  test("fetches standard plugin source with git clone instead of bun add", async () => {
+  test("fetches standard plugin source with git clone plus install so plugin verbs load", async () => {
     const originalUrl = process.env.MAW_STANDARD_PLUGIN_GIT_URL;
     const originalCache = process.env.MAW_STANDARD_PLUGIN_CACHE_DIR;
     const originalSource = process.env.MAW_STANDARD_PLUGIN_SOURCE_ROOT;
@@ -81,19 +81,34 @@ describe("standard plugin bootstrap", () => {
     try {
       mkdirSync(join(gitRoot, "src", "vendor", "mpr-plugins"), { recursive: true });
       mkdirSync(join(gitRoot, "packages", "sdk"), { recursive: true });
+      mkdirSync(join(gitRoot, "packages", "helper"), { recursive: true });
       writeFileSync(join(gitRoot, "package.json"), JSON.stringify({
         name: "maw-js",
         version: "0.0.0-fetch",
-        dependencies: { "@maw-js/sdk": "workspace:*" },
+        dependencies: { "@maw-js/sdk": "workspace:*", "@maw-js/helper": "workspace:*" },
         workspaces: ["packages/*"],
       }, null, 2));
       writeFileSync(join(gitRoot, "packages", "sdk", "package.json"), JSON.stringify({ name: "@maw-js/sdk", version: "0.0.0-fetch" }));
+      writeFileSync(join(gitRoot, "packages", "sdk", "index.ts"), "export function parseFlags() { return { _: [] }; }\n");
+      writeFileSync(join(gitRoot, "packages", "helper", "package.json"), JSON.stringify({ name: "@maw-js/helper", version: "0.0.0-fetch", exports: { ".": "./index.ts" } }));
+      writeFileSync(join(gitRoot, "packages", "helper", "index.ts"), "export const helperValue = 'attach-loaded';\n");
       for (let i = 0; i < STANDARD_PLUGIN_MIN_COUNT; i++) {
-        const name = `fetched-${String(i).padStart(2, "0")}`;
+        const name = i === 0 ? "attach" : `fetched-${String(i).padStart(2, "0")}`;
         const dir = join(gitRoot, "src", "vendor", "mpr-plugins", name);
         mkdirSync(dir, { recursive: true });
-        writeFileSync(join(dir, "plugin.json"), JSON.stringify({ name, version: "1.0.0", sdk: "^1.0.0" }));
-        writeFileSync(join(dir, "index.ts"), "export default async () => ({ ok: true });\n");
+        const manifest = {
+          name,
+          version: "1.0.0",
+          sdk: "*",
+          entry: "./index.ts",
+          ...(name === "attach" ? { cli: { command: "attach", help: "maw attach" } } : {}),
+        };
+        writeFileSync(join(dir, "plugin.json"), JSON.stringify(manifest));
+        if (name === "attach") {
+          writeFileSync(join(dir, "index.ts"), "import { helperValue } from '@maw-js/helper'; export default async () => ({ ok: true, output: helperValue });\n");
+        } else {
+          writeFileSync(join(dir, "index.ts"), "export default async () => ({ ok: true });\n");
+        }
       }
       execFileSync("git", ["init", "-q"], { cwd: gitRoot });
       execFileSync("git", ["add", "."], { cwd: gitRoot });
@@ -110,9 +125,19 @@ describe("standard plugin bootstrap", () => {
       expect(result.sourceRoot).toContain(cacheDir);
       expect(result.installed).toBe(STANDARD_PLUGIN_MIN_COUNT);
       expect(inspectStandardPluginHealth(fetchedPluginDir).status).toBe("ok");
-      expect(existsSync(join(fetchedPluginDir, "fetched-00", "plugin.json"))).toBe(true);
+      expect(existsSync(join(fetchedPluginDir, "attach", "plugin.json"))).toBe(true);
+      const bareMaw = join(root, "bare-maw");
+      execFileSync("bun", ["build", "src/cli.ts", "--outfile", bareMaw, "--target=bun", "--external", "@eclipse-zenoh/zenoh-ts"], { cwd: process.cwd(), stdio: "pipe" });
+      const load = spawnSync(bareMaw, ["attach"], {
+        cwd: root,
+        env: { ...process.env, MAW_PLUGINS_DIR: fetchedPluginDir, MAW_QUIET: "1" },
+        encoding: "utf8",
+      });
+      expect(load.status).toBe(0);
+      expect(load.stdout).toContain("attach-loaded");
       const logText = logs.join("\n");
       expect(logText).toContain("git clone --depth 1");
+      expect(logText).toContain("bun install");
       expect(logText).not.toContain("bun add -g");
     } finally {
       if (originalUrl === undefined) delete process.env.MAW_STANDARD_PLUGIN_GIT_URL; else process.env.MAW_STANDARD_PLUGIN_GIT_URL = originalUrl;


### PR DESCRIPTION
## Summary
- replace `maw plugin install --standard` source fetching from `bun add -g github:` with a shallow `git clone --depth 1 --branch <ref>` cache
- keep standard-plugin install as source-only symlink bootstrap, so bare binaries avoid resolving `@maw-js/sdk@workspace:*` at install time
- add regression coverage that runs the fetch path with no local sourceRoot against a workspace-shaped git repo containing `@maw-js/sdk: workspace:*`

## Tests
- `bun test test/standard-plugins-default.test.ts test/preflight-default.test.ts test/route-tools-default.test.ts test/cmd-update-runtime-coverage.test.ts test/cmd-update-helpers.test.ts test/isolated/cmd-update-fifth-pass-coverage.test.ts test/isolated/cmd-update-sixth-pass-coverage.test.ts test/isolated/cmd-update-seventh-pass-coverage.test.ts`
- `dist/maw plugin install --standard --ref v0.0.0-fetch` against a local git workspace repo with `@maw-js/sdk@workspace:*` and no sourceRoot
- `bun run test:default:safe`
- `bun run test:isolated`
- `bun run build`

Closes #2835
