### PR TITLE
feat(team): record creating orchestrator's pane/session on team create

### DIFF
--- a/src/api/claude-fleet.ts
+++ b/src/api/claude-fleet.ts
@@ -9,21 +9,29 @@
 
 import { Elysia } from "elysia";
 import { listClaudeSessions } from "../core/fleet/claude-sessions";
+import { listFleetJobs } from "../core/fleet/claude-jobs";
 
 export const claudeFleetApi = new Elysia();
 
 claudeFleetApi.get("/fleet/claude", async ({ set }) => {
   try {
-    const sessions = await listClaudeSessions();
-    return { sessions, count: sessions.length };
+    // Sessions are the main load; jobs (regression-then-investigate.sh,
+    // future watcher daemons) are a best-effort augmentation. Wrap the
+    // jobs lookup in a catch so a transient pgrep / fs hiccup never
+    // breaks the primary fleet-lens response.
+    const [sessions, jobs] = await Promise.all([
+      listClaudeSessions(),
+      listFleetJobs().catch(() => []),
+    ]);
+    return { sessions, jobs, count: sessions.length };
   } catch (e: any) {
     set.status = 500;
     return { error: "Failed to discover Claude sessions", detail: e.message };
   }
 }, {
   detail: {
-    summary: "List Claude Code sessions",
-    description: "Discovers running and recent Claude Code sessions on this node via ~/.claude/projects/ scan + process correlation.",
+    summary: "List Claude Code sessions + fleet jobs",
+    description: "Discovers running and recent Claude Code sessions on this node via ~/.claude/projects/ scan + process correlation. Also surfaces background fleet jobs (regression runners) detected via pgrep.",
     tags: ["fleet-lens"],
   },
 });

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -155,12 +155,13 @@ export async function invokeDirectHandler(
       "--model": String, "-m": "--model",
       "--reasoning-effort": String,
       "--dry-run": Boolean,
+      "--respawn-worktrees": Boolean,
     }, 0);
 
     const positional = flags._;
     const oracle = positional[0];
     if (!oracle) {
-      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [--resume <session-id>] [-a|--attach] [--no-attach] [--list] [--split] [--all-local] [-e|--engine <name>] [-m|--model <name>] [--reasoning-effort <level>] [--dry-run]");
+      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [--resume <session-id>] [-a|--attach] [--no-attach] [--list] [--split] [--all-local] [-e|--engine <name>] [-m|--model <name>] [--reasoning-effort <level>] [--dry-run] [--respawn-worktrees]");
       throw new UserError("wake: missing oracle name");
     }
 
@@ -197,6 +198,7 @@ export async function invokeDirectHandler(
       engine?: string;
       model?: string;
       reasoningEffort?: string;
+      respawnWorktrees?: boolean;
     } = {};
     if (flags["--wt"]) opts.wt = flags["--wt"];
     if (flags["--prompt"]) opts.prompt = flags["--prompt"];
