### PR TITLE
feat(team): deliver team inbox handoff on team up (#2742)

### DIFF
--- a/src/vendor/mpr-plugins/team/team-helpers.ts
+++ b/src/vendor/mpr-plugins/team/team-helpers.ts
@@ -158,6 +158,62 @@ export function writeMessage(teamName: string, memberName: string, from: string,
   writeFileSync(inboxPath, JSON.stringify(messages, null, 2));
 }
 
+/** A single entry in a teammate's `inboxes/<role>.json` array. */
+export interface TeamInboxMessage {
+  from: string;
+  text?: string;
+  summary?: string;
+  timestamp?: string;
+  read?: boolean;
+}
+
+/**
+ * Read a teammate's inbox file (the single-file array written by
+ * {@link writeMessage} / {@link writeShutdownRequest} and the charter prep).
+ * Returns `[]` when the file is absent or malformed — never throws.
+ */
+export function readTeamMemberInbox(teamName: string, memberName: string): TeamInboxMessage[] {
+  const inboxPath = join(TEAMS_DIR, teamName, "inboxes", `${memberName}.json`);
+  if (!existsSync(inboxPath)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(inboxPath, "utf-8"));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Unread subset of {@link readTeamMemberInbox}. */
+export function readUnreadTeamMemberInbox(teamName: string, memberName: string): TeamInboxMessage[] {
+  return readTeamMemberInbox(teamName, memberName).filter((msg) => !msg.read);
+}
+
+/**
+ * Flip every unread message in a teammate's inbox to `read: true` and persist.
+ * Returns the number flipped (0 when the file is absent/malformed or already
+ * fully read). Used after a handoff has been delivered so it does not re-fire
+ * on the next `team up`.
+ */
+export function markTeamMemberInboxRead(teamName: string, memberName: string): number {
+  const inboxPath = join(TEAMS_DIR, teamName, "inboxes", `${memberName}.json`);
+  if (!existsSync(inboxPath)) return 0;
+  let messages: TeamInboxMessage[];
+  try {
+    const parsed = JSON.parse(readFileSync(inboxPath, "utf-8"));
+    if (!Array.isArray(parsed)) return 0;
+    messages = parsed;
+  } catch {
+    return 0;
+  }
+  let count = 0;
+  for (const msg of messages) {
+    if (!msg.read) { msg.read = true; count++; }
+  }
+  // lgtm[js/file-system-race] — PRIVATE-PATH: inbox under ~/.maw/teams/<team>/inboxes/, see docs/security/file-system-race-stance.md
+  if (count > 0) writeFileSync(inboxPath, JSON.stringify(messages, null, 2));
+  return count;
+}
+
 export function cleanupTeamDir(name: string) {
   const teamDir = join(TEAMS_DIR, name);
   const tasksDir = join(TASKS_DIR, name);

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -13,6 +13,7 @@ import type { WakeOptions } from "../../../commands/shared/wake-cmd";
 import { UserError } from "../../../core/util/user-error";
 import { cmdSend } from "../../../commands/shared/comm-send";
 import { TEAM_LIFECYCLE_GUARD_WINDOW } from "./team-down";
+import { readUnreadTeamMemberInbox, markTeamMemberInboxRead, type TeamInboxMessage } from "./team-helpers";
 import {
   classifyMember,
   memberEngine,
@@ -233,18 +234,69 @@ export function quickCharter(count: number, opts: { name?: string; engine?: stri
   };
 }
 
+const MAX_HANDOFF_SUMMARIES = 10;
+
+/**
+ * Render the bring-up handoff notice for a member's unread team inbox. Pure so
+ * it can be tested without tmux. Lists message summaries (sender-tagged) up to
+ * a cap, then an "N more" tail. Mirrors the single-oracle ψ/inbox wake notice:
+ * surface what is waiting without dumping full message bodies into the pane.
+ */
+export function formatTeamInboxHandoff(role: string, messages: TeamInboxMessage[]): string {
+  const count = messages.length;
+  const header = `📬 Team handoff — ${count} unread inbox message${count === 1 ? "" : "s"} for ${role} while the team was down:`;
+  const lines = messages.slice(0, MAX_HANDOFF_SUMMARIES).map((msg) => {
+    const from = (msg.from ?? "").trim();
+    const label = ((msg.summary ?? "").trim() || from || "message");
+    return from && label !== from ? `  - [${from}] ${label}` : `  - ${label}`;
+  });
+  const omitted = count - lines.length;
+  if (omitted > 0) lines.push(`  … ${omitted} more`);
+  return [header, ...lines].join("\n");
+}
+
+/**
+ * Read a member's unread team inbox (the per-role handoff written by
+ * `maw team send`/`shutdown`) and render the bring-up notice, or `undefined`
+ * when there is nothing waiting. Read-only and never throws — marking the
+ * messages read is the caller's job, after a successful send.
+ */
+function takeInboxHandoff(team: string, member: TeamCharter["members"][number]): string | undefined {
+  let unread: TeamInboxMessage[];
+  try {
+    unread = readUnreadTeamMemberInbox(team, member.role);
+  } catch {
+    return undefined;
+  }
+  return unread.length ? formatTeamInboxHandoff(member.role, unread) : undefined;
+}
+
+/**
+ * Prime a freshly woken member with its charter prompt and any unread team
+ * inbox handoff. Both are folded into a single send — mirroring how
+ * single-oracle wake merges the ψ/inbox notice into the wake prompt
+ * (mergeWakeInboxPrompt) — so the handoff never lands as a second injection
+ * into a pane the prompt just set working. The inbox is marked read only after
+ * the send succeeds, so a delivery failure leaves it pending for the next
+ * `team up`. A missing prompt file is still a hard error (resolvePrimingPrompt
+ * throws before the send), exactly as before.
+ */
 async function primeMember(
   member: TeamCharter["members"][number],
   session: string,
   repoRoot: string,
+  team: string,
   deps: Pick<TeamUpDeps, "cmdSendFn">,
   warnings: string[],
 ): Promise<void> {
   const prompt = resolvePrimingPrompt(member, repoRoot);
-  if (!prompt) return;
+  const handoff = takeInboxHandoff(team, member);
+  const message = [prompt, handoff].filter(Boolean).join("\n\n");
+  if (!message) return;
   const send = deps.cmdSendFn ?? cmdSend;
   try {
-    await send(memberPrimingTarget(session, member), prompt, false, { currentSession: session });
+    await send(memberPrimingTarget(session, member), message, false, { currentSession: session });
+    if (handoff) markTeamMemberInboxRead(team, member.role);
   } catch (error) {
     warnings.push(`prompt prime failed for ${member.role}: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -385,7 +437,12 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
   if (launchTasks.length > 0) {
     await Promise.all(launchTasks.map((task) => waitForNonShell(task.item.member, session, tmux, sleep, targetRepoSlug)));
     await sleep(promptDelayMs(charter));
-    await Promise.all(launchTasks.map((task) => primeMember(task.item.member, session, callerRepoRoot, deps, warnings)));
+    // #2742 — priming also folds in each woken member's pending team inbox so
+    // messages sent while the team was down are handed off on bring-up, not
+    // silently stranded in inboxes/<role>.json. Key by charter.name: that is
+    // where charter prep + `maw team send` write, and it can differ from the
+    // `team` argument (e.g. a charter file named after a node or alias).
+    await Promise.all(launchTasks.map((task) => primeMember(task.item.member, session, callerRepoRoot, charter.name, deps, warnings)));
   }
 
   const finalPanes = await listPaneSnapshots(tmux).catch(() => panes);

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -11,9 +11,10 @@ import { parseTeamCharterText } from "../../src/vendor/mpr-plugins/team/team-cha
 import { classifyMember, engineCommand, memberWakeOptions, memberWakeTarget, resolveCharterPath } from "../../src/vendor/mpr-plugins/team/team-liveness";
 import * as commandTeamLiveness from "../../src/commands/plugins/team/team-liveness";
 import * as vendorTeamLiveness from "../../src/vendor/mpr-plugins/team/team-liveness";
-import { cmdTeamUp, quickCharter } from "../../src/vendor/mpr-plugins/team/team-up";
+import { cmdTeamUp, quickCharter, formatTeamInboxHandoff } from "../../src/vendor/mpr-plugins/team/team-up";
 import { cmdTeamDown, TEAM_LIFECYCLE_GUARD_WINDOW } from "../../src/vendor/mpr-plugins/team/team-down";
 import { cmdTeamApply } from "../../src/vendor/mpr-plugins/team/team-apply";
+import { _setDirs, TEAMS_DIR, TASKS_DIR, readUnreadTeamMemberInbox, markTeamMemberInboxRead } from "../../src/vendor/mpr-plugins/team/team-helpers";
 import { isUserError } from "../../src/core/util/user-error";
 
 const dirs: string[] = [];
@@ -750,6 +751,221 @@ members:
     expect(engineCommand("omx", { resume: true }, config)).toBe("maw run omx-resume");
     expect(engineCommand("opus48", { engines: { opus48: ["claude --model opus", ["--dangerously-skip-permissions", "--channels plugin:discord"]] } }, config)).toBe("claude --model opus --dangerously-skip-permissions --channels plugin:discord");
     expect(engineCommand("opus48", { resume: true, engines: { "opus48-resume": ["claude --resume abc", ["--dangerously-skip-permissions"]] } }, config)).toBe("claude --resume abc --dangerously-skip-permissions");
+  });
+});
+
+describe("team inbox handoff on team up (#2742)", () => {
+  // _setDirs mutates the module-global TEAMS_DIR; capture + restore so the
+  // handoff store points at a temp dir per test and never leaks into the rest
+  // of the suite (or a real ~/.claude/teams on the dev machine).
+  const ORIG_TEAMS = TEAMS_DIR;
+  const ORIG_TASKS = TASKS_DIR;
+  afterEach(() => { _setDirs(ORIG_TEAMS, ORIG_TASKS); });
+
+  function seedTeamInbox(team: string, role: string, messages: unknown[]): void {
+    const teamsRoot = mkdtempSync(join(tmpdir(), "maw-team-store-"));
+    dirs.push(teamsRoot);
+    const inboxDir = join(teamsRoot, team, "inboxes");
+    mkdirSync(inboxDir, { recursive: true });
+    writeFileSync(join(inboxDir, `${role}.json`), JSON.stringify(messages, null, 2));
+    _setDirs(teamsRoot, join(teamsRoot, "tasks"));
+  }
+
+  function charterRepo(team: string): string {
+    const root = mkdtempSync(join(tmpdir(), "maw-inbox-up-"));
+    dirs.push(root);
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, ".maw", "teams"), { recursive: true });
+    writeFileSync(join(root, ".maw", "teams", `${team}.yaml`), `
+name: ${team}
+session: charter-session
+members:
+  - role: coder
+    engine: omx
+    worktree: true
+`, "utf-8");
+    return root;
+  }
+
+  function liveOnSecondPoll(pane: string) {
+    let listCalls = 0;
+    return {
+      run: async (...args: string[]) => {
+        if (args[0] === "display-message") return "lead-session\n";
+        if (args[0] === "list-panes") {
+          listCalls++;
+          return listCalls === 1 ? "" : pane;
+        }
+        return "";
+      },
+    };
+  }
+
+  test("readUnreadTeamMemberInbox returns only unread; markTeamMemberInboxRead flips them", () => {
+    seedTeamInbox("t", "m", [
+      { from: "a", summary: "one", read: false },
+      { from: "b", summary: "two", read: true },
+      { from: "c", summary: "three", read: false },
+    ]);
+
+    expect(readUnreadTeamMemberInbox("t", "m").map((msg) => msg.summary)).toEqual(["one", "three"]);
+    expect(markTeamMemberInboxRead("t", "m")).toBe(2);
+    expect(readUnreadTeamMemberInbox("t", "m")).toHaveLength(0);
+    expect(markTeamMemberInboxRead("t", "m")).toBe(0);
+    expect(readUnreadTeamMemberInbox("t", "absent-member")).toEqual([]);
+  });
+
+  test("formatTeamInboxHandoff summarizes unread messages with sender labels", () => {
+    const msg = formatTeamInboxHandoff("coder", [
+      { from: "lead", summary: "do the thing" },
+      { from: "reviewer", summary: "rebase first" },
+    ]);
+    expect(msg).toContain("2 unread");
+    expect(msg).toContain("coder");
+    expect(msg).toContain("[lead] do the thing");
+    expect(msg).toContain("[reviewer] rebase first");
+  });
+
+  test("team up delivers unread team inbox messages to a freshly woken member and marks them read", async () => {
+    const root = charterRepo("inboxteam");
+    seedTeamInbox("inboxteam", "coder", [
+      { from: "lead", text: "{}", summary: "finish the parser refactor", timestamp: "2026-06-15T10:00:00.000Z", read: false },
+      { from: "lead", text: "{}", summary: "already-seen note", timestamp: "2026-06-14T10:00:00.000Z", read: true },
+      { from: "reviewer", text: "{}", summary: "rebase onto alpha before pushing", timestamp: "2026-06-15T11:00:00.000Z", read: false },
+    ]);
+    const sends: any[] = [];
+
+    await cmdTeamUp("inboxteam", { session: "charter-session" }, {
+      cwd: root,
+      tmux: liveOnSecondPoll("charter-session|coder|omx|/wt/coder|%1"),
+      loadConfigFn: () => config,
+      cmdWakeFn: async () => "woke",
+      cmdSendFn: async (...a: any[]) => { sends.push(a); },
+      sleep: async () => {},
+      logger: () => {},
+    });
+
+    expect(sends).toHaveLength(1);
+    const [target, message] = sends[0];
+    expect(target).toBe("charter-session:coder");
+    expect(message).toContain("2 unread");
+    expect(message).toContain("finish the parser refactor");
+    expect(message).toContain("rebase onto alpha before pushing");
+    expect(message).not.toContain("already-seen note");
+
+    expect(readUnreadTeamMemberInbox("inboxteam", "coder")).toHaveLength(0);
+  });
+
+  test("priming prompt and inbox handoff are merged into a single send, not two injections", async () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-inbox-prime-"));
+    dirs.push(root);
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, ".maw", "teams"), { recursive: true });
+    writeFileSync(join(root, ".maw", "teams", "primeteam.yaml"), `
+name: primeteam
+session: charter-session
+members:
+  - role: coder
+    engine: omx
+    worktree: true
+    prompt: kick off the build
+`, "utf-8");
+    seedTeamInbox("primeteam", "coder", [
+      { from: "lead", summary: "merge this note", read: false },
+    ]);
+    const sends: any[] = [];
+
+    await cmdTeamUp("primeteam", { session: "charter-session" }, {
+      cwd: root,
+      tmux: liveOnSecondPoll("charter-session|coder|omx|/wt/coder|%1"),
+      loadConfigFn: () => config,
+      cmdWakeFn: async () => "woke",
+      cmdSendFn: async (...a: any[]) => { sends.push(a); },
+      sleep: async () => {},
+      logger: () => {},
+    });
+
+    expect(sends).toHaveLength(1);
+    const [, message] = sends[0];
+    expect(message).toContain("kick off the build");
+    expect(message).toContain("merge this note");
+    expect(message.indexOf("kick off the build")).toBeLessThan(message.indexOf("merge this note"));
+    expect(readUnreadTeamMemberInbox("primeteam", "coder")).toHaveLength(0);
+  });
+
+  test("inbox handoff is keyed by the charter name, not the team-up argument", async () => {
+    const root = mkdtempSync(join(tmpdir(), "maw-inbox-alias-"));
+    dirs.push(root);
+    mkdirSync(join(root, ".git"));
+    mkdirSync(join(root, ".maw", "teams"), { recursive: true });
+    // Charter file is found by the CLI arg (aliasteam.yaml) but its internal
+    // name — where charter prep + `maw team send` actually write inboxes — is realteam.
+    writeFileSync(join(root, ".maw", "teams", "aliasteam.yaml"), `
+name: realteam
+session: charter-session
+members:
+  - role: coder
+    engine: omx
+    worktree: true
+`, "utf-8");
+    seedTeamInbox("realteam", "coder", [
+      { from: "lead", summary: "keyed by charter name", read: false },
+    ]);
+    const sends: any[] = [];
+
+    await cmdTeamUp("aliasteam", { session: "charter-session" }, {
+      cwd: root,
+      tmux: liveOnSecondPoll("charter-session|coder|omx|/wt/coder|%1"),
+      loadConfigFn: () => config,
+      cmdWakeFn: async () => "woke",
+      cmdSendFn: async (...a: any[]) => { sends.push(a); },
+      sleep: async () => {},
+      logger: () => {},
+    });
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0][1]).toContain("keyed by charter name");
+    expect(readUnreadTeamMemberInbox("realteam", "coder")).toHaveLength(0);
+  });
+
+  test("team up does not deliver a handoff when the member inbox has no unread messages", async () => {
+    const root = charterRepo("emptyteam");
+    seedTeamInbox("emptyteam", "coder", [
+      { from: "lead", summary: "old news", read: true },
+    ]);
+    const sends: any[] = [];
+
+    await cmdTeamUp("emptyteam", { session: "charter-session" }, {
+      cwd: root,
+      tmux: liveOnSecondPoll("charter-session|coder|omx|/wt/coder|%1"),
+      loadConfigFn: () => config,
+      cmdWakeFn: async () => "woke",
+      cmdSendFn: async (...a: any[]) => { sends.push(a); },
+      sleep: async () => {},
+      logger: () => {},
+    });
+
+    expect(sends).toHaveLength(0);
+  });
+
+  test("team up --status does not deliver inbox handoff or mark messages read", async () => {
+    const root = charterRepo("inboxteam");
+    seedTeamInbox("inboxteam", "coder", [
+      { from: "lead", summary: "finish the parser refactor", read: false },
+      { from: "reviewer", summary: "rebase onto alpha before pushing", read: false },
+    ]);
+    const sends: any[] = [];
+
+    await cmdTeamUp("inboxteam", { status: true, session: "charter-session" }, {
+      cwd: root,
+      tmux: fakeTmux([]).tmux,
+      loadConfigFn: () => config,
+      cmdSendFn: async (...a: any[]) => { sends.push(a); },
+      logger: () => {},
+    });
+
+    expect(sends).toHaveLength(0);
+    expect(readUnreadTeamMemberInbox("inboxteam", "coder")).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
## Problem

`maw team up` woke each member and primed the charter prompt, but never touched any inbox. Messages written to a member's team inbox (`~/.claude/teams/<charter.name>/inboxes/<role>.json`, via `maw team send` / `maw team shutdown`) just piled up and were never handed off on bring-up — so "maw team never does a handoff."

## Fix

Priming now reads each **freshly-woken** member's unread team inbox and folds the handoff into the **same priming send** — mirroring how single-oracle wake merges the `ψ/inbox` notice via `mergeWakeInboxPrompt`. This avoids landing the handoff as a second injection into a pane the prompt just set working (the "busy pane" corruption the status-broker doc warns about). The inbox is marked read only **after** the send succeeds, so a delivery failure leaves it pending for the next `team up`.

- `team-helpers`: add `readTeamMemberInbox` / `readUnreadTeamMemberInbox` / `markTeamMemberInboxRead` for the single-file `<role>.json` store (it only had writers).
- `team-up`: `takeInboxHandoff` + pure `formatTeamInboxHandoff`; `primeMember` folds in the handoff and marks read post-send. Keyed by **`charter.name`** (where charter prep + `team send` write), which can differ from the `team up` argument.

## Scope notes

- Only freshly-woken members (missing/dead/force) get the handoff — already-live panes are left untouched.
- Out of scope: `maw team inbox <role>` (the read command) is wired only in the core dispatcher, not the vendored one that ships, and reads a *different* store (`inboxes/<agent>/*.json`) than where `team send` writes. That pre-existing inconsistency is why summaries are delivered inline rather than pointing at that command.

## Tests

7 new cases in `team-up-coverage.test.ts`: helper read/mark-read, pure formatting, delivery + mark-read, prompt/handoff merge into a single send, charter-name keying (vs the CLI arg), no-unread no-op, and `--status` no-op. Full file green on `alpha` (43 pass); `tsc --noEmit` clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)