### PR TITLE
release: v26.6.14-alpha.2110

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maw-js",
-  "version": "26.6.14-alpha.2024",
+  "version": "26.6.14-alpha.2110",
   "license": "BUSL-1.1",
   "repository": "Soul-Brews-Studio/maw-js",
   "type": "module",


### PR DESCRIPTION
Re-cut alpha: standard-plugin bootstrap now git clone + bun install (#2835/#2836). Verified clean-room on white: bare host → full plugin set + attach works. 🤖 Generated with Claude Code