### PR TITLE
fix: fleet-wake resolves both flat and github.com-nested ghq layouts

### DIFF
--- a/src/commands/shared/fleet-wake.ts
+++ b/src/commands/shared/fleet-wake.ts
@@ -17,6 +17,32 @@ import {
 export { firstStderrLine, isSshTransportError, runWakeLoopFailSoft } from "./fleet-wake-failsoft";
 export type { WakeStep, WakeLoopResult } from "./fleet-wake-failsoft";
 
+/**
+ * Resolve a fleet-config `repo` field to an absolute cwd.
+ *
+ * Two conventions exist across maw setups, and both must be supported:
+ *   - flat (#748): `repo` is already the full path segment under ghqRoot,
+ *     e.g. "projects/neo-oracle" → <ghqRoot>/projects/neo-oracle. This is
+ *     the shape some environments use when repos aren't ghq-managed.
+ *   - github.com-nested (the `ghq` tool's own default, and the shape
+ *     `fleet-init-scan.ts`/`fleet-sync.ts` actually write): `repo` is
+ *     "org/repo" → <ghqRoot>/github.com/org/repo.
+ *
+ * getGhqRoot() returns the BARE root and documents that github.com-nested
+ * callers must append the suffix themselves — a contract this function
+ * previously violated by only trying the flat shape (#748 fixed one class
+ * of wrong-cwd bug but introduced this one for the more common ghq layout).
+ * Try flat first to preserve existing #748 behavior, then fall back to nested.
+ */
+function resolveRepoCwd(repo: string): string {
+  const ghqRoot = getGhqRoot();
+  const flatPath = join(ghqRoot, repo);
+  if (existsSync(flatPath)) return flatPath;
+  const nestedPath = join(ghqRoot, "github.com", repo);
+  if (existsSync(nestedPath)) return nestedPath;
+  return flatPath;
+}
+
 export async function cmdSleep() {
   const sessions = loadFleet();
   let killed = 0;
@@ -72,17 +98,15 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
       process.stdout.write(`  \x1b[90m⏳\x1b[0m ${progress} ${sess.name}...`);
 
       const first = sess.windows[0];
-      // #748 — Oracle repos live at <ghqRoot>/<repo> directly (e.g. /root/projects/neo-oracle),
-      // not under github.com/<org>/<repo>. Falling back to /root via missing-cwd was making
-      // every Oracle session inherit Labubu's CLAUDE.md identity.
-      const firstPath = join(getGhqRoot(), first.repo);
       // #748 follow-up — tmux silently falls back to $HOME when -c <missing-path>,
       // which re-surfaces the wrong-CLAUDE.md bug if ghqRoot resolves to a stale value
       // (e.g. test fixture leak setting "/tmp/nope"). Refuse to spawn into a missing
       // path; raise a clear error instead of silently inheriting the wrong identity.
+      const firstPath = resolveRepoCwd(first.repo);
       if (!existsSync(firstPath)) {
         throw new Error(
           `wake: refusing to spawn ${sess.name} — cwd "${firstPath}" does not exist. ` +
+          `Tried flat (<ghqRoot>/${first.repo}) and github.com-nested (<ghqRoot>/github.com/${first.repo}). ` +
           `Check ghqRoot resolution (config.ghqRoot, $GHQ_ROOT, \`ghq root\`) and fleet config repo "${first.repo}".`,
         );
       }
@@ -100,7 +124,7 @@ export async function cmdWakeAll(opts: { kill?: boolean; all?: boolean; resume?:
 
       for (let i = 1; i < sess.windows.length; i++) {
         const win = sess.windows[i];
-        const winPath = join(getGhqRoot(), win.repo);
+        const winPath = resolveRepoCwd(win.repo);
         if (!existsSync(winPath)) {
           // Skip rather than throw — first-window throw already surfaced the
           // root cause; per-window failures should fail-soft so other windows

--- a/test/fleet-wake-default.test.ts
+++ b/test/fleet-wake-default.test.ts
@@ -130,6 +130,14 @@ function repo(slug: string) {
   return dir;
 }
 
+/** Repo that only exists under the github.com-nested ghq layout (no flat dir). */
+function repoNested(slug: string) {
+  const dir = join(ghqRoot, "github.com", slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, ".keep"), "x");
+  return dir;
+}
+
 beforeEach(() => {
   rmSync(fixedFleetDir, { recursive: true, force: true });
   mkdirSync(fixedFleetDir, { recursive: true });
@@ -265,5 +273,17 @@ describe("fleet wake default coverage", () => {
     expect(logs.join("\n")).toContain("refusing to spawn 01-bad");
     expect(newSessions).toEqual([]);
     expect(logs.join("\n")).toContain("0 sessions, 0 windows woke up");
+  });
+
+  test("falls back to github.com-nested layout when the flat repo path doesn't exist", async () => {
+    // Only the nested path exists — no <ghqRoot>/org/nested-only dir.
+    repoNested("org/nested-only");
+    sessions = [{ name: "01-nested", windows: [{ name: "main", repo: "org/nested-only" }] }];
+
+    await cmdWakeAll();
+
+    expect(newSessions).toEqual([["01-nested", { window: "main", cwd: join(ghqRoot, "github.com", "org/nested-only") }]]);
+    expect(logs.join("\n")).not.toContain("refusing to spawn");
+    expect(logs.join("\n")).toContain("1 sessions, 1 windows woke up");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2857.

`cmdWakeAll()` in `src/commands/shared/fleet-wake.ts` built the wake-time
cwd with `join(getGhqRoot(), repo)`. But `getGhqRoot()` documents that
github.com-nested callers must append that segment themselves:

> Returns the bare filesystem path that `ghq root` prints — *without* the
> `github.com/` host suffix. Callers that need the host-nested repos root
> must append `"github.com"` themselves.

`fleet-wake.ts` never did, so it only worked for the flat layout `#748`
was written for (`<ghqRoot>/<repo>` directly). Anyone on the standard
`ghq` layout (`<ghqRoot>/github.com/<org>/<repo>`) — which is also the
shape `fleet-init-scan.ts`/`fleet-sync.ts` actually write into the `repo`
field — hits a hard failure the moment a fleet-config-driven wake runs
(e.g. `maw restart`, which calls `cmdSleep()` then `cmdWakeAll()` directly):

```
wake: refusing to spawn 01-foo — cwd "<ghqRoot>/org/foo-oracle" does not exist.
```

even though `<ghqRoot>/github.com/org/foo-oracle` is a real, existing repo.

## Fix

Added `resolveRepoCwd()`, tried at both call sites (session's first window
and subsequent windows): try the flat path first (preserving the original
`#748` behavior/priority), then fall back to the github.com-nested path.
No behavior change for flat-layout users; unblocks nested-layout users.

## Testing

- Added a new test case to `test/fleet-wake-default.test.ts` covering a
  repo that only exists under the nested layout — confirms `cmdWakeAll`
  now resolves and wakes it instead of throwing.
- Existing `fleet-wake-default.test.ts` suite (4 pre-existing cases) still
  passes unchanged.
- Verified manually against a real `~/ghq/github.com/<org>/<repo>` setup:
  `maw restart --no-update` went from hard-failing (session left dead) to
  completing cleanly and re-waking the session.

```
bun test test/fleet-wake-default.test.ts
 5 pass
 0 fail
```