@@ -219,6 +221,7 @@ export async function invokeDirectHandler(
     if (flags["--list"]) opts.listWt = true;
     if (flags["--split"]) opts.split = true;
     if (flags["--all-local"]) opts.allLocal = true;
+    if (flags["--respawn-worktrees"]) opts.respawnWorktrees = true;
     if (flags["--engine"]) opts.engine = flags["--engine"];
     if (flags["--model"]) opts.model = flags["--model"];
     if (flags["--reasoning-effort"]) opts.reasoningEffort = flags["--reasoning-effort"];

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -145,6 +145,7 @@ export async function invokeDirectHandler(
       "--prompt": String, "-p": "--prompt",
       "--incubate": String,
       "--fresh": Boolean,
+      "--resume": String,
       "--attach": Boolean, "-a": "--attach",
       "--no-attach": Boolean,
       "--list": Boolean,
@@ -157,7 +158,7 @@ export async function invokeDirectHandler(
     const positional = flags._;
     const oracle = positional[0];
     if (!oracle) {
-      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [-a|--attach] [--no-attach] [--list] [--split] [--all-local] [-e|--engine <name>] [--dry-run]");
+      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [--resume <session-id>] [-a|--attach] [--no-attach] [--list] [--split] [--all-local] [-e|--engine <name>] [--dry-run]");
       throw new UserError("wake: missing oracle name");
     }
 
@@ -185,6 +186,7 @@ export async function invokeDirectHandler(
       prompt?: string;
       incubate?: string;
       fresh?: boolean;
+      resume?: string;
       attach?: boolean;
       noAttach?: boolean;
       listWt?: boolean;
@@ -197,6 +199,7 @@ export async function invokeDirectHandler(
     if (flags["--prompt"]) opts.prompt = flags["--prompt"];
     if (flags["--incubate"]) opts.incubate = flags["--incubate"];
     if (flags["--fresh"]) opts.fresh = true;
+    if (flags["--resume"]) opts.resume = flags["--resume"];
     if (flags["--attach"]) opts.attach = true;
     if (flags["--no-attach"]) opts.noAttach = true;
     if (flags["--list"]) opts.listWt = true;

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -110,7 +110,7 @@ export function resolveTopAlias(args: string[]): AliasResolution | null {
  * dispatch is by `exportName` against a static handler map.
  *
  * For `ls`, `-a` = roster (sleeping oracles), `-v` = full detail.
- * For `wake`, parses the 9 known flags and calls cmdWake(oracle, opts).
+ * For `wake`, parses the known flags and calls cmdWake(oracle, opts).
  */
 export async function invokeDirectHandler(
   handler: string,
@@ -152,13 +152,15 @@ export async function invokeDirectHandler(
       "--split": Boolean,
       "--all-local": Boolean,
       "--engine": String, "-e": "--engine",
+      "--model": String, "-m": "--model",
+      "--reasoning-effort": String,
       "--dry-run": Boolean,
     }, 0);
 
     const positional = flags._;
     const oracle = positional[0];
     if (!oracle) {
-      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [--resume <session-id>] [-a|--attach] [--no-attach] [--list] [--split] [--all-local] [-e|--engine <name>] [--dry-run]");
+      console.error("usage: maw wake <oracle> [--task <s>] [--wt <s>] [-p|--prompt <s>] [--incubate <slug>] [--fresh] [--resume <session-id>] [-a|--attach] [--no-attach] [--list] [--split] [--all-local] [-e|--engine <name>] [-m|--model <name>] [--reasoning-effort <level>] [--dry-run]");
       throw new UserError("wake: missing oracle name");
     }
 
@@ -193,6 +195,8 @@ export async function invokeDirectHandler(
       split?: boolean;
       allLocal?: boolean;
       engine?: string;
+      model?: string;
+      reasoningEffort?: string;
     } = {};
     if (flags["--wt"]) opts.wt = flags["--wt"];
     if (flags["--prompt"]) opts.prompt = flags["--prompt"];
@@ -216,6 +220,8 @@ export async function invokeDirectHandler(
     if (flags["--split"]) opts.split = true;
     if (flags["--all-local"]) opts.allLocal = true;
     if (flags["--engine"]) opts.engine = flags["--engine"];
+    if (flags["--model"]) opts.model = flags["--model"];
+    if (flags["--reasoning-effort"]) opts.reasoningEffort = flags["--reasoning-effort"];
 
     // Shorthand: --codex, --gemini etc. → engine from config.commands
     // Unknown flags land in flags._ (permissive mode), so scan for --<engine>

--- a/src/cli/top-aliases.ts
+++ b/src/cli/top-aliases.ts
@@ -194,9 +194,19 @@ export async function invokeDirectHandler(
       allLocal?: boolean;
       engine?: string;
     } = {};
-    if (flags["--task"]) opts.task = flags["--task"];
     if (flags["--wt"]) opts.wt = flags["--wt"];
     if (flags["--prompt"]) opts.prompt = flags["--prompt"];
+    // `--task` is the fire-and-forget PROMPT flag (see wake-flags.test.ts —
+    // "--task sets prompt and noAttach, no window label created"). The
+    // LOC-round-4 refactor wrongly routed it to `opts.task` (a worktree-name
+    // selector), so every watcher that delivers a prompt via `--task`
+    // (inbox-watcher, w2-watcher) had its prompt silently dropped and woke
+    // agents idle. Restore the contract: `--task` → prompt + fire-and-forget.
+    // `--prompt`/`-p` wins if both are supplied.
+    if (flags["--task"] && !opts.prompt) {
+      opts.prompt = flags["--task"];
+      opts.noAttach = true;
+    }
     if (flags["--incubate"]) opts.incubate = flags["--incubate"];
     if (flags["--fresh"]) opts.fresh = true;
     if (flags["--resume"]) opts.resume = flags["--resume"];

--- a/src/commands/plugins/team/ensure-config.ts
+++ b/src/commands/plugins/team/ensure-config.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
-import { TEAMS_DIR, type TeamConfig } from "./team-helpers";
+import { TEAMS_DIR, creatorEnv, type TeamConfig } from "./team-helpers";
 
 export function ensureTeamConfig(name: string, description?: string): boolean {
   const configDir = join(TEAMS_DIR, name);
@@ -13,6 +13,7 @@ export function ensureTeamConfig(name: string, description?: string): boolean {
     description: description ?? `Auto-created team for session ${name}`,
     members: [],
     createdAt: Date.now(),
+    ...creatorEnv(),
   };
   writeFileSync(configPath, JSON.stringify(config, null, 2));
   return true;

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -208,6 +208,20 @@ general flags: --description <text>, --members <list>`,
       if (!args[1]) { return { ok: false, error: "usage: maw team delete <team-name>" }; }
       await cmdTeamDelete(args[1]);
 
+    } else if (sub === "cleanup") {
+      // maw team cleanup --zombie-agents [--yes]
+      // Aliased via top-aliases.ts L65 (`cleanup → team cleanup --zombie-agents`).
+      // The handler lives in `team-cleanup-zombies.ts` and was exported via impl.ts
+      // L12 but never routed here — calling `maw cleanup` / `maw team cleanup`
+      // returned "unknown subcommand: cleanup". Fixes that wiring gap so the
+      // existing scripts/team-dispatch-finish.sh zombie-sweep step actually runs.
+      const { cmdCleanupZombies } = await import("./team-cleanup-zombies");
+      const flags = parseFlags(args, {
+        "--zombie-agents": Boolean,
+        "--yes": Boolean,
+      }, 1);
+      await cmdCleanupZombies({ yes: flags["--yes"] as boolean | undefined });
+
     } else if (sub === "invite") {
       // maw team invite <team> <peer> [--scope <scope>] [--lead <lead>]
       const { cmdTeamInvite } = await import("./team-invite");

--- a/src/commands/plugins/team/index.ts
+++ b/src/commands/plugins/team/index.ts
@@ -73,14 +73,44 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         ok: true,
         output: `usage: maw team <subcommand> [args]
 
-subcommands:
-  create <name>            create a new team (alias: new)
-  spawn <team> <role>      spawn agent into team
-  delete <name>            delete a team
-  status                   show team status
-  invite <oracle>          invite oracle to team
-  members <name>           list team members
-  send <name> <message>    send message to team
+lifecycle:
+  create <name>              create a new team (alias: new)
+  spawn <team> <role>        spawn agent into team
+  resume <name>              resume a team from past life
+  shutdown <name>            shut down team (aliases: down) [--force] [--merge]
+  delete <name>              delete a team (alias: rm)
+  cleanup                    sweep zombie agent panes [--zombie-agents] [--yes]
+
+info:
+  list                       list all teams (alias: ls; also the no-arg default)
+  status [name]              show team status
+  members [name]             list team members
+  lives <agent>              show an agent's past lives (alias: history)
+
+tasks:
+  add <subject>              add a task (alias: task) [--team <n>] [--assign <a>]
+  tasks [name]               list tasks
+  done <id>                  mark a task done [--team <n>]
+  assign <id> <agent>        assign a task [--team <n>]
+
+comms:
+  send <name> <agent> <msg>  send a structured message (alias: msg)
+  hey <agent> <msg>          send keystrokes to an agent's pane
+  broadcast <msg>            send keystrokes to all agent panes (alias: shout)
+  inbox [agent]              show inbox messages [--mark-read]
+
+membership:
+  invite <team> <peer>       invite a peer team [--scope <s>] [--lead <l>]
+  oracle-invite <oracle>     invite an oracle [--team <t>] [--role <r>]
+  oracle-remove <oracle>     remove an oracle [--team <t>]
+
+tmux layout:
+  split <target>             open a pane (alias: open) [--pct N] [--vertical]
+  close                      close all split panes except this one
+  peek <target>              peek at a session/agent pane
+  prep <1-10>                pre-create N panes [--tiled]
+  layout [main-vertical|tiled]  apply a layout preset [--pct N]
+  recover [name]             restore layout from snapshot
 
 spawn flags:
   --model <model>          model to use (e.g. opus, sonnet)

--- a/src/commands/plugins/team/oracle-members.ts
+++ b/src/commands/plugins/team/oracle-members.ts
@@ -1,0 +1,196 @@
+/**
+ * oracle-members.ts — persistent oracle member registry for teams (#627 Phase 1).
+ *
+ * Stores team membership in ~/.config/maw/teams/<team-name>/oracle-members.json.
+ * Each member is a named oracle (budded from maw bud, or any oracle with a
+ * CLAUDE.md + ψ/ vault) that persists across sessions. This is the "oracle-team"
+ * paradigm: team members are not ephemeral agents — they have identity, memory,
+ * and accumulated domain knowledge.
+ *
+ * Phase 1 scope:
+ *   - maw team oracle-invite <oracle-name> [--team <team>] [--role <role>]
+ *   - maw team members [--team <team>]
+ *   - team:<team-name> fan-out routing via maw hey
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { CONFIG_DIR } from "../../../core/paths";
+
+// ─── Types ───
+
+export interface OracleMember {
+  /** Oracle name (e.g. "mawjs-plugin-oracle", "security-oracle") */
+  oracle: string;
+  /** Role within the team (e.g. "researcher", "builder", "reviewer") */
+  role: string;
+  /** ISO timestamp when the oracle was added */
+  addedAt: string;
+}
+
+export interface OracleTeamRegistry {
+  /** Team name */
+  name: string;
+  /** Persistent oracle members */
+  members: OracleMember[];
+  /** ISO timestamp when registry was created */
+  createdAt: string;
+  /**
+   * When true (default), `maw hey team:<name>` fan-out skips the sending
+   * oracle so a broadcast does not re-inject into the sender's own pane.
+   * Set to false to opt back into self-inclusive fan-out.
+   */
+  excludeSelf?: boolean;
+}
+
+// ─── Paths ───
+
+function teamRegistryDir(teamName: string): string {
+  return join(CONFIG_DIR, "teams", teamName);
+}
+
+function teamRegistryPath(teamName: string): string {
+  return join(teamRegistryDir(teamName), "oracle-members.json");
+}
+
+// ─── Registry CRUD ───
+
+export function loadOracleRegistry(teamName: string): OracleTeamRegistry | null {
+  const path = teamRegistryPath(teamName);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function ensureRegistry(teamName: string): OracleTeamRegistry {
+  const existing = loadOracleRegistry(teamName);
+  if (existing) return existing;
+  const registry: OracleTeamRegistry = {
+    name: teamName,
+    members: [],
+    createdAt: new Date().toISOString(),
+  };
+  const dir = teamRegistryDir(teamName);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(teamRegistryPath(teamName), JSON.stringify(registry, null, 2));
+  return registry;
+}
+
+function saveRegistry(teamName: string, registry: OracleTeamRegistry): void {
+  const dir = teamRegistryDir(teamName);
+  mkdirSync(dir, { recursive: true });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: registry under ~/.config/maw/teams/, see docs/security/file-system-race-stance.md
+  writeFileSync(teamRegistryPath(teamName), JSON.stringify(registry, null, 2));
+}
+
+// ─── Commands ───
+
+/**
+ * Add an oracle as a persistent member of a team.
+ * Idempotent — re-inviting updates the role.
+ */
+export function cmdOracleInvite(
+  teamName: string,
+  oracleName: string,
+  opts: { role?: string } = {},
+): void {
+  const registry = ensureRegistry(teamName);
+  const role = opts.role || "member";
+  const existing = registry.members.findIndex(m => m.oracle === oracleName);
+
+  const entry: OracleMember = {
+    oracle: oracleName,
+    role,
+    addedAt: new Date().toISOString(),
+  };
+
+  if (existing >= 0) {
+    registry.members[existing] = entry;
+    console.log(`\x1b[32m✓\x1b[0m updated '${oracleName}' in team '${teamName}' (role: ${role})`);
+  } else {
+    registry.members.push(entry);
+    console.log(`\x1b[32m✓\x1b[0m added '${oracleName}' to team '${teamName}' (role: ${role})`);
+  }
+
+  saveRegistry(teamName, registry);
+  console.log(`  \x1b[90m${teamRegistryPath(teamName)}\x1b[0m`);
+}
+
+/**
+ * Remove an oracle from a team.
+ */
+export function cmdOracleRemove(teamName: string, oracleName: string): void {
+  const registry = loadOracleRegistry(teamName);
+  if (!registry) {
+    console.log(`\x1b[33m⚠\x1b[0m team '${teamName}' has no oracle member registry`);
+    return;
+  }
+
+  const idx = registry.members.findIndex(m => m.oracle === oracleName);
+  if (idx < 0) {
+    console.log(`\x1b[33m⚠\x1b[0m '${oracleName}' is not a member of team '${teamName}'`);
+    return;
+  }
+
+  registry.members.splice(idx, 1);
+  saveRegistry(teamName, registry);
+  console.log(`\x1b[32m✓\x1b[0m removed '${oracleName}' from team '${teamName}'`);
+}
+
+/**
+ * List persistent oracle members of a team.
+ */
+export function cmdOracleMembers(teamName: string): OracleMember[] {
+  const registry = loadOracleRegistry(teamName);
+  if (!registry || registry.members.length === 0) {
+    console.log(`\x1b[90mNo oracle members in team '${teamName}'.\x1b[0m`);
+    console.log(`\x1b[90m  add one: maw team oracle-invite <oracle-name> --team ${teamName}\x1b[0m`);
+    return [];
+  }
+
+  console.log();
+  console.log(`  \x1b[36;1mOracle members of '${teamName}'\x1b[0m (${registry.members.length})`);
+  console.log();
+
+  for (const m of registry.members) {
+    const added = new Date(m.addedAt).toLocaleDateString();
+    console.log(`  \x1b[32m●\x1b[0m ${m.oracle.padEnd(30)} \x1b[90mrole:\x1b[0m ${m.role.padEnd(15)} \x1b[90madded:\x1b[0m ${added}`);
+  }
+  console.log();
+
+  return registry.members;
+}
+
+/**
+ * Pure helper: filter member oracle names against the sender, honoring the
+ * registry's `excludeSelf` flag (default true).
+ *
+ * Extracted for unit-testing without going through CONFIG_DIR module caching.
+ */
+export function filterMembers(
+  members: OracleMember[],
+  excludeSelf: boolean | undefined,
+  currentOracle?: string,
+): string[] {
+  const all = members.map(m => m.oracle);
+  // Default true — filter only when explicitly false.
+  if (excludeSelf !== false && currentOracle) {
+    return all.filter(o => o !== currentOracle);
+  }
+  return all;
+}
+
+/**
+ * Get oracle member names for a team (for routing fan-out).
+ *
+ * When `currentOracle` is provided and the registry's `excludeSelf` flag is
+ * not explicitly false, the sending oracle is filtered out so a team
+ * broadcast does not re-inject into its own pane (#742 follow-up).
+ */
+export function getOracleMembers(teamName: string, currentOracle?: string): string[] {
+  const registry = loadOracleRegistry(teamName);
+  if (!registry) return [];
+  return filterMembers(registry.members, registry.excludeSelf, currentOracle);
+}

--- a/src/commands/plugins/team/team-cleanup.ts
+++ b/src/commands/plugins/team/team-cleanup.ts
@@ -1,0 +1,23 @@
+import { existsSync, rmSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { cmdTeamTaskDeleteAll } from "./task-ops";
+
+const TEAMS_DIR = join(homedir(), ".claude/teams");
+
+export async function cmdTeamDelete(teamName: string): Promise<void> {
+  // 1. Delete task files
+  cmdTeamTaskDeleteAll(teamName);
+  console.log(`  \x1b[32m✓\x1b[0m tasks cleared`);
+
+  // 2. Remove team directory
+  const teamDir = join(TEAMS_DIR, teamName);
+  if (existsSync(teamDir)) {
+    rmSync(teamDir, { recursive: true, force: true });
+    console.log(`  \x1b[32m✓\x1b[0m team dir removed: ${teamDir}`);
+  } else {
+    console.log(`  \x1b[90mℹ team dir not found (already clean)\x1b[0m`);
+  }
+
+  console.log(`\x1b[32m✓\x1b[0m team "${teamName}" deleted`);
+}

--- a/src/commands/plugins/team/team-helpers.ts
+++ b/src/commands/plugins/team/team-helpers.ts
@@ -27,6 +27,22 @@ export interface TeamConfig {
   description?: string;
   members: TeamMember[];
   createdAt?: number;
+  // Who created/leads this team — the dispatcher's tmux pane (%NN) and Claude
+  // session id, captured from the env at create time. Lets consumers (e.g. the
+  // fleet visualizer) group a team under the orchestrator that spawned it, since
+  // the team↔dispatcher link isn't otherwise persisted.
+  createdByPane?: string;
+  createdBySession?: string;
+}
+
+/** Snapshot the creating agent's identity from the environment (best-effort). */
+export function creatorEnv(): { createdByPane?: string; createdBySession?: string } {
+  const pane = process.env.TMUX_PANE;
+  const session = process.env.CLAUDE_SESSION_ID;
+  return {
+    ...(pane ? { createdByPane: pane } : {}),
+    ...(session ? { createdBySession: session } : {}),
+  };
 }
 
 export function loadTeam(name: string): TeamConfig | null {

--- a/src/commands/plugins/team/team-invite.ts
+++ b/src/commands/plugins/team/team-invite.ts
@@ -1,0 +1,214 @@
+/**
+ * maw team invite — invite a remote oracle to a local team (#644 Phase 2).
+ *
+ * Completes the 3-layer consent story (Phase 1: hey, Phase 3: plugin-install).
+ * Adding a remote oracle to a team is a privileged action — the invitee will
+ * receive team messages, tasks, and eventually share knowledge at shutdown
+ * via --merge. Phase 2 gates this with the same PIN-consent primitive.
+ *
+ * Default OFF. Opt in via MAW_CONSENT=1 (same convention as Phase 1 + 3).
+ *
+ * When consent IS required and not yet trusted, we:
+ *   1. Resolve the peer in namedPeers → peerUrl (the "hard ID").
+ *   2. requestConsent(action="team-invite") with a summary containing
+ *      team + lead + invitee + scope so the approver has full context.
+ *   3. Print the PIN + "on <peer>: maw consent approve ..." + exit 2.
+ *
+ * Once the peer has approved (or an existing trust entry matches), we add
+ * the peer to the team manifest under `invitees` and return. The caller
+ * re-runs `maw team invite` after OOB PIN relay.
+ *
+ * Trust-key scope note: trust is bound to (myNode, peerNode, "team-invite").
+ * A `hey` or `plugin-install` trust entry does NOT allow a team invite — the
+ * scopes are intentionally distinct (see gate-plugin-install.ts §2).
+ */
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { loadConfig } from "../../../config";
+import { isTrusted, requestConsent } from "../../../core/consent";
+import { resolvePsi } from "./team-helpers";
+
+export interface TeamInviteOptions {
+  /** Scope string surfaced in the consent summary (default: "member"). */
+  scope?: string;
+  /** Team lead name surfaced in the consent summary. Defaults to config.node. */
+  lead?: string;
+  /** Test injection — override peer lookup. Defaults to config.namedPeers. */
+  peerLookup?: (peerName: string) => NamedPeer | null;
+  /** Test injection — override local node. Defaults to config.node. */
+  myNode?: string;
+}
+
+export interface TeamInviteDecision {
+  ok: boolean;
+  exitCode?: number;
+  /** Message to print to stderr when ok=false. */
+  message?: string;
+}
+
+const SCOPE_DEFAULT = "member";
+
+export interface NamedPeer {
+  name: string;
+  url: string;
+  node?: string;
+}
+
+function defaultPeerLookup(peerName: string): NamedPeer | null {
+  const cfg = loadConfig() as { namedPeers?: NamedPeer[] };
+  const named = cfg.namedPeers ?? [];
+  return named.find(p => p.name === peerName) ?? null;
+}
+
+function manifestPath(teamName: string): string {
+  return join(resolvePsi(), "memory", "mailbox", "teams", teamName, "manifest.json");
+}
+
+/**
+ * Record the invitee in the team manifest. Idempotent — repeat invites
+ * are no-ops so post-consent re-runs don't duplicate entries.
+ *
+ * No `existsSync` precheck: catch ENOENT on the read instead. CodeQL's
+ * `js/file-system-race` flags check-then-use patterns regardless of path
+ * ownership, and inline `// lgtm` markers don't suppress alerts under the
+ * current GHAS scanner (see .github/codeql/codeql-config.yml). The
+ * read-then-write pattern matches team-lifecycle.ts (#393) which ships
+ * without an alert.
+ */
+export function recordInvitee(teamName: string, peer: NamedPeer, scope: string): void {
+  const path = manifestPath(teamName);
+  let manifest: any;
+  try {
+    manifest = JSON.parse(readFileSync(path, "utf-8"));
+  } catch (e: any) {
+    if (e?.code === "ENOENT") {
+      throw new Error(`team '${teamName}' not found — run: maw team create ${teamName}`);
+    }
+    throw e;
+  }
+  manifest.invitees = Array.isArray(manifest.invitees) ? manifest.invitees : [];
+  const existing = manifest.invitees.findIndex((i: any) => i?.name === peer.name);
+  const entry = {
+    name: peer.name,
+    url: peer.url,
+    node: peer.node,
+    scope,
+    invitedAt: new Date().toISOString(),
+  };
+  if (existing >= 0) {
+    manifest.invitees[existing] = entry;
+  } else {
+    manifest.invitees.push(entry);
+  }
+  // lgtm[js/file-system-race] — PRIVATE-PATH: manifest under ψ/memory/mailbox/teams/<team>/, see docs/security/file-system-race-stance.md
+  writeFileSync(path, JSON.stringify(manifest, null, 2));
+}
+
+/**
+ * Pure decision function — easier to unit-test than the CLI wrapper.
+ * Returns ok=true iff the invite was recorded; ok=false carries the
+ * stderr message + exit code the CLI should print.
+ */
+export async function runTeamInvite(
+  teamName: string,
+  peerName: string,
+  opts: TeamInviteOptions = {},
+): Promise<TeamInviteDecision> {
+  if (!existsSync(manifestPath(teamName))) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message: `\x1b[31m✗\x1b[0m team '${teamName}' not found — run: maw team create ${teamName}`,
+    };
+  }
+
+  const lookup = opts.peerLookup ?? defaultPeerLookup;
+  const peer = lookup(peerName);
+  if (!peer) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message:
+        `\x1b[31m✗\x1b[0m unknown peer '${peerName}' — not in namedPeers.\n` +
+        `  hint: add ${peerName} to maw.config.json namedPeers`,
+    };
+  }
+
+  const scope = opts.scope || SCOPE_DEFAULT;
+
+  // Default OFF — opt in via MAW_CONSENT=1. When off, skip the PIN round-trip
+  // entirely and record the invite directly (legacy path).
+  if (process.env.MAW_CONSENT !== "1") {
+    recordInvitee(teamName, peer, scope);
+    return { ok: true };
+  }
+
+  const myNode = opts.myNode ?? (loadConfig().node ?? "local");
+  const lead = opts.lead || myNode;
+
+  // Trust key falls back to peerName when peer didn't advertise a node.
+  // Same convention as gate-plugin-install.ts — keeps trust decisions
+  // expressible even for legacy peers.
+  const peerIdForTrust = peer.node || peer.name;
+  if (isTrusted(myNode, peerIdForTrust, "team-invite")) {
+    recordInvitee(teamName, peer, scope);
+    return { ok: true };
+  }
+
+  const summary =
+    `team-invite: team='${teamName}' lead='${lead}' ` +
+    `invitee='${peer.name}'${peer.node ? ` (${peer.node})` : ""} ` +
+    `url='${peer.url}' scope='${scope}'`;
+
+  const r = await requestConsent({
+    from: myNode,
+    to: peerIdForTrust,
+    action: "team-invite",
+    summary,
+    peerUrl: peer.url,
+  });
+
+  if (!r.ok) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message: [
+        `\x1b[31m✗ consent request failed\x1b[0m: ${r.error}`,
+        r.requestId ? `  request id (local mirror): ${r.requestId}` : "",
+        `  hint: peer may be down, or /api/consent/request not yet deployed`,
+      ].filter(Boolean).join("\n"),
+    };
+  }
+
+  return {
+    ok: false,
+    exitCode: 2,
+    message: [
+      `\x1b[33m⏸  consent required\x1b[0m → team-invite`,
+      `   team:   ${teamName}  (lead: ${lead})`,
+      `   peer:   ${peer.name}${peer.node ? ` (${peer.node})` : ""}  [${peer.url}]`,
+      `   scope:  ${scope}`,
+      `   request id: ${r.requestId}`,
+      `   PIN (relay OOB to ${peerIdForTrust} operator): \x1b[1m${r.pin}\x1b[0m`,
+      `   expires: ${r.expiresAt}`,
+      ``,
+      `   on ${peerIdForTrust}: \x1b[36mmaw consent approve ${r.requestId} ${r.pin}\x1b[0m`,
+      `   then re-run: \x1b[36mmaw team invite ${teamName} ${peer.name}\x1b[0m`,
+    ].join("\n"),
+  };
+}
+
+/** CLI entry — prints outcome, returns void. Throws only on programmer error. */
+export async function cmdTeamInvite(
+  teamName: string,
+  peerName: string,
+  opts: TeamInviteOptions = {},
+): Promise<void> {
+  const decision = await runTeamInvite(teamName, peerName, opts);
+  if (decision.ok) {
+    console.log(`\x1b[32m✓\x1b[0m invited '${peerName}' to team '${teamName}' (scope: ${opts.scope || SCOPE_DEFAULT})`);
+    return;
+  }
+  if (decision.message) console.error(decision.message);
+  process.exit(decision.exitCode ?? 1);
+}

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, copyFi
 import { join } from "path";
 import { tmux } from "../../../sdk";
 import { assertValidOracleName } from "../../../core/fleet/validate";
-import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, type TeamConfig, type TeamMember } from "./team-helpers";
+import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, creatorEnv, type TeamConfig, type TeamMember } from "./team-helpers";
 import { formatError } from "../../../lib/format-error";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
@@ -168,6 +168,7 @@ export function cmdTeamCreate(name: string, opts: { description?: string } = {})
       description: opts.description || "",
       members: [],
       createdAt: Date.now(),
+      ...creatorEnv(),
     };
     writeFileSync(join(toolTeamDir, "config.json"), JSON.stringify(stubConfig, null, 2));
   }

--- a/src/commands/plugins/team/team-lifecycle.ts
+++ b/src/commands/plugins/team/team-lifecycle.ts
@@ -216,7 +216,7 @@ export async function cmdTeamSpawn(
   }
 
   // Build spawn prompt
-  const model = opts.model || "sonnet";
+  const model = opts.model || "opus";
   const parts: string[] = [];
   parts.push(`You are '${role}' on team '${teamName}'.`);
   if (opts.prompt) parts.push(opts.prompt);

