### PR TITLE
team up: use charter engines for wake path

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -437,6 +437,8 @@ export interface WakeOptions {
   sessionId?: string;
   fromSnapshot?: boolean;
   snapshotId?: string;
+  /** Charter-level engine override map (e.g. `engines.omx`). */
+  engines?: Record<string, unknown>;
   /** Filesystem layout for newly-created worktrees (#1850): default nested, legacy sibling via --layout legacy. */
   layout?: WorktreeLayout;
   /** Force Discord channel launch for Claude-like engines (#1999). */
@@ -476,14 +478,18 @@ function isAttachOnlyWake(opts: WakeOptions): boolean {
 type WakeCommandOptions = Pick<WakeOptions, "engine" | "parentSessionId" | "sessionId" | "channels"> & {
   /** Strip engine resume/continue placeholders for reboot-rehydrated dead panes (#2391). */
   freshLaunch?: boolean;
+  /** Optional charter-scoped engine overrides (e.g. `engines.omx`). */
+  engines?: Record<string, unknown>;
 };
 
 function buildWakeCommand(windowName: string, cwd: string, opts: WakeCommandOptions): string {
   const commandOpts = opts.channels
-    ? { engine: opts.engine, channels: ["plugin:discord@claude-plugins-official"], fresh: opts.freshLaunch }
+    ? { engine: opts.engine, channels: ["plugin:discord@claude-plugins-official"], fresh: opts.freshLaunch, engines: opts.engines }
     : opts.freshLaunch
-      ? { engine: opts.engine, fresh: true }
-      : opts.engine;
+      ? { engine: opts.engine, fresh: true, engines: opts.engines }
+      : opts.engine
+        ? { engine: opts.engine, engines: opts.engines }
+        : { engines: opts.engines };
   return prefixCommandWithSpawnSessionEnv(
     buildCommandInDir(windowName, cwd, commandOpts),
     { explicit: opts.parentSessionId, sessionId: opts.sessionId, cwd },

--- a/src/config/command-logic.ts
+++ b/src/config/command-logic.ts
@@ -11,6 +11,8 @@ const DISCORD_CHANNEL_PLUGIN = "plugin:discord@claude-plugins-official";
 
 export interface BuildCommandOpts {
   engine?: string;
+  /** Per-call override map for engine command definitions (used by team wake paths). */
+  engines?: Record<string, unknown>;
   channels?: string[];
   channelEnv?: Record<string, string>;
   devChannels?: boolean;
@@ -29,6 +31,24 @@ export type BuildCommandInput = string | BuildCommandOpts | undefined;
 
 function normalizeBuildCommandOpts(input?: BuildCommandInput): BuildCommandOpts {
   return typeof input === "string" ? { engine: input } : { ...(input || {}) };
+}
+
+function flattenEngineValue(value: unknown): string[] {
+  if (Array.isArray(value)) return value.flatMap((item) => flattenEngineValue(item));
+  if (typeof value === "string") return [value.trim()].filter(Boolean);
+  if (value == null) return [];
+  return [String(value).trim()].filter(Boolean);
+}
+
+function resolveAdhocEngine(engines: Record<string, unknown> | undefined, key: string): string | undefined {
+  if (!engines) return undefined;
+  const value = engines[key];
+  const command = flattenEngineValue(value).join(" ").trim();
+  return command || undefined;
+}
+
+function makeAdhocEngine(key: string, command: string): EngineDef {
+  return { name: key, cmd: command };
 }
 
 function hasChannelsFlag(cmd: string): boolean {
@@ -124,9 +144,10 @@ function commandKeyForAgent(
 ): string {
   const keys = enginePatternKeysForConfig(config);
   const known = new Set(engineNamesForConfig(config));
+  const hasAdhocEngine = (engine: string): boolean => Boolean(opts.engines && Object.prototype.hasOwnProperty.call(opts.engines, engine));
 
   if (opts.engine) {
-    if (known.has(opts.engine)) return opts.engine;
+    if (known.has(opts.engine) || hasAdhocEngine(opts.engine)) return opts.engine;
     const knownList = [...known].sort().join(", ") || "none";
     throw new UserError(`engine '${opts.engine}' not resolvable — known: [${knownList}]; define it in config.engines/config.commands or check charter`);
   }
@@ -161,7 +182,10 @@ function selectEngineForAgent(
   agentName: string,
   opts: BuildCommandOpts,
 ): EngineDef {
-  return resolveEngine(commandKeyForAgent(config, agentName, opts), config);
+  const key = commandKeyForAgent(config, agentName, opts);
+  const override = resolveAdhocEngine(opts.engines, key);
+  if (override) return makeAdhocEngine(key, override);
+  return resolveEngine(key, config);
 }
 
 function engineHas(engine: EngineDef | null, capability: string): boolean {

--- a/src/vendor/mpr-plugins/team/team-apply.ts
+++ b/src/vendor/mpr-plugins/team/team-apply.ts
@@ -151,7 +151,7 @@ export async function cmdTeamApply(teamOrPath: string, opts: TeamApplyOptions = 
       const command = engineCommand(launchEngine, { resume: false, engines: charter.engines }, config);
       actions.push({ kind: "spawn", role: item.role, state: item.state, action: opts.apply ? "spawn member" : "would spawn member", command });
       if (opts.apply) {
-        await wakeMember(targetRepoSlug, item.member, { engine: launchEngine, session, repoPath: repoRoot, channels: item.member.channels === true }, { cmdWakeFn: deps.cmdWakeFn });
+        await wakeMember(targetRepoSlug, item.member, { engine: launchEngine, session, repoPath: repoRoot, channels: item.member.channels === true, engines: charter.engines }, { cmdWakeFn: deps.cmdWakeFn });
       }
       continue;
     }

--- a/src/vendor/mpr-plugins/team/team-liveness.ts
+++ b/src/vendor/mpr-plugins/team/team-liveness.ts
@@ -71,6 +71,7 @@ export function memberWakeOptions(
     engine: opts.engine,
     session: opts.session,
     repoPath: opts.repoPath,
+    ...(opts.engines ? { engines: opts.engines } : {}),
     ...(channels ? { channels: true } : {}),
   };
   if (member.worktree === false) return base;

--- a/src/vendor/mpr-plugins/team/team-up.ts
+++ b/src/vendor/mpr-plugins/team/team-up.ts
@@ -352,7 +352,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
         run: async () => {
           if (item.pane) await tmux.run("kill-window", "-t", `${item.pane.sessionName ?? session}:${item.pane.windowName}`);
           const repoPath = await getWorktreeRepoRoot();
-          await wakeMember(targetRepoSlug, item.member, { engine: launchEngine, session, repoPath, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
+          await wakeMember(targetRepoSlug, item.member, { engine: launchEngine, session, repoPath, channels: memberChannels(charter, item.member), engines: charter.engines }, { cmdWakeFn: deps.cmdWakeFn });
         },
       });
     } else if (item.state === "live") {
@@ -376,7 +376,7 @@ export async function cmdTeamUp(team: string, opts: TeamUpOptions = {}, deps: Te
         item,
         run: async () => {
           const repoPath = await getWorktreeRepoRoot();
-          await wakeMember(targetRepoSlug, item.member, { engine: launchEngine, session, repoPath, channels: memberChannels(charter, item.member) }, { cmdWakeFn: deps.cmdWakeFn });
+          await wakeMember(targetRepoSlug, item.member, { engine: launchEngine, session, repoPath, channels: memberChannels(charter, item.member), engines: charter.engines }, { cmdWakeFn: deps.cmdWakeFn });
         },
       });
     }

--- a/test/command-simplified.test.ts
+++ b/test/command-simplified.test.ts
@@ -165,6 +165,12 @@ describe("buildCommand — post-#541 contract", () => {
     expect(buildCommand("any-agent", "codex")).toBe("codex --search");
   });
 
+  test("engine param resolves command from ad-hoc engines map", () => {
+    fakeConfig.commands = { default: "claude --dangerously-skip-permissions" };
+    expect(buildCommandFromConfig(testConfig(), "any-agent", { engine: "omx", engines: { omx: ["omx", "--direct", "--madmax"] } })).toBe("omx --direct --madmax");
+    expect(buildCommandInDirFromConfig(testConfig(), "any-agent", "/tmp/x", { engine: "omx", engines: { omx: ["omx", "--direct", "--madmax"] } })).toBe("omx --direct --madmax");
+  });
+
   test("engine param requires configured seed engines instead of runtime built-ins", () => {
     fakeConfig.commands = { default: "claude" };
     fakeConfig.engines = { codex: { name: "codex", cmd: "codex" } };

--- a/test/isolated/team-up-coverage.test.ts
+++ b/test/isolated/team-up-coverage.test.ts
@@ -15,6 +15,7 @@ import { cmdTeamUp, quickCharter } from "../../src/vendor/mpr-plugins/team/team-
 import { cmdTeamDown, TEAM_LIFECYCLE_GUARD_WINDOW } from "../../src/vendor/mpr-plugins/team/team-down";
 import { cmdTeamApply } from "../../src/vendor/mpr-plugins/team/team-apply";
 import { isUserError } from "../../src/core/util/user-error";
+import { buildCommandInDirFromConfig } from "../../src/config/command-logic";
 
 const dirs: string[] = [];
 afterEach(() => {
@@ -742,6 +743,59 @@ members:
     expect(result.actions[0]).toMatchObject({
       role: "builder",
       command: "claude --model claude-opus-4-8 --dangerously-skip-permissions --channels plugin:discord@claude-plugins-official",
+    });
+  });
+
+  test("wake path honors charter engine command without appending default (no missing separator)", async () => {
+    const root = tempRepo();
+    writeFileSync(join(root, ".maw", "teams", "charter-engine.yaml"), `
+name: charter-engine
+session: charter-session
+engines:
+  omx:
+    - "omx"
+    - --direct
+    - "--madmax"
+members:
+  - role: coder-1
+    engine: omx
+    worktree: true
+`, "utf-8");
+    const wakes: Array<{ oracle: string; opts: any; command: string }> = [];
+    const { tmux } = fakeTmux([]);
+
+    const cfg = {
+      ...config,
+      commands: {
+        ...config.commands,
+        default: "ANTHROPIC_MODEL=claude-opus-4-8 command claude --dangerously-skip-permissions",
+      },
+    } as any;
+
+    await cmdTeamUp("charter-engine", {}, {
+      cwd: root,
+      tmux,
+      loadConfigFn: () => cfg,
+      cmdWakeFn: async (oracle: string, opts: any) => {
+        const command = buildCommandInDirFromConfig(cfg, oracle, root, opts);
+        wakes.push({ oracle, opts, command });
+        return command;
+      },
+      sleep: async () => {},
+      logger: () => {},
+    });
+
+    expect(wakes).toHaveLength(1);
+    expect(wakes[0]).toMatchObject({
+      oracle: expect.stringContaining("maw-team-up-"),
+      opts: {
+        wt: "coder-1",
+        engine: "omx",
+        session: "charter-session",
+        repoPath: root,
+        engines: { omx: ["omx", "--direct", "--madmax"] },
+      },
+      command: "omx --direct --madmax",
     });
   });
 


### PR DESCRIPTION
Closes #2845

Fixes `maw team up` wake-path command construction so it uses the charter-defined engine command (from `team.engines`) instead of global/default engine fallback, preventing malformed concatenation (missing separator or appended default).

Adds regression coverage:
- `engines.omx = ["omx", "--direct", "--madmax"]` must produce exact wake command `omx --direct --madmax` with no default tail.