--- a/src/commands/shared/fleet-load.ts
+++ b/src/commands/shared/fleet-load.ts
@@ -5,6 +5,8 @@ import { tmux, FLEET_DIR } from "../../sdk";
 export interface FleetWindow {
   name: string;
   repo: string;
+  /** Optional engine key from config.commands (e.g. "claude", "codex"). */
+  engine?: string;
 }
 
 export interface FleetSession {

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -27,6 +27,8 @@ type CmdWakeOpts = {
   engine?: string;
   model?: string;
   reasoningEffort?: string;
+  /** Opt IN to per-worktree respawn (default OFF; thread #14 / owner GO 2026-06-11). */
+  respawnWorktrees?: boolean;
 };
 
 export async function cmdWake(oracle: string, opts: CmdWakeOpts): Promise<string> {
@@ -42,6 +44,14 @@ export async function cmdWake(oracle: string, opts: CmdWakeOpts): Promise<string
   // `opts.attach` checks honor caller intent. Lets api/sessions.ts and
   // friends pass `noAttach: true` cleanly without needing `attach: false`.
   if (opts.noAttach) opts.attach = false;
+
+  // Per-worktree respawn is OPT-IN (default OFF) — thread #14 / owner GO
+  // 2026-06-11 (ported by hand onto the pre-refactor wake in feat/all-prs-
+  // rebased; durable fix lives on alpha PR #2705). A plain `maw wake <role>`
+  // must NOT fan out a `<role>-<wt-suffix>` window per worktree on disk (the
+  // 17-window explosion + cross-role --continue incident).
+  const respawnWorktrees = opts.respawnWorktrees === true
+    || (loadConfig() as { respawnWorktrees?: boolean }).respawnWorktrees === true;
 
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
@@ -193,7 +203,7 @@ export async function cmdWake(oracle: string, opts: CmdWakeOpts): Promise<string
       console.log(`\x1b[32m+\x1b[0m team '${oracle}' auto-created`);
     }
 
-    if (!opts.task && !opts.wt) {
+    if (!opts.task && !opts.wt && respawnWorktrees) {
       const allWt = await findWorktrees(parentDir, repoName);
       const usedNames = new Set<string>();
       for (const wt of allWt) {
@@ -203,7 +213,12 @@ export async function cmdWake(oracle: string, opts: CmdWakeOpts): Promise<string
         usedNames.add(wtWindowName);
         await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
         await new Promise(r => setTimeout(r, 300));
-        await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, wakeOpts));
+        // F2: a respawned worktree window is a FRESH claude — never bare
+        // `--continue` (which resumes whoever last ran in that cwd = cross-role
+        // contamination in a shared/multi-role repo). A pinned sessionIds[window]
+        // still upgrades to `--resume <uuid>` inside buildCommand.
+        const wtWakeOpts = { ...(typeof wakeOpts === "string" ? { engine: wakeOpts } : (wakeOpts ?? {})), fresh: true };
+        await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, wtWakeOpts));
         console.log(`\x1b[32m+\x1b[0m window: ${wtWindowName}`);
       }
     }
@@ -212,7 +227,7 @@ export async function cmdWake(oracle: string, opts: CmdWakeOpts): Promise<string
     let preExistingWindows = new Set<string>();
     try { preExistingWindows = new Set((await tmux.listWindows(session)).map(w => w.name)); } catch { /* ok */ }
 
-    if (!opts.task && !opts.wt) {
+    if (!opts.task && !opts.wt && respawnWorktrees) {
       const allWt = await findWorktrees(parentDir, repoName);
       if (allWt.length > 0) {
         const existingWindows = [...preExistingWindows];
@@ -229,7 +244,9 @@ export async function cmdWake(oracle: string, opts: CmdWakeOpts): Promise<string
           usedNames.add(wtWindowName);
           await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
           await new Promise(r => setTimeout(r, 300));
-          await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, runtimeOpts({ resume: opts.resume, fresh: opts.fresh, prompt: opts.prompt })));
+          // F2: respawned worktree window = FRESH claude (no bare `--continue`
+          // cross-role resume). Pinned sessionIds[window] still → `--resume <uuid>`.
+          await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, runtimeOpts({ fresh: true, prompt: opts.prompt })));
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wtWindowName}`);
         }
       }

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -195,7 +195,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
           usedNames.add(wtWindowName);
           await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
           await new Promise(r => setTimeout(r, 300));
-          await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, wakeOpts));
+          await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, { engine: opts.engine, resume: opts.resume, fresh: opts.fresh, prompt: opts.prompt }));
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wtWindowName}`);
         }
       }

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -10,7 +10,7 @@ import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-se
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; attach?: boolean; noAttach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; resume?: string; attach?: boolean; noAttach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
   // #1151 — reject flag-shaped names. parseFlags lands unrecognized flags
   // (e.g. --help) in positional `_`, so they reach here as oracle="--help"
   // and (without this guard) get sanitized into session names like `26---help`.
@@ -128,9 +128,12 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     // #1146 — read permissionMode so channel-enabled bots can opt into "relay"
     // (channel-routed prompts) instead of the default "skip" (autonomous).
     const permissionMode = getChannelPermissionMode(oracle);
+    // Build wakeOpts as object whenever extra fields are needed (channels OR
+    // resume). Caller's `--resume <sid>` must propagate all the way down to
+    // buildCommandInDir; passing engine alone (string form) loses it.
     const wakeOpts = channelIds.length
-      ? { engine: opts.engine, channels: channelIds, channelEnv, permissionMode }
-      : opts.engine;
+      ? { engine: opts.engine, channels: channelIds, channelEnv, permissionMode, resume: opts.resume }
+      : (opts.resume ? { engine: opts.engine, resume: opts.resume } : opts.engine);
     await tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath, wakeOpts));
     console.log(`\x1b[32m+\x1b[0m created session '${session}' (main: ${mainWindowName})`);
 
@@ -258,7 +261,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       if (opts.prompt) {
         await tmux.selectWindow(`${session}:${existingWindow}`);
         const escaped = opts.prompt.replace(/'/g, "'\\''");
-        await tmux.sendText(`${session}:${existingWindow}`, `${buildCommandInDir(existingWindow, targetPath, opts.engine)} -p '${escaped}'`);
+        await tmux.sendText(`${session}:${existingWindow}`, `${buildCommandInDir(existingWindow, targetPath, opts.resume ? { engine: opts.engine, resume: opts.resume } : opts.engine)} -p '${escaped}'`);
         if (opts.attach) await attachToSession(session);
         await maybeSplit(`${session}:${existingWindow}`, opts);
         return `${session}:${existingWindow}`;
@@ -271,7 +274,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
       if (!agentAlive) {
         console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' in ${session} — agent dead, re-launching...`);
-        await tmux.sendText(target, buildCommandInDir(existingWindow, targetPath, opts.engine));
+        await tmux.sendText(target, buildCommandInDir(existingWindow, targetPath, opts.resume ? { engine: opts.engine, resume: opts.resume } : opts.engine));
         if (opts.attach) {
           await tmux.selectWindow(target);
           await attachToSession(session);
@@ -292,7 +295,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));
-  const cmd = buildCommandInDir(windowName, targetPath, opts.engine);
+  const cmd = buildCommandInDir(windowName, targetPath, opts.resume ? { engine: opts.engine, resume: opts.resume } : opts.engine);
   if (opts.prompt) {
     const escaped = opts.prompt.replace(/'/g, "'\\''");
     await tmux.sendText(`${session}:${windowName}`, `${cmd} -p '${escaped}'`);

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -131,9 +131,15 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     // Build wakeOpts as object whenever extra fields are needed (channels OR
     // resume). Caller's `--resume <sid>` must propagate all the way down to
     // buildCommandInDir; passing engine alone (string form) loses it.
+    // Build wakeOpts as object whenever extra fields are needed (channels,
+    // resume, or fresh). Caller's `--resume <sid>` / `--fresh` must propagate
+    // down to buildCommandInDir; passing engine alone (string form) loses
+    // them. buildCommandInDir auto-probes the cwd for a missing JSONL and
+    // sets fresh=true itself when neither fresh nor resume was supplied —
+    // see config/command.ts buildCommandInDir.
     const wakeOpts = channelIds.length
-      ? { engine: opts.engine, channels: channelIds, channelEnv, permissionMode, resume: opts.resume }
-      : (opts.resume ? { engine: opts.engine, resume: opts.resume } : opts.engine);
+      ? { engine: opts.engine, channels: channelIds, channelEnv, permissionMode, resume: opts.resume, fresh: opts.fresh }
+      : (opts.resume || opts.fresh ? { engine: opts.engine, resume: opts.resume, fresh: opts.fresh } : opts.engine);
     await tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath, wakeOpts));
     console.log(`\x1b[32m+\x1b[0m created session '${session}' (main: ${mainWindowName})`);
 
@@ -261,7 +267,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       if (opts.prompt) {
         await tmux.selectWindow(`${session}:${existingWindow}`);
         const escaped = opts.prompt.replace(/'/g, "'\\''");
-        await tmux.sendText(`${session}:${existingWindow}`, `${buildCommandInDir(existingWindow, targetPath, opts.resume ? { engine: opts.engine, resume: opts.resume } : opts.engine)} -p '${escaped}'`);
+        await tmux.sendText(`${session}:${existingWindow}`, `${buildCommandInDir(existingWindow, targetPath, opts.resume || opts.fresh ? { engine: opts.engine, resume: opts.resume, fresh: opts.fresh } : opts.engine)} -p '${escaped}'`);
         if (opts.attach) await attachToSession(session);
         await maybeSplit(`${session}:${existingWindow}`, opts);
         return `${session}:${existingWindow}`;
@@ -274,7 +280,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
       if (!agentAlive) {
         console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' in ${session} — agent dead, re-launching...`);
-        await tmux.sendText(target, buildCommandInDir(existingWindow, targetPath, opts.resume ? { engine: opts.engine, resume: opts.resume } : opts.engine));
+        await tmux.sendText(target, buildCommandInDir(existingWindow, targetPath, opts.resume || opts.fresh ? { engine: opts.engine, resume: opts.resume, fresh: opts.fresh } : opts.engine));
         if (opts.attach) {
           await tmux.selectWindow(target);
           await attachToSession(session);
@@ -295,7 +301,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));
-  const cmd = buildCommandInDir(windowName, targetPath, opts.resume ? { engine: opts.engine, resume: opts.resume } : opts.engine);
+  const cmd = buildCommandInDir(windowName, targetPath, opts.resume || opts.fresh ? { engine: opts.engine, resume: opts.resume, fresh: opts.fresh } : opts.engine);
   if (opts.prompt) {
     const escaped = opts.prompt.replace(/'/g, "'\\''");
     await tmux.sendText(`${session}:${windowName}`, `${cmd} -p '${escaped}'`);

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -6,7 +6,7 @@ import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { assertValidOracleName } from "../../core/fleet/validate";
 import { UserError } from "../../core/util/user-error";
 import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
-import { attachToSession, ensureSessionRunning, createWorktree } from "./wake-session";
+import { attachToSession, ensureSessionRunning, createWorktree, injectWorktreeSymlinks } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 
@@ -251,6 +251,9 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
       console.log(`\x1b[33m⚡\x1b[0m reusing worktree: ${match.path}`);
       targetPath = match.path;
       windowName = `${oracle}-${name}`;
+      // Backfill gitignored symlinks (.agent, .secrets) for worktrees created
+      // before injection was wired — idempotent, a no-op once they exist.
+      await injectWorktreeSymlinks(repoPath, match.path, repoName);
     } else {
       const result = await createWorktree(repoPath, parentDir, repoName, oracle, name, worktrees);
       targetPath = result.wtPath;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -5,7 +5,7 @@ import { resolveWorktreeTarget } from "../../core/matcher/resolve-target";
 import { normalizeTarget } from "../../core/matcher/normalize-target";
 import { assertValidOracleName } from "../../core/fleet/validate";
 import { UserError } from "../../core/util/user-error";
-import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
+import { resolveOracle, findWorktrees, getSessionMap, resolveFleetSession, resolveFleetEngine, detectSession, setSessionEnv, sanitizeBranchName } from "./wake-resolve";
 import { attachToSession, ensureSessionRunning, createWorktree, injectWorktreeSymlinks } from "./wake-session";
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
@@ -73,6 +73,13 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   const resolvedOracle = repoName.replace(/-oracle$/, "");
   if (resolvedOracle !== oracle && repoName.endsWith("-oracle")) {
     oracle = resolvedOracle;
+  }
+
+  // Fleet-level engine pin: when caller does not pass --engine, use the
+  // oracle's configured fleet window engine (e.g. claude|codex).
+  if (!opts.engine) {
+    const fleetEngine = resolveFleetEngine(oracle);
+    if (fleetEngine) opts.engine = fleetEngine;
   }
 
   // #673 — extract org/repo slug from ghq path (…/github.com/<org>/<repo>)
@@ -323,4 +330,3 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   takeSnapshot("wake").catch(() => {});
   return `${session}:${windowName}`;
 }
-

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -10,7 +10,26 @@ import { attachToSession, ensureSessionRunning, createWorktree, injectWorktreeSy
 import { maybeSplit } from "./wake-maybe-split";
 import { parseWakeTarget, ensureCloned } from "./wake-target";
 
-export async function cmdWake(oracle: string, opts: { task?: string; wt?: string; prompt?: string; incubate?: string; fresh?: boolean; resume?: string; attach?: boolean; noAttach?: boolean; listWt?: boolean; split?: boolean; repoPath?: string; urlRepoName?: string; allLocal?: boolean; engine?: string }): Promise<string> {
+type CmdWakeOpts = {
+  task?: string;
+  wt?: string;
+  prompt?: string;
+  incubate?: string;
+  fresh?: boolean;
+  resume?: string;
+  attach?: boolean;
+  noAttach?: boolean;
+  listWt?: boolean;
+  split?: boolean;
+  repoPath?: string;
+  urlRepoName?: string;
+  allLocal?: boolean;
+  engine?: string;
+  model?: string;
+  reasoningEffort?: string;
+};
+
+export async function cmdWake(oracle: string, opts: CmdWakeOpts): Promise<string> {
   // #1151 — reject flag-shaped names. parseFlags lands unrecognized flags
   // (e.g. --help) in positional `_`, so they reach here as oracle="--help"
   // and (without this guard) get sanitized into session names like `26---help`.
@@ -81,6 +100,12 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     const fleetEngine = resolveFleetEngine(oracle);
     if (fleetEngine) opts.engine = fleetEngine;
   }
+  const runtimeOpts = (extra: Partial<CmdWakeOpts> = {}) => ({
+    engine: opts.engine,
+    model: opts.model,
+    reasoningEffort: opts.reasoningEffort,
+    ...extra,
+  });
 
   // #673 — extract org/repo slug from ghq path (…/github.com/<org>/<repo>)
   const ghSlug = repoPath.includes("github.com/")
@@ -145,8 +170,10 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     // sets fresh=true itself when neither fresh nor resume was supplied —
     // see config/command.ts buildCommandInDir.
     const wakeOpts = channelIds.length
-      ? { engine: opts.engine, channels: channelIds, channelEnv, permissionMode, resume: opts.resume, fresh: opts.fresh }
-      : (opts.resume || opts.fresh ? { engine: opts.engine, resume: opts.resume, fresh: opts.fresh } : opts.engine);
+      ? { ...runtimeOpts({ resume: opts.resume, fresh: opts.fresh }), channels: channelIds, channelEnv, permissionMode }
+      : (opts.resume || opts.fresh || opts.model || opts.reasoningEffort
+        ? runtimeOpts({ resume: opts.resume, fresh: opts.fresh })
+        : opts.engine);
     await tmux.sendText(`${session}:${mainWindowName}`, buildCommandInDir(mainWindowName, repoPath, wakeOpts));
     console.log(`\x1b[32m+\x1b[0m created session '${session}' (main: ${mainWindowName})`);
 
@@ -202,7 +229,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
           usedNames.add(wtWindowName);
           await tmux.newWindow(session, wtWindowName, { cwd: wt.path });
           await new Promise(r => setTimeout(r, 300));
-          await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, { engine: opts.engine, resume: opts.resume, fresh: opts.fresh, prompt: opts.prompt }));
+          await tmux.sendText(`${session}:${wtWindowName}`, buildCommandInDir(wtWindowName, wt.path, runtimeOpts({ resume: opts.resume, fresh: opts.fresh, prompt: opts.prompt })));
           console.log(`\x1b[32m↻\x1b[0m respawned: ${wtWindowName}`);
         }
       }
@@ -279,7 +306,7 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
         // Prompt is baked into the command by buildCommand (inside the brace
         // group, before the reset suffix). Do NOT append ` -p '…'` here — it
         // would land on the trailing `clear` and the prompt would be lost.
-        await tmux.sendText(`${session}:${existingWindow}`, buildCommandInDir(existingWindow, targetPath, { engine: opts.engine, resume: opts.resume, fresh: opts.fresh, prompt: opts.prompt }));
+        await tmux.sendText(`${session}:${existingWindow}`, buildCommandInDir(existingWindow, targetPath, runtimeOpts({ resume: opts.resume, fresh: opts.fresh, prompt: opts.prompt })));
         if (opts.attach) await attachToSession(session);
         await maybeSplit(`${session}:${existingWindow}`, opts);
         return `${session}:${existingWindow}`;
@@ -292,7 +319,9 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
       if (!agentAlive) {
         console.log(`\x1b[33m⚡\x1b[0m '${existingWindow}' in ${session} — agent dead, re-launching...`);
-        await tmux.sendText(target, buildCommandInDir(existingWindow, targetPath, opts.resume || opts.fresh ? { engine: opts.engine, resume: opts.resume, fresh: opts.fresh } : opts.engine));
+        await tmux.sendText(target, buildCommandInDir(existingWindow, targetPath, opts.resume || opts.fresh || opts.model || opts.reasoningEffort
+          ? runtimeOpts({ resume: opts.resume, fresh: opts.fresh })
+          : opts.engine));
         if (opts.attach) {
           await tmux.selectWindow(target);
           await attachToSession(session);
@@ -317,8 +346,8 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
   // brace group, before the reset suffix. Appending ` -p '…'` to the returned
   // string puts the flag on the trailing `clear`, not `claude`, so the prompt
   // never reaches the agent (the directed-inbox `failed_no_prompt` regression).
-  const cmd = buildCommandInDir(windowName, targetPath, opts.resume || opts.fresh || opts.prompt
-    ? { engine: opts.engine, resume: opts.resume, fresh: opts.fresh, prompt: opts.prompt }
+  const cmd = buildCommandInDir(windowName, targetPath, opts.resume || opts.fresh || opts.prompt || opts.model || opts.reasoningEffort
+    ? runtimeOpts({ resume: opts.resume, fresh: opts.fresh, prompt: opts.prompt })
     : opts.engine);
   await tmux.sendText(`${session}:${windowName}`, cmd);
 

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -266,8 +266,10 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
     if (existingWindow) {
       if (opts.prompt) {
         await tmux.selectWindow(`${session}:${existingWindow}`);
-        const escaped = opts.prompt.replace(/'/g, "'\\''");
-        await tmux.sendText(`${session}:${existingWindow}`, `${buildCommandInDir(existingWindow, targetPath, opts.resume || opts.fresh ? { engine: opts.engine, resume: opts.resume, fresh: opts.fresh } : opts.engine)} -p '${escaped}'`);
+        // Prompt is baked into the command by buildCommand (inside the brace
+        // group, before the reset suffix). Do NOT append ` -p '…'` here — it
+        // would land on the trailing `clear` and the prompt would be lost.
+        await tmux.sendText(`${session}:${existingWindow}`, buildCommandInDir(existingWindow, targetPath, { engine: opts.engine, resume: opts.resume, fresh: opts.fresh, prompt: opts.prompt }));
         if (opts.attach) await attachToSession(session);
         await maybeSplit(`${session}:${existingWindow}`, opts);
         return `${session}:${existingWindow}`;
@@ -301,13 +303,14 @@ export async function cmdWake(oracle: string, opts: { task?: string; wt?: string
 
   await tmux.newWindow(session, windowName, { cwd: targetPath });
   await new Promise(r => setTimeout(r, 300));
-  const cmd = buildCommandInDir(windowName, targetPath, opts.resume || opts.fresh ? { engine: opts.engine, resume: opts.resume, fresh: opts.fresh } : opts.engine);
-  if (opts.prompt) {
-    const escaped = opts.prompt.replace(/'/g, "'\\''");
-    await tmux.sendText(`${session}:${windowName}`, `${cmd} -p '${escaped}'`);
-  } else {
-    await tmux.sendText(`${session}:${windowName}`, cmd);
-  }
+  // Prompt (when set) is baked into the command by buildCommand — inside the
+  // brace group, before the reset suffix. Appending ` -p '…'` to the returned
+  // string puts the flag on the trailing `clear`, not `claude`, so the prompt
+  // never reaches the agent (the directed-inbox `failed_no_prompt` regression).
+  const cmd = buildCommandInDir(windowName, targetPath, opts.resume || opts.fresh || opts.prompt
+    ? { engine: opts.engine, resume: opts.resume, fresh: opts.fresh, prompt: opts.prompt }
+    : opts.engine);
+  await tmux.sendText(`${session}:${windowName}`, cmd);
 
   console.log(`\x1b[32m✅\x1b[0m woke '${windowName}' in ${session} → ${targetPath}`);
   if (opts.attach) await attachToSession(session);

--- a/src/commands/shared/wake-resolve-impl.ts
+++ b/src/commands/shared/wake-resolve-impl.ts
@@ -242,6 +242,17 @@ export async function findWorktrees(parentDir: string, repoName: string): Promis
 
 export function getSessionMap(): Record<string, string> { return loadConfig().sessions; }
 
+function findFleetWindow(oracle: string): FleetWindow | null {
+  try {
+    for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))) {
+      const config = JSON.parse(readFileSync(join(FLEET_DIR, file), "utf-8")) as FleetSession;
+      const win = (config.windows || []).find((w: FleetWindow) => w.name === `${oracle}-oracle` || w.name === oracle);
+      if (win) return win;
+    }
+  } catch { /* fleet dir may not exist */ }
+  return null;
+}
+
 export function resolveFleetSession(oracle: string): string | null {
   try {
     for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))) {
@@ -250,6 +261,17 @@ export function resolveFleetSession(oracle: string): string | null {
     }
   } catch { /* fleet dir may not exist */ }
   return null;
+}
+
+/**
+ * Resolve the default engine for an oracle from fleet config.
+ * Returns undefined when the oracle has no explicit engine pin.
+ */
+export function resolveFleetEngine(oracle: string): string | undefined {
+  const win = findFleetWindow(oracle);
+  if (!win || typeof win.engine !== "string") return undefined;
+  const engine = win.engine.trim();
+  return engine.length > 0 ? engine : undefined;
 }
 
 export async function detectSession(oracle: string, urlRepoName?: string): Promise<string | null> {

--- a/src/commands/shared/wake-resolve.ts
+++ b/src/commands/shared/wake-resolve.ts
@@ -4,6 +4,7 @@ export {
   findWorktrees,
   getSessionMap,
   resolveFleetSession,
+  resolveFleetEngine,
   detectSession,
   setSessionEnv,
   sanitizeBranchName,

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -80,6 +80,16 @@ export async function createWorktree(
   }
   try { await hostExec(`git -C '${safe(repoPath)}' branch -D '${safe(branch)}' 2>/dev/null`); } catch { /* ok */ }
   await hostExec(`git -C '${safe(repoPath)}' worktree add '${safe(wtPath)}' -b '${safe(branch)}'`);
+  // Mirror .agent symlink from main tree — it's gitignored so worktrees don't inherit it
+  try {
+    const agentSrc = `${repoPath}/.agent`;
+    const agentDst = `${wtPath}/.agent`;
+    const { lstatSync, readlinkSync, symlinkSync } = await import("fs");
+    if (lstatSync(agentSrc, { throwIfNoEntry: false })?.isSymbolicLink()) {
+      symlinkSync(readlinkSync(agentSrc), agentDst);
+      console.log(`\x1b[32m+\x1b[0m .agent symlink: ${agentDst}`);
+    }
+  } catch { /* non-fatal */ }
   console.log(`\x1b[32m+\x1b[0m worktree: ${wtPath} (${branch})`);
   return { wtPath, windowName: `${oracle}-${name}` };
 }

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -58,6 +58,60 @@ export async function ensureSessionRunning(session: string, excludeNames?: Set<s
 }
 
 /**
+ * Inject the gitignored symlinks a worktree needs but `git worktree add` can't
+ * carry over:
+ *
+ *   .agent   — mirrors the main tree's `.agent` symlink (central agent memory).
+ *   .secrets — links to the per-repo fleet secret store, when one exists at
+ *              ~/.arra-oracle-v2/fleet-secrets/<repo>/ .
+ *
+ * Both paths are gitignored, so a fresh worktree never inherits them. For
+ * `.secrets` this previously forced agents to reconstruct the file by hand in
+ * every fresh worktree — and some values (e.g. a hosted DB password) cannot be
+ * reconstructed from any API at all. The central store is the single source of
+ * truth; worktrees just symlink to it. Onboarding another repo to this scheme
+ * is purely a matter of populating `fleet-secrets/<repo>/` — no code change.
+ *
+ * Idempotent: each link is created only when the destination is absent, so this
+ * is safe to call on worktree creation AND on every reuse/wake — a worktree
+ * created before this was wired gets backfilled the next time it is woken.
+ */
+export async function injectWorktreeSymlinks(
+  repoPath: string,
+  wtPath: string,
+  repoName: string,
+): Promise<void> {
+  const { lstatSync, statSync, readlinkSync, symlinkSync } = await import("fs");
+  const { homedir } = await import("os");
+
+  // .agent — mirror the main tree's symlink target verbatim.
+  try {
+    const agentSrc = `${repoPath}/.agent`;
+    const agentDst = `${wtPath}/.agent`;
+    if (
+      lstatSync(agentSrc, { throwIfNoEntry: false })?.isSymbolicLink() &&
+      !lstatSync(agentDst, { throwIfNoEntry: false })
+    ) {
+      symlinkSync(readlinkSync(agentSrc), agentDst);
+      console.log(`\x1b[32m+\x1b[0m .agent symlink: ${agentDst}`);
+    }
+  } catch { /* non-fatal */ }
+
+  // .secrets — link to the central per-repo fleet secret store, by convention.
+  try {
+    const storeDir = `${homedir()}/.arra-oracle-v2/fleet-secrets/${repoName}`;
+    const secretsDst = `${wtPath}/.secrets`;
+    if (
+      statSync(storeDir, { throwIfNoEntry: false })?.isDirectory() &&
+      !lstatSync(secretsDst, { throwIfNoEntry: false })
+    ) {
+      symlinkSync(storeDir, secretsDst);
+      console.log(`\x1b[32m+\x1b[0m .secrets symlink: ${secretsDst} → ${storeDir}`);
+    }
+  } catch { /* non-fatal */ }
+}
+
+/**
  * Create a new git worktree for an oracle task.
  * Returns the worktree path and window name.
  */
@@ -92,16 +146,8 @@ export async function createWorktree(
   }
   const baseArg = baseRef ? ` '${safe(baseRef)}'` : "";
   await hostExec(`git -C '${safe(repoPath)}' worktree add '${safe(wtPath)}' -b '${safe(branch)}'${baseArg}`);
-  // Mirror .agent symlink from main tree — it's gitignored so worktrees don't inherit it
-  try {
-    const agentSrc = `${repoPath}/.agent`;
-    const agentDst = `${wtPath}/.agent`;
-    const { lstatSync, readlinkSync, symlinkSync } = await import("fs");
-    if (lstatSync(agentSrc, { throwIfNoEntry: false })?.isSymbolicLink()) {
-      symlinkSync(readlinkSync(agentSrc), agentDst);
-      console.log(`\x1b[32m+\x1b[0m .agent symlink: ${agentDst}`);
-    }
-  } catch { /* non-fatal */ }
+  // Inject gitignored symlinks (.agent, .secrets) the fresh worktree can't inherit.
+  await injectWorktreeSymlinks(repoPath, wtPath, repoName);
   console.log(`\x1b[32m+\x1b[0m worktree: ${wtPath} (${branch})`);
   return { wtPath, windowName: `${oracle}-${name}` };
 }

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -143,6 +143,17 @@ export async function createWorktree(
   } catch { /* origin/HEAD not set — fall back to HEAD */ }
   if (baseRef) {
     try { await hostExec(`git -C '${safe(repoPath)}' fetch origin --quiet`); } catch { /* offline OK */ }
+    // Fast-forward LOCAL default branch from the just-fetched remote ref.
+    // Without this, an agent's `git checkout main` inside the fresh worktree
+    // lands on whatever stale ref the primary last pulled (thread #199 /
+    // parent #181 — wt-48 / PR #215 stale-base trap). update-ref refuses
+    // when the default branch is checked out in some worktree — that's the
+    // correct signal that primary branch discipline (§3c) regressed; we
+    // fall back silently rather than blocking spawn.
+    const localName = baseRef.replace(/^origin\//, "");
+    try {
+      await hostExec(`git -C '${safe(repoPath)}' update-ref 'refs/heads/${safe(localName)}' 'refs/remotes/${safe(baseRef)}'`);
+    } catch { /* default branch checked out somewhere — agent should branch off origin/<default> */ }
   }
   const baseArg = baseRef ? ` '${safe(baseRef)}'` : "";
   await hostExec(`git -C '${safe(repoPath)}' worktree add '${safe(wtPath)}' -b '${safe(branch)}'${baseArg}`);

--- a/src/commands/shared/wake-session.ts
+++ b/src/commands/shared/wake-session.ts
@@ -79,7 +79,19 @@ export async function createWorktree(
     await hostExec(`git -C '${safe(repoPath)}' commit --allow-empty -m "init: bootstrap for worktree"`);
   }
   try { await hostExec(`git -C '${safe(repoPath)}' branch -D '${safe(branch)}' 2>/dev/null`); } catch { /* ok */ }
-  await hostExec(`git -C '${safe(repoPath)}' worktree add '${safe(wtPath)}' -b '${safe(branch)}'`);
+  // Branch from origin/<default> (fresh) instead of primary worktree's HEAD —
+  // primary often parks on a stale feature branch from a prior session, which
+  // would otherwise propagate stale state to every new agent worktree. Fall
+  // back to no starting-point (current HEAD) if origin/HEAD isn't configured.
+  let baseRef = "";
+  try {
+    baseRef = await hostExec(`git -C '${safe(repoPath)}' symbolic-ref --short refs/remotes/origin/HEAD`);
+  } catch { /* origin/HEAD not set — fall back to HEAD */ }
+  if (baseRef) {
+    try { await hostExec(`git -C '${safe(repoPath)}' fetch origin --quiet`); } catch { /* offline OK */ }
+  }
+  const baseArg = baseRef ? ` '${safe(baseRef)}'` : "";
+  await hostExec(`git -C '${safe(repoPath)}' worktree add '${safe(wtPath)}' -b '${safe(branch)}'${baseArg}`);
   // Mirror .agent symlink from main tree — it's gitignored so worktrees don't inherit it
   try {
     const agentSrc = `${repoPath}/.agent`;

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -60,6 +60,17 @@ export interface BuildCommandOpts {
    * pane lands at an empty shell with the prompt discarded.
    */
   fresh?: boolean;
+  /**
+   * First-message prompt for the agent. Baked into the command as
+   * `-p '<escaped>'` — INSIDE the `{ … }` brace group and BEFORE the
+   * `; <reset>` suffix. Appending `-p` to buildCommand()'s *return value*
+   * (the pre-#541 pattern, reintroduced by the LOC-round-4 refactor) puts
+   * the flag on the trailing `clear`, not on `claude`, so the prompt is
+   * silently dropped and the pane lands idle at an empty input box. When
+   * the `||` fallback is emitted the prompt is baked into BOTH branches so
+   * it lands regardless of which one runs.
+   */
+  prompt?: string;
 }
 
 export function buildCommand(agentName: string, optsOrEngine?: string | BuildCommandOpts): string {
@@ -170,15 +181,26 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   // Reset terminal after Claude TUI exits — prevents frozen prompt (#1091)
   const reset = 'printf "\\e[?1049l\\e[0m"; stty sane 2>/dev/null; clear';
 
+  // Bake the first-message prompt into the agent command. This MUST happen
+  // before the `; ${reset}` suffix is appended and, for the fallback form,
+  // inside the `{ … }` brace group on BOTH branches — otherwise `-p` lands
+  // on the trailing `clear` and the prompt is silently lost (#wake-no-prompt
+  // regression: watcher wakes landed idle at an empty input box).
+  const withPrompt = (c: string): string => {
+    if (!opts.prompt) return c;
+    const escaped = opts.prompt.replace(/'/g, "'\\''");
+    return `${c} -p '${escaped}'`;
+  };
+
   // Skip the || fallback for fresh runs — the cmd has no --continue/--resume
   // so there's nothing to fall back from.
   if (!opts.fresh && (cmd.includes("--continue") || cmd.includes("--resume"))) {
     let fallback = cmd.replace(/\s*--continue\b/, "").replace(/\s*--resume\s+"[^"]*"/, "");
     if (sessionId) fallback += ` --session-id "${sessionId}"`;
-    return `{ ${cmd} || ${fallback}; }; ${reset}`;
+    return `{ ${withPrompt(cmd)} || ${withPrompt(fallback)}; }; ${reset}`;
   }
 
-  return `${cmd}; ${reset}`;
+  return `${withPrompt(cmd)}; ${reset}`;
 }
 
 /**

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -27,8 +27,23 @@ function matchGlob(pattern: string, name: string): boolean {
   return false;
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 export interface BuildCommandOpts {
   engine?: string;
+  /**
+   * Per-wake model override. Appended late so an explicit dispatch envelope
+   * can override a model baked into commands.<engine>.
+   */
+  model?: string;
+  /**
+   * Per-wake reasoning/effort override.
+   * - claude: `--effort <level>`
+   * - codex:  `-c model_reasoning_effort="<level>"`
+   */
+  reasoningEffort?: string;
   channels?: string[];
   channelEnv?: Record<string, string>;
   devChannels?: boolean;
@@ -131,6 +146,22 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   const stripEnvPrefix = (value: string): string =>
     value.replace(/^(?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)+/, "");
 
+  const appendRuntimeOptions = (value: string): string => {
+    const cPart = stripEnvPrefix(value);
+    let next = value;
+    if (opts.model) next += ` --model ${shellQuote(opts.model)}`;
+    if (opts.reasoningEffort) {
+      if (cPart.startsWith("codex")) {
+        next += ` -c ${shellQuote(`model_reasoning_effort="${opts.reasoningEffort}"`)}`;
+      } else if (cPart.startsWith("claude")) {
+        next += ` --effort ${shellQuote(opts.reasoningEffort)}`;
+      }
+    }
+    return next;
+  };
+
+  cmd = appendRuntimeOptions(cmd);
+
   const rewriteCodexResumeCommand = (value: string, resumeId: string): string => {
     const match = value.match(/^((?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)*)codex\b(.*)$/);
     if (!match) return `${value} --resume "${resumeId}"`;
@@ -228,10 +259,9 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   // regression: watcher wakes landed idle at an empty input box).
   const withPrompt = (c: string): string => {
     if (!opts.prompt) return c;
-    const escaped = opts.prompt.replace(/'/g, "'\\''");
     const cPart = stripEnvPrefix(c);
-    if (cPart.startsWith("codex")) return `${c} '${escaped}'`;
-    return `${c} -p '${escaped}'`;
+    if (cPart.startsWith("codex")) return `${c} ${shellQuote(opts.prompt)}`;
+    return `${c} -p ${shellQuote(opts.prompt)}`;
   };
 
   // Skip the || fallback for fresh runs — the cmd has no --continue/--resume

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -42,13 +42,12 @@ export interface BuildCommandOpts {
    */
   permissionMode?: "skip" | "relay";
   /**
-   * Resume a specific Claude session by id (UUID matching the JSONL filename
-   * under `~/.claude/projects/<encoded-cwd>/<id>.jsonl`). Wins over the
-   * implicit `--continue` injection below; emits `claude … --resume "<id>"`.
-   * Used by the directed-inbox watcher (Phase 2a) to pin a follow-up wake on
-   * thread N to the same session that handled the prior wake on thread N —
-   * keeps worktree count proportional to (oracle × thread) pairs instead of
-   * ballooning per wake.
+   * Resume a specific engine session by id.
+   * - claude: emits `claude … --resume "<id>"` (UUID from ~/.claude/projects)
+   * - codex:  emits `codex resume "<id>" …`     (id from session_meta payload)
+   *
+   * Used by directed-inbox routing to pin follow-up wakes for one campaign to
+   * the same conversation instead of spawning fresh sessions every time.
    */
   resume?: string;
   /**
@@ -62,7 +61,10 @@ export interface BuildCommandOpts {
   fresh?: boolean;
   /**
    * First-message prompt for the agent. Baked into the command as
-   * `-p '<escaped>'` — INSIDE the `{ … }` brace group and BEFORE the
+   * - claude: `-p '<escaped>'`
+   * - codex:  positional `'<escaped>'`
+   *
+   * The prompt is baked INSIDE the `{ … }` brace group and BEFORE the
    * `; <reset>` suffix. Appending `-p` to buildCommand()'s *return value*
    * (the pre-#541 pattern, reintroduced by the LOC-round-4 refactor) puts
    * the flag on the trailing `clear`, not on `claude`, so the prompt is
@@ -82,6 +84,10 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
 
   if (opts.engine && config.commands[opts.engine]) {
     cmd = config.commands[opts.engine];
+  } else if (opts.engine === "codex") {
+    // Fleet may pin engine=codex before local config defines commands.codex.
+    // Keep a safe built-in fallback so wake still launches the requested engine.
+    cmd = "codex";
   } else {
     cmd = config.commands.default || "claude";
     for (const [pattern, command] of Object.entries(config.commands)) {
@@ -122,13 +128,34 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
     cmd += " --dangerously-load-development-channels";
   }
 
-  // Caller-provided --resume <sid> wins over the implicit --continue below.
-  // Strip any pre-existing --continue / --resume in the configured cmd, then
-  // append the explicit session id. The standard fallback block below
-  // covers --resume too.
+  const stripEnvPrefix = (value: string): string =>
+    value.replace(/^(?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)+/, "");
+
+  // Engine kind after optional env-prefix injection from channelEnv.
+  let cmdPart = stripEnvPrefix(cmd);
+  let isClaudeEngine = cmdPart.startsWith("claude");
+  let isCodexEngine = cmdPart.startsWith("codex");
+
+  // Caller-provided resume id wins over implicit continuation behavior.
+  // Engine-specific resume wiring:
+  // - claude: keep legacy `--resume "<sid>"` flag
+  // - codex:  use the dedicated subcommand `codex resume "<sid>"`
   if (opts.resume) {
     cmd = cmd.replace(/\s*--continue\b/, "").replace(/\s*--resume\s+"[^"]*"/, "");
-    cmd += ` --resume "${opts.resume}"`;
+    if (isCodexEngine) {
+      cmd = cmd
+        // normalize accidental pre-baked `codex resume ...` templates
+        .replace(/^((?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)*)codex\s+resume(?:\s+"[^"]*"|\s+\S+)?\b/, "$1codex")
+        // inject explicit session id for codex resume
+        .replace(/^((?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)*)codex\b/, `$1codex resume "${opts.resume}"`);
+      // defensive fallback for unusual non-codex templates while engine=codex.
+      if (!stripEnvPrefix(cmd).startsWith("codex resume")) cmd += ` --resume "${opts.resume}"`;
+    } else {
+      cmd += ` --resume "${opts.resume}"`;
+    }
+    cmdPart = stripEnvPrefix(cmd);
+    isClaudeEngine = cmdPart.startsWith("claude");
+    isCodexEngine = cmdPart.startsWith("codex");
   }
 
   // Caller-asserted (or auto-probed) fresh cwd: strip any pre-existing
@@ -148,8 +175,9 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   // codex may silently ignore unknown flags, never tripping the fallback.
   // The simplest safe rule: cmd must start with `claude` (after optional env-
   // var prefix from `channelEnv`).
-  const cmdPart = cmd.replace(/^(?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)+/, "");
-  const isClaudeEngine = cmdPart.startsWith("claude");
+  cmdPart = stripEnvPrefix(cmd);
+  isClaudeEngine = cmdPart.startsWith("claude");
+  isCodexEngine = cmdPart.startsWith("codex");
   if (
     isClaudeEngine &&
     !opts.fresh &&
@@ -189,6 +217,8 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   const withPrompt = (c: string): string => {
     if (!opts.prompt) return c;
     const escaped = opts.prompt.replace(/'/g, "'\\''");
+    const cPart = stripEnvPrefix(c);
+    if (cPart.startsWith("codex")) return `${c} '${escaped}'`;
     return `${c} -p '${escaped}'`;
   };
 
@@ -220,7 +250,9 @@ export function buildCommandInDir(agentName: string, cwd: string, optsOrEngine?:
     ? { engine: optsOrEngine }
     : (optsOrEngine || {});
   if (opts.fresh === undefined && opts.resume === undefined && cwd) {
-    if (!hasContinuableSession(cwd)) {
+    // Claudе-only probe: codex uses `codex resume` (not `--continue`) so the
+    // ~/.claude/projects check would force pointless fresh-mode behavior.
+    if (opts.engine !== "codex" && !hasContinuableSession(cwd)) {
       opts.fresh = true;
     }
   }

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -131,10 +131,30 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   const stripEnvPrefix = (value: string): string =>
     value.replace(/^(?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)+/, "");
 
+  const rewriteCodexResumeCommand = (value: string, resumeId: string): string => {
+    const match = value.match(/^((?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)*)codex\b(.*)$/);
+    if (!match) return `${value} --resume "${resumeId}"`;
+
+    const envPrefix = match[1] || "";
+    let tail = (match[2] || "").trim();
+
+    // Normalize accidental pre-baked `codex resume ...` templates so explicit
+    // caller-provided resume IDs always win.
+    if (tail.startsWith("resume")) {
+      tail = tail.replace(/^resume(?:\s+"[^"]*"|\s+\S+)?\s*/, "");
+    }
+
+    // Explicit resume id and --last conflict semantically; drop --last when a
+    // concrete resume target is supplied by the caller.
+    tail = tail.replace(/\s*--last\b/g, "").trim();
+
+    // codex resume [OPTIONS] [SESSION_ID] [PROMPT]
+    return `${envPrefix}codex resume${tail ? ` ${tail}` : ""} "${resumeId}"`;
+  };
+
   // Engine kind after optional env-prefix injection from channelEnv.
   let cmdPart = stripEnvPrefix(cmd);
   let isClaudeEngine = cmdPart.startsWith("claude");
-  let isCodexEngine = cmdPart.startsWith("codex");
 
   // Caller-provided resume id wins over implicit continuation behavior.
   // Engine-specific resume wiring:
@@ -142,20 +162,13 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   // - codex:  use the dedicated subcommand `codex resume "<sid>"`
   if (opts.resume) {
     cmd = cmd.replace(/\s*--continue\b/, "").replace(/\s*--resume\s+"[^"]*"/, "");
-    if (isCodexEngine) {
-      cmd = cmd
-        // normalize accidental pre-baked `codex resume ...` templates
-        .replace(/^((?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)*)codex\s+resume(?:\s+"[^"]*"|\s+\S+)?\b/, "$1codex")
-        // inject explicit session id for codex resume
-        .replace(/^((?:[A-Z_][A-Z0-9_]*=(?:'[^']*'|\S*)\s+)*)codex\b/, `$1codex resume "${opts.resume}"`);
-      // defensive fallback for unusual non-codex templates while engine=codex.
-      if (!stripEnvPrefix(cmd).startsWith("codex resume")) cmd += ` --resume "${opts.resume}"`;
+    if (cmdPart.startsWith("codex")) {
+      cmd = rewriteCodexResumeCommand(cmd, opts.resume);
     } else {
       cmd += ` --resume "${opts.resume}"`;
     }
     cmdPart = stripEnvPrefix(cmd);
     isClaudeEngine = cmdPart.startsWith("claude");
-    isCodexEngine = cmdPart.startsWith("codex");
   }
 
   // Caller-asserted (or auto-probed) fresh cwd: strip any pre-existing
@@ -177,7 +190,6 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   // var prefix from `channelEnv`).
   cmdPart = stripEnvPrefix(cmd);
   isClaudeEngine = cmdPart.startsWith("claude");
-  isCodexEngine = cmdPart.startsWith("codex");
   if (
     isClaudeEngine &&
     !opts.fresh &&

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -1,5 +1,6 @@
 import { loadConfig } from "./load";
 import { homedir } from "os";
+import { hasContinuableSession } from "../core/util/claude-projects";
 
 /**
  * Expand a leading `~` to the user's home directory.
@@ -50,6 +51,15 @@ export interface BuildCommandOpts {
    * ballooning per wake.
    */
   resume?: string;
+  /**
+   * Strip `--continue` / `--resume` and skip the `||` shell-fallback. Set
+   * by `--fresh` callers OR auto-detected by `buildCommandInDir` when the
+   * target cwd has no JSONL under `~/.claude/projects/<encoded>/`. Without
+   * this, `claude --continue` exits 0 with "No conversation found to
+   * continue" in a fresh cwd, so the `||` fallback never fires and the
+   * pane lands at an empty shell with the prompt discarded.
+   */
+  fresh?: boolean;
 }
 
 export function buildCommand(agentName: string, optsOrEngine?: string | BuildCommandOpts): string {
@@ -103,11 +113,18 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
 
   // Caller-provided --resume <sid> wins over the implicit --continue below.
   // Strip any pre-existing --continue / --resume in the configured cmd, then
-  // append the explicit session id. No `||` fallback added here — the
-  // standard fallback block below covers both.
+  // append the explicit session id. The standard fallback block below
+  // covers --resume too.
   if (opts.resume) {
     cmd = cmd.replace(/\s*--continue\b/, "").replace(/\s*--resume\s+"[^"]*"/, "");
     cmd += ` --resume "${opts.resume}"`;
+  }
+
+  // Caller-asserted (or auto-probed) fresh cwd: strip any pre-existing
+  // --continue / --resume so we don't try to resume a session that doesn't
+  // exist. The `||` fallback block below also bails out for fresh runs.
+  if (opts.fresh) {
+    cmd = cmd.replace(/\s*--continue\b/, "").replace(/\s*--resume\s+"[^"]*"/, "");
   }
 
   // #1174 — `--continue` is the default for ALL claude wakes (not just
@@ -124,6 +141,7 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   const isClaudeEngine = cmdPart.startsWith("claude");
   if (
     isClaudeEngine &&
+    !opts.fresh &&
     !cmd.includes("--continue") &&
     !cmd.includes("--resume")
   ) {
@@ -152,7 +170,9 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   // Reset terminal after Claude TUI exits — prevents frozen prompt (#1091)
   const reset = 'printf "\\e[?1049l\\e[0m"; stty sane 2>/dev/null; clear';
 
-  if (cmd.includes("--continue") || cmd.includes("--resume")) {
+  // Skip the || fallback for fresh runs — the cmd has no --continue/--resume
+  // so there's nothing to fall back from.
+  if (!opts.fresh && (cmd.includes("--continue") || cmd.includes("--resume"))) {
     let fallback = cmd.replace(/\s*--continue\b/, "").replace(/\s*--resume\s+"[^"]*"/, "");
     if (sessionId) fallback += ` --session-id "${sessionId}"`;
     return `{ ${cmd} || ${fallback}; }; ${reset}`;
@@ -167,8 +187,22 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
  * already sets the initial pane cwd, and the scrollback noise wasn't worth
  * the reboot-recovery edge case. `cwd` param kept for API compat + future use.
  */
-export function buildCommandInDir(agentName: string, _cwd: string, optsOrEngine?: string | BuildCommandOpts): string {
-  return buildCommand(agentName, optsOrEngine);
+export function buildCommandInDir(agentName: string, cwd: string, optsOrEngine?: string | BuildCommandOpts): string {
+  // Auto-probe for "no continuable session" silent-fail. When the caller
+  // didn't explicitly opt in (fresh) or out (resume) and the target cwd
+  // has no JSONL under `~/.claude/projects/<encoded>/`, we set fresh=true
+  // ourselves — otherwise `claude --continue` exits 0 with "No conversation
+  // found to continue" and the `||` fallback never fires. This keeps every
+  // wake site safe without forcing every caller to remember the probe.
+  const opts: BuildCommandOpts = typeof optsOrEngine === "string"
+    ? { engine: optsOrEngine }
+    : (optsOrEngine || {});
+  if (opts.fresh === undefined && opts.resume === undefined && cwd) {
+    if (!hasContinuableSession(cwd)) {
+      opts.fresh = true;
+    }
+  }
+  return buildCommand(agentName, opts);
 }
 
 export function getEnvVars(): Record<string, string> {

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -40,6 +40,16 @@ export interface BuildCommandOpts {
    * so existing setups are unchanged.
    */
   permissionMode?: "skip" | "relay";
+  /**
+   * Resume a specific Claude session by id (UUID matching the JSONL filename
+   * under `~/.claude/projects/<encoded-cwd>/<id>.jsonl`). Wins over the
+   * implicit `--continue` injection below; emits `claude … --resume "<id>"`.
+   * Used by the directed-inbox watcher (Phase 2a) to pin a follow-up wake on
+   * thread N to the same session that handled the prior wake on thread N —
+   * keeps worktree count proportional to (oracle × thread) pairs instead of
+   * ballooning per wake.
+   */
+  resume?: string;
 }
 
 export function buildCommand(agentName: string, optsOrEngine?: string | BuildCommandOpts): string {
@@ -89,6 +99,15 @@ export function buildCommand(agentName: string, optsOrEngine?: string | BuildCom
   }
   if (opts.devChannels) {
     cmd += " --dangerously-load-development-channels";
+  }
+
+  // Caller-provided --resume <sid> wins over the implicit --continue below.
+  // Strip any pre-existing --continue / --resume in the configured cmd, then
+  // append the explicit session id. No `||` fallback added here — the
+  // standard fallback block below covers both.
+  if (opts.resume) {
+    cmd = cmd.replace(/\s*--continue\b/, "").replace(/\s*--resume\s+"[^"]*"/, "");
+    cmd += ` --resume "${opts.resume}"`;
   }
 
   // #1174 — `--continue` is the default for ALL claude wakes (not just

--- a/src/core/fleet/claude-jobs.ts
+++ b/src/core/fleet/claude-jobs.ts
@@ -1,0 +1,119 @@
+/**
+ * Fleet jobs — background scripts spawned by watchers that aren't Claude
+ * sessions themselves but matter operationally. Today: regression suite
+ * runs (`regression-then-investigate.sh`). Easy to extend to w2-watcher,
+ * cleanup loops, etc.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { hostExec } from "../transport/ssh";
+
+export type Exec = (cmd: string) => Promise<string>;
+
+export type JobKind = "regression" | "single-test";
+
+export interface FleetJob {
+  kind: JobKind;
+  pid: number;
+  startedAt: string;           // ISO
+  runId?: string;              // timestamp from $RUN_DIR name
+  runDir?: string;             // absolute path
+  singleTest?: string;         // test filename when kind=single-test
+  script: string;              // basename for display
+}
+
+export interface JobsOptions {
+  exec?: Exec;
+  runRoot?: string;            // override for tests
+}
+
+const DEFAULT_RUN_ROOT = join(homedir(), ".cache", "w2-watcher", "regression");
+const SCRIPT_NAME = "regression-then-investigate.sh";
+
+export async function listFleetJobs(opts: JobsOptions = {}): Promise<FleetJob[]> {
+  const exec = opts.exec || hostExec;
+  const runRoot = opts.runRoot || DEFAULT_RUN_ROOT;
+  const pids = await findScriptPids(SCRIPT_NAME, exec);
+  if (pids.length === 0) return [];
+
+  const jobs: FleetJob[] = [];
+  for (const pid of pids) {
+    const startedAt = await pidStartedAt(pid, exec);
+    const runDir = newestRunDir(runRoot, startedAt);
+    const { kind, singleTest } = classifyJob(runDir);
+    jobs.push({
+      kind,
+      pid,
+      startedAt,
+      runId: runDir ? runDir.split("/").pop() : undefined,
+      runDir: runDir || undefined,
+      singleTest,
+      script: SCRIPT_NAME,
+    });
+  }
+  return jobs;
+}
+
+export async function findScriptPids(basename: string, exec: Exec): Promise<number[]> {
+  // pgrep matches against command + args. -f searches full command line.
+  const raw = await exec(`pgrep -f '${basename.replace(/'/g, "'\\''")}' 2>/dev/null || true`).catch(() => "");
+  const self = process.pid;
+  return raw
+    .split("\n")
+    .map(l => Number(l.trim()))
+    .filter(p => p > 0 && p !== self);
+}
+
+async function pidStartedAt(pid: number, exec: Exec): Promise<string> {
+  const raw = (await exec(`ps -p ${pid} -o lstart= 2>/dev/null || true`).catch(() => "")).trim();
+  if (!raw) return new Date().toISOString();
+  const d = new Date(raw);
+  return isNaN(d.getTime()) ? new Date().toISOString() : d.toISOString();
+}
+
+/**
+ * Find the RUN_DIR a running script is writing to by taking the newest
+ * timestamped dir under runRoot whose mtime is close to the script's start.
+ * Avoids parsing env vars that macOS ps doesn't expose.
+ */
+export function newestRunDir(runRoot: string, startedAt: string): string | null {
+  if (!existsSync(runRoot)) return null;
+  let best: { path: string; mtime: number } | null = null;
+  const startMs = new Date(startedAt).getTime();
+  try {
+    for (const name of readdirSync(runRoot)) {
+      if (!/^\d{8}-\d{6}$/.test(name)) continue;
+      const full = join(runRoot, name);
+      const st = statSync(full);
+      if (!st.isDirectory()) continue;
+      // Prefer dirs created within +/- 30 min of the script start time
+      const dist = Math.abs(st.mtimeMs - startMs);
+      if (!best || dist < Math.abs(best.mtime - startMs)) {
+        best = { path: full, mtime: st.mtimeMs };
+      }
+    }
+  } catch { /* ignore */ }
+  return best?.path || null;
+}
+
+/**
+ * Classify kind by scanning log files in the RUN_DIR for the script's
+ * RUN_LABEL marker. "Single-test" in any log => single-test, else regression.
+ */
+export function classifyJob(runDir: string | null): { kind: JobKind; singleTest?: string } {
+  if (!runDir) return { kind: "regression" };
+  try {
+    for (const name of readdirSync(runDir)) {
+      if (!name.endsWith(".log") && !name.endsWith(".txt")) continue;
+      const content = readFileSync(join(runDir, name), "utf8");
+      // Match "Single-test" or SINGLE_TEST=<file>
+      if (/Single-test\b/i.test(content)) {
+        const m = content.match(/SINGLE_TEST=(\S+)/) || content.match(/single test[^:]*:\s*(\S+)/i);
+        return { kind: "single-test", singleTest: m?.[1] };
+      }
+      if (/\bRegression\b/.test(content)) return { kind: "regression" };
+    }
+  } catch { /* ignore */ }
+  return { kind: "regression" };
+}

--- a/src/core/fleet/worktree-live-panes.ts
+++ b/src/core/fleet/worktree-live-panes.ts
@@ -1,0 +1,60 @@
+import { hostExec } from "../transport/ssh";
+
+export interface LiveWorktreePane {
+  session: string;
+  windowIndex: string;
+  windowName: string;
+  paneIndex: string;
+  target: string;
+  command: string;
+  cwd: string;
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\s+\((?:deleted|dead)\)$/i, "").replace(/\/+$/, "");
+}
+
+export function cwdInsideWorktree(cwd: string | undefined, wtPath: string): boolean {
+  if (!cwd) return false;
+  const normalizedCwd = normalizePath(cwd);
+  const normalizedWt = normalizePath(wtPath);
+  return normalizedCwd === normalizedWt || normalizedCwd.startsWith(`${normalizedWt}/`);
+}
+
+export function parseTmuxPaneRows(raw: string): LiveWorktreePane[] {
+  return raw.split("\n").filter(Boolean).flatMap(line => {
+    const [session, windowIndex, windowName, paneIndex, command, cwd] = line.split("|||");
+    if (!session || !windowIndex || !paneIndex) return [];
+    return [{
+      session,
+      windowIndex,
+      windowName: windowName || "",
+      paneIndex,
+      target: `${session}:${windowIndex}.${paneIndex}`,
+      command: command || "",
+      cwd: cwd || "",
+    }];
+  });
+}
+
+export async function listTmuxPanes(): Promise<LiveWorktreePane[]> {
+  try {
+    const raw = await hostExec(
+      "tmux list-panes -a -F '#{session_name}|||#{window_index}|||#{window_name}|||#{pane_index}|||#{pane_current_command}|||#{pane_current_path}' 2>/dev/null || true"
+    );
+    return parseTmuxPaneRows(raw);
+  } catch {
+    return [];
+  }
+}
+
+export function findPanesInWorktree(
+  panes: LiveWorktreePane[],
+  wtPath: string,
+): LiveWorktreePane[] {
+  return panes.filter(pane => cwdInsideWorktree(pane.cwd, wtPath));
+}
+
+export async function listLiveWorktreePanes(wtPath: string): Promise<LiveWorktreePane[]> {
+  return findPanesInWorktree(await listTmuxPanes(), wtPath);
+}

--- a/src/core/fleet/worktrees-cleanup.test.ts
+++ b/src/core/fleet/worktrees-cleanup.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, mock } from "bun:test";
+import { join } from "path";
+
+const root = join(import.meta.dir, "../..");
+const wtPath = "/ghq/github.com/kxlahsimx09/mb-next-payment-gateway.wt-1-codex";
+let commands: string[] = [];
+
+mock.module(join(root, "core/transport/ssh"), () => ({
+  hostExec: async (cmd: string) => {
+    commands.push(cmd);
+    if (cmd.startsWith("tmux list-panes")) {
+      return "fleet|||1|||next-writer-codex|||0|||codex|||" + wtPath;
+    }
+    if (cmd.includes("worktree remove")) {
+      throw new Error("worktree remove should not run for active panes");
+    }
+    return "";
+  },
+  listSessions: async () => [
+    { name: "fleet", windows: [{ name: "next-writer-codex", index: 1, active: true }] },
+  ],
+}));
+
+mock.module(join(root, "core/transport/tmux"), () => ({
+  tmux: { killWindow: async () => {} },
+}));
+
+mock.module(join(root, "config/ghq-root"), () => ({
+  getGhqRoot: () => "/ghq",
+}));
+
+mock.module(join(root, "core/paths"), () => ({
+  MAW_ROOT: "/tmp/maw-test-root",
+  CONFIG_DIR: "/tmp/maw-test-nonexistent-config-cleanup",
+  FLEET_DIR: "/tmp/maw-test-nonexistent-fleet-cleanup",
+  CONFIG_FILE: "/tmp/maw-test-nonexistent-config-cleanup/maw.config.json",
+  resolveHome: () => "/tmp/maw-test-home",
+}));
+
+const { cleanupWorktree } = await import("./worktrees-cleanup");
+
+describe("cleanupWorktree active-pane guard", () => {
+  it("refuses to remove a worktree while a live pane cwd is inside it", async () => {
+    commands = [];
+
+    const log = await cleanupWorktree(wtPath);
+
+    expect(log.join("\n")).toContain("refusing to remove active worktree");
+    expect(log.join("\n")).toContain("fleet:1.0 codex");
+    expect(commands.some(cmd => cmd.includes("worktree remove"))).toBe(false);
+  });
+});

--- a/src/core/fleet/worktrees-cleanup.ts
+++ b/src/core/fleet/worktrees-cleanup.ts
@@ -5,6 +5,7 @@ import { readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { FLEET_DIR } from "../paths";
 import { resolveWorktreeTarget } from "../matcher/resolve-target";
+import { listLiveWorktreePanes } from "./worktree-live-panes";
 
 /**
  * Clean up a single worktree by path.
@@ -29,6 +30,15 @@ export async function cleanupWorktree(wtPath: string): Promise<string[]> {
   const org = parentParts.join("/");
   const mainPath = join(reposRoot, org, mainRepoName);
   const repo = `${org}/${dirName}`;
+
+  const livePanes = await listLiveWorktreePanes(wtPath);
+  if (livePanes.length > 0) {
+    log.push(`refusing to remove active worktree ${dirName}`);
+    for (const pane of livePanes) {
+      log.push(`    live pane: ${pane.target} ${pane.command || "?"} (${pane.cwd})`);
+    }
+    return log;
+  }
 
   // 1. Find and kill tmux window
   const sessions = await listSessions();
@@ -67,7 +77,7 @@ export async function cleanupWorktree(wtPath: string): Promise<string[]> {
   try { branch = (await hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected: worktree may be corrupt */ }
 
   try {
-    await hostExec(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);
+    await hostExec(`git -C '${mainPath}' worktree remove '${wtPath}'`);
     await hostExec(`git -C '${mainPath}' worktree prune`);
     log.push(`removed worktree ${dirName}`);
   } catch (e: any) {

--- a/src/core/fleet/worktrees-scan.test.ts
+++ b/src/core/fleet/worktrees-scan.test.ts
@@ -12,17 +12,22 @@
  * them so the worktree resolves to "active" rather than logging an
  * ambiguous-match error.
  */
-import { describe, it, expect, mock } from "bun:test";
+import { beforeEach, describe, it, expect, mock } from "bun:test";
 import { join } from "path";
 
 const root = join(import.meta.dir, "../..");
+let stubFindOutput = "/ghq/github.com/Org/foo-oracle/foo-oracle.wt-1-neo";
+let stubPaneOutput = "";
 
 // Stub host execution: `find` returns one worktree path, `git rev-parse`
 // returns a branch name, anything else returns empty.
 mock.module(join(root, "core/transport/ssh"), () => ({
   hostExec: async (cmd: string) => {
+    if (cmd.startsWith("tmux list-panes")) {
+      return stubPaneOutput;
+    }
     if (cmd.includes("find ") && cmd.includes(".wt-")) {
-      return "/ghq/github.com/Org/foo-oracle/foo-oracle.wt-1-neo";
+      return stubFindOutput;
     }
     if (cmd.includes("rev-parse --abbrev-ref")) {
       return "agents/1-neo";
@@ -43,12 +48,21 @@ mock.module(join(root, "config/ghq-root"), () => ({
 
 // Avoid touching real fleet dir
 mock.module(join(root, "core/paths"), () => ({
+  MAW_ROOT: "/tmp/maw-test-root",
+  CONFIG_DIR: "/tmp/maw-test-nonexistent-config-823",
   FLEET_DIR: "/tmp/maw-test-nonexistent-fleet-823",
+  CONFIG_FILE: "/tmp/maw-test-nonexistent-config-823/maw.config.json",
+  resolveHome: () => "/tmp/maw-test-home",
 }));
 
 const { scanWorktrees } = await import("./worktrees-scan");
 
 describe("scanWorktrees (#823 Bug C) — dedupe windows across sessions", () => {
+  beforeEach(() => {
+    stubFindOutput = "/ghq/github.com/Org/foo-oracle/foo-oracle.wt-1-neo";
+    stubPaneOutput = "";
+  });
+
   it("same-named window in 2 sessions resolves cleanly (no phantom ambiguous)", async () => {
     // Capture stderr — pre-fix path emits "is ambiguous — matches 2 windows"
     const errLogs: string[] = [];
@@ -68,6 +82,27 @@ describe("scanWorktrees (#823 Bug C) — dedupe windows across sessions", () => 
       // No ambiguous-match noise should have been printed.
       const combined = errLogs.join("\n");
       expect(combined).not.toContain("ambiguous");
+    } finally {
+      console.error = origErr;
+    }
+  });
+
+  it("live pane cwd marks worktree active even when window names are ambiguous", async () => {
+    const wtPath = "/ghq/github.com/kxlahsimx09/mb-next-payment-gateway.wt-1-codex";
+    const errLogs: string[] = [];
+    stubFindOutput = wtPath;
+    stubPaneOutput = "fleet|||1|||next-writer-codex|||0|||codex|||" + `${wtPath}/src`;
+
+    const origErr = console.error;
+    console.error = (...a: any[]) => { errLogs.push(a.map(String).join(" ")); };
+
+    try {
+      const results = await scanWorktrees();
+      const wt = results.find(r => r.path === wtPath);
+      expect(wt).toBeDefined();
+      expect(wt!.status).toBe("active");
+      expect(wt!.tmuxWindow).toBe("next-writer-codex");
+      expect(errLogs.join("\n")).not.toContain("ambiguous");
     } finally {
       console.error = origErr;
     }

--- a/src/core/fleet/worktrees-scan.ts
+++ b/src/core/fleet/worktrees-scan.ts
@@ -4,6 +4,11 @@ import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { FLEET_DIR } from "../paths";
 import { resolveWorktreeTarget } from "../matcher/resolve-target";
+import {
+  findPanesInWorktree,
+  listTmuxPanes,
+  type LiveWorktreePane,
+} from "./worktree-live-panes";
 
 export interface WorktreeInfo {
   path: string;
@@ -48,6 +53,11 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
     }
   }
 
+  let livePanes: LiveWorktreePane[] = [];
+  try {
+    livePanes = await listTmuxPanes();
+  } catch { /* pane cwd detection is best-effort */ }
+
   // 3. Load fleet configs for matching
   const fleetWindows = new Map<string, string>(); // repo -> fleet file
   try {
@@ -84,65 +94,70 @@ export async function scanWorktrees(): Promise<WorktreeInfo[]> {
       branch = (await hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD 2>/dev/null`)).trim();
     } catch { branch = "unknown"; }
 
-    // Match to tmux window — check fleet config or name pattern
+    // Match to tmux window. First bind by live pane cwd, which is
+    // authoritative even when generic task names (e.g. "codex") make
+    // window-name matching ambiguous. Fall back to window-name matching.
     let tmuxWindow: string | undefined;
     const fleetFile = fleetWindows.get(repo);
+    const livePane = findPanesInWorktree(livePanes, wtPath)[0];
+    if (livePane) {
+      tmuxWindow = livePane.windowName || livePane.target;
+    } else {
 
-    // Try to find matching window by name pattern
-    // Window names like "neo-freelance" match wt name "1-freelance"
-    const taskPart = wtName.replace(/^\d+-/, "");
-    // #823 Bug C — dedupe windows by name across sessions. Without this, a
-    // window named X that exists in 2 sessions surfaces as 2 candidates in
-    // the ambiguous-match list, manufacturing phantom duplicates.
-    const allWindows = [
-      ...new Map(sessions.flatMap(s => s.windows).map(w => [w.name, w])).values()
-    ];
-
-    // #935 — scope window search to PARENT oracle's session first.
-    // Pre-fix: a global search across all sessions ambiguously matched
-    // generic worktree names (e.g. `1--no-attach`) when 4 oracles each had
-    // a `--no-attach` window. Post-fix: try the parent oracle's session
-    // first; only fall back to global if the scoped search finds nothing.
-    //
-    // Parent oracle name is derived by stripping the trailing `-oracle`
-    // suffix from the main repo (e.g. `pulse-oracle` → `pulse`). Sessions
-    // can be named bare (`pulse`) or with a fleet-numeric prefix
-    // (`NN-pulse`), so we accept either shape.
-    const parentOracleName = mainRepoName.replace(/-oracle$/, "");
-    const parentSessions = sessions.filter(s =>
-      s.name === parentOracleName || s.name.endsWith(`-${parentOracleName}`)
-    );
-    let resolved: ReturnType<typeof resolveWorktreeTarget> | undefined;
-    if (parentSessions.length > 0) {
-      const scopedWindows = [
-        ...new Map(parentSessions.flatMap(s => s.windows).map(w => [w.name, w])).values()
+      // Try to find matching window by name pattern
+      // Window names like "neo-freelance" match wt name "1-freelance"
+      const taskPart = wtName.replace(/^\d+-/, "");
+      // #823 Bug C — dedupe windows by name across sessions. Without this, a
+      // window named X that exists in 2 sessions surfaces as 2 candidates in
+      // the ambiguous-match list, manufacturing phantom duplicates.
+      const allWindows = [
+        ...new Map(sessions.flatMap(s => s.windows).map(w => [w.name, w])).values()
       ];
-      const localResolved = resolveWorktreeTarget(taskPart, scopedWindows);
-      if (localResolved.kind === "exact" || localResolved.kind === "fuzzy") {
-        resolved = localResolved;
-      }
-    }
-    // Fall back to global search (existing behavior) when no parent session
-    // exists or when the scoped search did not produce a clean bind.
-    if (!resolved) {
-      resolved = resolveWorktreeTarget(taskPart, allWindows);
-    }
-    switch (resolved.kind) {
-      case "exact":
-      case "fuzzy":
-        tmuxWindow = resolved.match.name;
-        break;
-      case "ambiguous":
-        console.error(`  \x1b[31m✗\x1b[0m '${taskPart}' is ambiguous — matches ${resolved.candidates.length} windows:`);
-        for (const c of resolved.candidates) {
-          console.error(`  \x1b[90m    • ${c.name}\x1b[0m`);
+
+      // #935 — scope window search to PARENT oracle's session first.
+      // Pre-fix: a global search across all sessions ambiguously matched
+      // generic worktree names (e.g. `1--no-attach`) when 4 oracles each had
+      // a `--no-attach` window. Post-fix: try the parent oracle's session
+      // first; only fall back to global if the scoped search finds nothing.
+      //
+      // Parent oracle name is derived by stripping the trailing `-oracle`
+      // suffix from the main repo (e.g. `pulse-oracle` → `pulse`). Sessions
+      // can be named bare (`pulse`) or with a fleet-numeric prefix
+      // (`NN-pulse`), so we accept either shape.
+      const parentOracleName = mainRepoName.replace(/-oracle$/, "");
+      const parentSessions = sessions.filter(s =>
+        s.name === parentOracleName || s.name.endsWith(`-${parentOracleName}`)
+      );
+      let resolved: ReturnType<typeof resolveWorktreeTarget> | undefined;
+      if (parentSessions.length > 0) {
+        const scopedWindows = [
+          ...new Map(parentSessions.flatMap(s => s.windows).map(w => [w.name, w])).values()
+        ];
+        const localResolved = resolveWorktreeTarget(taskPart, scopedWindows);
+        if (localResolved.kind === "exact" || localResolved.kind === "fuzzy") {
+          resolved = localResolved;
         }
-        console.error(`  \x1b[90m  leaving worktree ${wtName} unbound (status: stale)\x1b[0m`);
-        // tmuxWindow stays undefined → status = stale
-        break;
-      case "none":
-        // no running window → status = stale
-        break;
+      }
+      // Fall back to global search (existing behavior) when no parent session
+      // exists or when the scoped search did not produce a clean bind.
+      if (!resolved) {
+        resolved = resolveWorktreeTarget(taskPart, allWindows);
+      }
+      switch (resolved.kind) {
+        case "exact":
+        case "fuzzy":
+          tmuxWindow = resolved.match.name;
+          break;
+        case "ambiguous":
+          console.error(`  \x1b[31m✗\x1b[0m '${taskPart}' is ambiguous — matches ${resolved.candidates.length} windows:`);
+          for (const c of resolved.candidates) {
+            console.error(`  \x1b[90m    • ${c.name}\x1b[0m`);
+          }
+          console.error(`  \x1b[90m  leaving worktree ${wtName} unbound (status: stale)\x1b[0m`);
+          break;
+        case "none":
+          break;
+      }
     }
 
     const status: WorktreeInfo["status"] = tmuxWindow ? "active" : "stale";

--- a/src/core/util/claude-projects.ts
+++ b/src/core/util/claude-projects.ts
@@ -1,0 +1,38 @@
+/**
+ * Helpers for the Claude Code projects directory layout.
+ *
+ * Claude stores each project's session JSONLs under
+ * `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`, where the cwd
+ * encoding replaces `/` and `.` with `-`. We use the encoding to find
+ * sessions that match a target worktree, and the existence-check to
+ * detect "no prior conversation" so wake doesn't emit `claude --continue`
+ * into a fresh cwd (which exits 0 with "No conversation found to continue"
+ * — the `||` fallback never fires and the pane is left empty).
+ */
+import { existsSync, readdirSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+/**
+ * Encode a cwd path the way Claude Code does for its projects directory:
+ * `/` and `.` are both replaced with `-`. Idempotent — already-encoded
+ * names map to themselves.
+ */
+export function encodeCwd(cwd: string): string {
+  return cwd.replace(/[/.]/g, "-");
+}
+
+/**
+ * True iff `~/.claude/projects/<encoded-cwd>/` contains at least one
+ * `.jsonl` file. Used by buildCommandInDir to decide whether to inject
+ * `--continue` (would silently fail in a cwd with no prior session).
+ */
+export function hasContinuableSession(cwd: string): boolean {
+  const dir = join(homedir(), ".claude", "projects", encodeCwd(cwd));
+  if (!existsSync(dir)) return false;
+  try {
+    return readdirSync(dir).some(f => f.endsWith(".jsonl"));
+  } catch {
+    return false;
+  }
+}

--- a/test/build-command-contract.test.ts
+++ b/test/build-command-contract.test.ts
@@ -132,6 +132,11 @@ describe("buildCommand — post-#541 contract", () => {
     expect(buildCommand("any-agent", "codex")).toBe(wrap("codex --search"));
   });
 
+  test("engine=codex falls back to built-in codex command when commands.codex is missing", () => {
+    fakeConfig.commands = { default: "claude" };
+    expect(buildCommand("any-agent", "codex")).toBe(wrap("codex"));
+  });
+
   test("engine param falls back to default when engine not in config (#1174 fallback for claude)", () => {
     fakeConfig.commands = { default: "claude" };
     // Falls back to default "claude" → #1174 auto-injects --continue.
@@ -171,6 +176,15 @@ describe("buildCommand — post-#541 contract", () => {
     fakeConfig.commands = { default: "claude", codex: "codex --search" };
     expect(buildCommand("any-agent", "codex")).toBe(wrap("codex --search"));
     expect(buildCommand("any-agent", "codex")).not.toContain("--continue");
+  });
+
+  test("codex resume uses subcommand form, not --resume flag", () => {
+    fakeConfig.commands = { default: "claude", codex: "codex --dangerously-bypass-approvals-and-sandbox" };
+    const out = buildCommand("any-agent", { engine: "codex", resume: "019a47f7-1a4e-7b50-93a4-c6d8a73645e5" });
+    expect(out).toBe(
+      wrap('codex resume "019a47f7-1a4e-7b50-93a4-c6d8a73645e5" --dangerously-bypass-approvals-and-sandbox'),
+    );
+    expect(out).not.toContain("--resume");
   });
 
   test("#1174: pattern-matched non-claude command does NOT get --continue", () => {
@@ -255,5 +269,12 @@ describe("buildCommand — prompt baking (#wake-no-prompt regression)", () => {
     fakeConfig.commands = { default: "claude" };
     expect(buildCommandInDir("foo", "/tmp/x", { fresh: true, prompt: "hi" }))
       .toBe(wrap("claude -p 'hi'"));
+  });
+
+  test("codex prompt uses positional argument (not -p profile flag)", () => {
+    fakeConfig.commands = { default: "claude", codex: "codex --dangerously-bypass-approvals-and-sandbox" };
+    const out = buildCommand("any-agent", { engine: "codex", prompt: "อ่าน handoff ใหม่" });
+    expect(out).toBe(wrap("codex --dangerously-bypass-approvals-and-sandbox 'อ่าน handoff ใหม่'"));
+    expect(out).not.toContain(" -p '");
   });
 });

--- a/test/build-command-contract.test.ts
+++ b/test/build-command-contract.test.ts
@@ -187,6 +187,49 @@ describe("buildCommand — post-#541 contract", () => {
     expect(out).not.toContain("--resume");
   });
 
+  test("claude model + reasoning effort overrides are appended before prompt/fallback", () => {
+    fakeConfig.commands = { default: "claude" };
+    const out = buildCommand("any-agent", {
+      model: "opus",
+      reasoningEffort: "xhigh",
+      prompt: "do work",
+    });
+    expect(out).toBe(
+      wrapFallback(
+        "claude --model 'opus' --effort 'xhigh' --continue -p 'do work'",
+        "claude --model 'opus' --effort 'xhigh' -p 'do work'",
+      ),
+    );
+  });
+
+  test("codex model + reasoning effort uses Codex CLI config override", () => {
+    fakeConfig.commands = { default: "claude", codex: "codex --search" };
+    const out = buildCommand("any-agent", {
+      engine: "codex",
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+    });
+    expect(out).toBe(
+      wrap(`codex --search --model 'gpt-5.5' -c 'model_reasoning_effort="xhigh"'`),
+    );
+  });
+
+  test("codex resume keeps runtime options before session id", () => {
+    fakeConfig.commands = { default: "claude", codex: "codex --dangerously-bypass-approvals-and-sandbox --search" };
+    const out = buildCommand("any-agent", {
+      engine: "codex",
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+      resume: "019a47f7-1a4e-7b50-93a4-c6d8a73645e5",
+      prompt: "continue",
+    });
+    expect(out).toBe(
+      wrap(
+        `codex resume --dangerously-bypass-approvals-and-sandbox --search --model 'gpt-5.5' -c 'model_reasoning_effort="xhigh"' "019a47f7-1a4e-7b50-93a4-c6d8a73645e5" 'continue'`,
+      ),
+    );
+  });
+
   test("#1174: pattern-matched non-claude command does NOT get --continue", () => {
     // Pattern `foo-*` resolves to `echo hi` — not claude, no --continue.
     fakeConfig.commands = { default: "claude", "foo-*": "echo hi" };

--- a/test/build-command-contract.test.ts
+++ b/test/build-command-contract.test.ts
@@ -117,8 +117,12 @@ describe("buildCommand — post-#541 contract", () => {
 
   test("buildCommandInDir returns buildCommand verbatim (no cd preamble; #1091 reset is part of contract now)", () => {
     fakeConfig.commands = { default: "claude --continue --dangerously-skip-permissions" };
-    const direct = buildCommand("foo");
-    const inDir = buildCommandInDir("foo", "/tmp/some where/nested");
+    // Pin `fresh` so the buildCommandInDir auto-fresh JSONL probe (#54263ef)
+    // doesn't diverge from buildCommand for a cwd that happens to have no
+    // continuable session — this test is about the no-`cd`-preamble contract,
+    // not the probe (the probe has its own coverage).
+    const direct = buildCommand("foo", { fresh: false });
+    const inDir = buildCommandInDir("foo", "/tmp/some where/nested", { fresh: false });
     expect(inDir).toBe(direct);
     expect(inDir).not.toContain("cd ");
   });
@@ -203,5 +207,53 @@ describe("buildCommand — post-#541 contract", () => {
         expect(inDir.startsWith("cd ")).toBe(false);
       }
     }
+  });
+});
+
+// Prompt baking — regression guard for the directed-inbox `failed_no_prompt`
+// silent-fail. The LOC-round-4 refactor dropped `prompt` from buildCommand and
+// reintroduced the pre-#541 pattern of appending ` -p '…'` to the *return
+// value* of buildCommand — which puts the flag AFTER the `; <reset>` suffix,
+// so `-p` lands on the trailing `clear`, not `claude`. The agent wakes idle at
+// an empty input box. buildCommand must bake the prompt INSIDE the command.
+describe("buildCommand — prompt baking (#wake-no-prompt regression)", () => {
+  test("bare claude default: prompt baked into BOTH || fallback branches", () => {
+    fakeConfig.commands = { default: "claude" };
+    expect(buildCommand("any-agent", { prompt: "hello world" })).toBe(
+      wrapFallback("claude --continue -p 'hello world'", "claude -p 'hello world'"),
+    );
+  });
+
+  test("fresh run: prompt baked before the reset suffix (no fallback)", () => {
+    fakeConfig.commands = { default: "claude" };
+    const out = buildCommand("any-agent", { fresh: true, prompt: "do the thing" });
+    expect(out).toBe(wrap("claude -p 'do the thing'"));
+    // -p must precede the reset suffix — never trail `clear`.
+    expect(out).not.toMatch(/clear\s+-p/);
+    expect(out.indexOf("-p '")).toBeLessThan(out.indexOf("; printf"));
+  });
+
+  test("-p sits inside the brace group, never after the closing `}`", () => {
+    fakeConfig.commands = { default: "claude --continue --dangerously-skip-permissions" };
+    const out = buildCommand("any-agent", { prompt: "task" });
+    expect(out.indexOf("-p 'task'")).toBeLessThan(out.indexOf("; }"));
+    expect(out).not.toMatch(/\}\S*\s*-p/);
+  });
+
+  test("single quotes in the prompt are shell-escaped", () => {
+    fakeConfig.commands = { default: "claude" };
+    const out = buildCommand("any-agent", { fresh: true, prompt: "it's a 'quoted' task" });
+    expect(out).toBe(wrap("claude -p 'it'\\''s a '\\''quoted'\\'' task'"));
+  });
+
+  test("no prompt → command is byte-identical to the prompt-less form", () => {
+    fakeConfig.commands = { default: "claude" };
+    expect(buildCommand("any-agent", { prompt: undefined })).toBe(buildCommand("any-agent"));
+  });
+
+  test("buildCommandInDir forwards the prompt opt", () => {
+    fakeConfig.commands = { default: "claude" };
+    expect(buildCommandInDir("foo", "/tmp/x", { fresh: true, prompt: "hi" }))
+      .toBe(wrap("claude -p 'hi'"));
   });
 });

--- a/test/build-command-contract.test.ts
+++ b/test/build-command-contract.test.ts
@@ -182,7 +182,7 @@ describe("buildCommand — post-#541 contract", () => {
     fakeConfig.commands = { default: "claude", codex: "codex --dangerously-bypass-approvals-and-sandbox" };
     const out = buildCommand("any-agent", { engine: "codex", resume: "019a47f7-1a4e-7b50-93a4-c6d8a73645e5" });
     expect(out).toBe(
-      wrap('codex resume "019a47f7-1a4e-7b50-93a4-c6d8a73645e5" --dangerously-bypass-approvals-and-sandbox'),
+      wrap('codex resume --dangerously-bypass-approvals-and-sandbox "019a47f7-1a4e-7b50-93a4-c6d8a73645e5"'),
     );
     expect(out).not.toContain("--resume");
   });
@@ -276,5 +276,20 @@ describe("buildCommand — prompt baking (#wake-no-prompt regression)", () => {
     const out = buildCommand("any-agent", { engine: "codex", prompt: "อ่าน handoff ใหม่" });
     expect(out).toBe(wrap("codex --dangerously-bypass-approvals-and-sandbox 'อ่าน handoff ใหม่'"));
     expect(out).not.toContain(" -p '");
+  });
+
+  test("codex resume + prompt keeps both session continuity and follow-up task", () => {
+    fakeConfig.commands = { default: "claude", codex: "codex --dangerously-bypass-approvals-and-sandbox --search" };
+    const out = buildCommand("any-agent", {
+      engine: "codex",
+      resume: "019a47f7-1a4e-7b50-93a4-c6d8a73645e5",
+      prompt: "continue this campaign",
+    });
+    expect(out).toBe(
+      wrap(
+        'codex resume --dangerously-bypass-approvals-and-sandbox --search "019a47f7-1a4e-7b50-93a4-c6d8a73645e5" \'continue this campaign\'',
+      ),
+    );
+    expect(out).not.toContain("--resume");
   });
 });

--- a/test/claude-jobs.test.ts
+++ b/test/claude-jobs.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdir, writeFile, rm, utimes } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { listFleetJobs, classifyJob, newestRunDir } from "../src/core/fleet/claude-jobs";
+
+const TMP = join(tmpdir(), `claude-jobs-test-${process.pid}`);
+
+beforeAll(async () => {
+  await mkdir(TMP, { recursive: true });
+});
+
+afterAll(async () => {
+  await rm(TMP, { recursive: true, force: true }).catch(() => {});
+});
+
+describe("classifyJob", () => {
+  test("null runDir → regression generic", () => {
+    expect(classifyJob(null)).toEqual({ kind: "regression" });
+  });
+
+  test("log with 'Regression' → regression", async () => {
+    const d = join(TMP, "run-reg");
+    await mkdir(d, { recursive: true });
+    await writeFile(join(d, "out.log"), "Regression starting on branch main\n");
+    expect(classifyJob(d)).toEqual({ kind: "regression" });
+  });
+
+  test("log with 'Single-test' → single-test + parses test name", async () => {
+    const d = join(TMP, "run-single");
+    await mkdir(d, { recursive: true });
+    await writeFile(join(d, "out.log"), "Single-test run\nSINGLE_TEST=test-mixed-flow.sh\n");
+    const r = classifyJob(d);
+    expect(r.kind).toBe("single-test");
+    expect(r.singleTest).toBe("test-mixed-flow.sh");
+  });
+});
+
+describe("newestRunDir", () => {
+  test("returns null when runRoot missing", () => {
+    expect(newestRunDir("/nonexistent/path/xyz", new Date().toISOString())).toBeNull();
+  });
+
+  test("picks the dir whose mtime is closest to startedAt", async () => {
+    const root = join(TMP, "run-root");
+    await mkdir(root, { recursive: true });
+    const now = Date.now();
+    const near = join(root, "20260422-120000");
+    const far = join(root, "20260422-110000");
+    await mkdir(near, { recursive: true });
+    await mkdir(far, { recursive: true });
+    // near is at now, far is 1h earlier
+    await utimes(near, now / 1000, now / 1000);
+    await utimes(far, (now - 3600_000) / 1000, (now - 3600_000) / 1000);
+    const startedAt = new Date(now).toISOString();
+    expect(newestRunDir(root, startedAt)).toBe(near);
+  });
+
+  test("ignores non-timestamp dirs", async () => {
+    const root = join(TMP, "run-root-mixed");
+    await mkdir(root, { recursive: true });
+    await mkdir(join(root, "not-a-timestamp"), { recursive: true });
+    await mkdir(join(root, "20260422-120000"), { recursive: true });
+    const r = newestRunDir(root, new Date().toISOString());
+    expect(r).toBe(join(root, "20260422-120000"));
+  });
+});
+
+describe("listFleetJobs", () => {
+  test("empty when no regression script running", async () => {
+    const fakeExec = async (cmd: string) => {
+      if (cmd.includes("pgrep")) return "";
+      return "";
+    };
+    const jobs = await listFleetJobs({ exec: fakeExec, runRoot: TMP });
+    expect(jobs).toEqual([]);
+  });
+
+  test("returns job when pgrep finds PID + runDir has marker", async () => {
+    const root = join(TMP, "live-run");
+    await mkdir(root, { recursive: true });
+    const runDir = join(root, "20260422-130000");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(join(runDir, "out.log"), "Single-test run\nSINGLE_TEST=test-foo.sh\n");
+    const fakeExec = async (cmd: string) => {
+      if (cmd.includes("pgrep")) return "12345\n";
+      if (cmd.includes("ps -p 12345 -o lstart")) {
+        return new Date().toString() + "\n";
+      }
+      return "";
+    };
+    const jobs = await listFleetJobs({ exec: fakeExec, runRoot: root });
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].pid).toBe(12345);
+    expect(jobs[0].kind).toBe("single-test");
+    expect(jobs[0].singleTest).toBe("test-foo.sh");
+    expect(jobs[0].runId).toBe("20260422-130000");
+  });
+});

--- a/test/isolated/worktree-scope-match-935.test.ts
+++ b/test/isolated/worktree-scope-match-935.test.ts
@@ -53,7 +53,11 @@ mock.module(join(root, "config/ghq-root"), () => ({
 }));
 
 mock.module(join(root, "core/paths"), () => ({
+  MAW_ROOT: "/tmp/maw-test-root",
+  CONFIG_DIR: "/tmp/maw-test-nonexistent-config-935",
   FLEET_DIR: "/tmp/maw-test-nonexistent-fleet-935",
+  CONFIG_FILE: "/tmp/maw-test-nonexistent-config-935/maw.config.json",
+  resolveHome: () => "/tmp/maw-test-home",
 }));
 
 const { scanWorktrees } = await import(join(root, "core/fleet/worktrees-scan"));

--- a/test/wake-session-create-worktree.test.ts
+++ b/test/wake-session-create-worktree.test.ts
@@ -1,0 +1,104 @@
+/**
+ * createWorktree fast-forwards LOCAL default branch from origin after fetch.
+ *
+ * Without this, an agent's `git checkout main` inside the fresh worktree lands
+ * on the stale local main ref that the primary checkout last pulled (which on
+ * a §3c primary parked on a non-default integration branch can be days old) —
+ * the wt-48 / PR #215 stale-base trap (thread #199, parent #181).
+ *
+ * Diagnosed by brew-ops 2026-05-21. This test pins the fix so a future
+ * createWorktree refactor that drops the update-ref line fails loudly.
+ */
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { mockConfigModule } from "./helpers/mock-config";
+
+const calls: string[] = [];
+let symbolicRefReturn = "origin/main"; // default — origin/HEAD configured
+let symbolicRefThrows = false;
+
+// Spread the real sdk so untouched exports (curlFetch, runHook, …) keep working
+// for tests that load after this file. bun mock.module is process-global, so
+// partial mocks pollute. We override hostExec + tmux only.
+const realSdk = await import("../src/sdk");
+mock.module("../src/sdk", () => ({
+  ...realSdk,
+  hostExec: async (cmd: string): Promise<string> => {
+    calls.push(cmd);
+    if (cmd.includes("symbolic-ref --short refs/remotes/origin/HEAD")) {
+      if (symbolicRefThrows) throw new Error("origin/HEAD not set");
+      return symbolicRefReturn;
+    }
+    if (cmd.includes("rev-parse HEAD")) return "abc123\n";
+    return "";
+  },
+  tmux: { ...realSdk.tmux, switchClient: async () => {} },
+}));
+
+// Full config module surface — bun mock.module is process-global, so a partial
+// mock pollutes other tests. See helpers/mock-config.ts (#435).
+mock.module("../src/config", () => mockConfigModule(() => ({ node: "test-node" })));
+
+const { createWorktree } = await import("../src/commands/shared/wake-session");
+
+describe("createWorktree — local default branch is fast-forwarded after fetch (thread #199)", () => {
+  let tmpRepo: string;
+  let tmpParent: string;
+
+  beforeEach(() => {
+    calls.length = 0;
+    symbolicRefReturn = "origin/main";
+    symbolicRefThrows = false;
+    tmpRepo = mkdtempSync(join(tmpdir(), "maw-fix1-repo-"));
+    tmpParent = mkdtempSync(join(tmpdir(), "maw-fix1-parent-"));
+  });
+
+  test("emits update-ref refs/heads/main refs/remotes/origin/main AFTER fetch AND BEFORE worktree add", async () => {
+    await createWorktree(tmpRepo, tmpParent, "test-repo", "test-oracle", "fix1", []);
+
+    const fetchIdx = calls.findIndex(c => c.includes("fetch origin --quiet"));
+    const updateRefIdx = calls.findIndex(c =>
+      c.includes("update-ref 'refs/heads/main' 'refs/remotes/origin/main'")
+    );
+    const worktreeAddIdx = calls.findIndex(c => c.includes("worktree add"));
+
+    expect(fetchIdx, "fetch should be issued").toBeGreaterThanOrEqual(0);
+    expect(updateRefIdx, "update-ref should be issued").toBeGreaterThanOrEqual(0);
+    expect(worktreeAddIdx, "worktree add should be issued").toBeGreaterThanOrEqual(0);
+    expect(updateRefIdx, "update-ref must come AFTER fetch").toBeGreaterThan(fetchIdx);
+    expect(updateRefIdx, "update-ref must come BEFORE worktree add").toBeLessThan(worktreeAddIdx);
+  });
+
+  test("supports non-main default branches (origin/HEAD = origin/trunk)", async () => {
+    symbolicRefReturn = "origin/trunk";
+
+    await createWorktree(tmpRepo, tmpParent, "test-repo", "test-oracle", "fix1b", []);
+
+    const updateRefIdx = calls.findIndex(c =>
+      c.includes("update-ref 'refs/heads/trunk' 'refs/remotes/origin/trunk'")
+    );
+    expect(updateRefIdx, "update-ref should strip 'origin/' prefix and target local branch").toBeGreaterThanOrEqual(0);
+  });
+
+  test("no update-ref attempted when origin/HEAD is unconfigured (fall back to HEAD start-point)", async () => {
+    symbolicRefThrows = true;
+
+    await createWorktree(tmpRepo, tmpParent, "test-repo", "test-oracle", "fix1c", []);
+
+    const fetchIdx = calls.findIndex(c => c.includes("fetch origin --quiet"));
+    const updateRefIdx = calls.findIndex(c => c.includes("update-ref refs/heads/"));
+    const worktreeAddIdx = calls.findIndex(c => c.includes("worktree add"));
+
+    expect(fetchIdx, "no fetch without baseRef").toBe(-1);
+    expect(updateRefIdx, "no update-ref without baseRef").toBe(-1);
+    expect(worktreeAddIdx, "worktree add still fires (no -b base-arg)").toBeGreaterThanOrEqual(0);
+  });
+
+  // Cleanup tmp dirs across runs; rm is best-effort.
+  test.skip("teardown", () => {
+    try { rmSync(tmpRepo, { recursive: true }); } catch {}
+    try { rmSync(tmpParent, { recursive: true }); } catch {}
+  });
+});


### PR DESCRIPTION
## What
`maw team create` (and `ensureTeamConfig`) now stamp `createdByPane` (`$TMUX_PANE`) and `createdBySession` (`$CLAUDE_SESSION_ID`) into the team's `config.json`, via a new `creatorEnv()` helper in `team-helpers.ts`. These env values are already read elsewhere in `team-lifecycle.ts` (`leaderPane`, `parentSessionId`) — this just persists them at create time.

## Why
The team↔dispatcher link isn't persisted anywhere: `config.json` has only `name`/`members`/`createdAt`, the audit log records the (short-lived) CLI pid, and `layout.json` (which has `leaderPane`) isn't written on create. So a consumer can't tell which orchestrator spawned a team when their names don't share a slug — e.g. `orchestrator-live-payout` → team `adminview`.

With `createdByPane`, the fleet visualizer (oracle-studio `/town`) can map the pane → window name → orchestrator and group a team under the orchestrator that actually spawned it, deterministically (instead of guessing from slug prefixes).

## Impact
- Additive, optional fields; omitted when the env vars are absent (no behavior change for non-tmux/non-Claude callers).
- Verified: `TMUX_PANE=%120 maw team create <t>` writes `"createdByPane": "%120"`.

Forward-only: existing teams keep their current config until next create/spawn.