### PR TITLE
feat(oracle-scan): add scanIgnore glob denylist for local detection

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -184,6 +184,18 @@ export interface MawConfig {
   githubOrg?: string;
   /** GitHub orgs to scan for oracle repos (default: Soul-Brews-Studio, laris-co) */
   githubOrgs?: string[];
+  /**
+   * Glob patterns matched against `org/repo` keys to EXCLUDE from the local
+   * oracle scan (#registry-noise). A repo is dropped from detection when its
+   * key matches any pattern, even if it would otherwise qualify (ψ/ dir,
+   * fleet reference, or `-oracle` suffix). Case-insensitive. `*` matches any
+   * run of characters (including `/`), `?` matches a single character.
+   *
+   * Use for non-soul repos that trip the heuristics — e.g. a vault that owns
+   * a top-level `ψ/`, or a tool named `*-oracle` that isn't a fleet member:
+   *   "scanIgnore": ["Oraclep-World/oracle-vault", "*\/opensource-nat-brain-oracle"]
+   */
+  scanIgnore?: string[];
   /** Fixed Claude session UUIDs per agent */
   sessionIds?: Record<string, string>;
   /** Path to ψ/ directory */

--- a/src/core/fleet/registry-oracle-scan-local.ts
+++ b/src/core/fleet/registry-oracle-scan-local.ts
@@ -120,15 +120,39 @@ export function deriveName(repo: string): string {
   return repo.replace(/-oracle$/, "");
 }
 
+/**
+ * @internal
+ * Compile `scanIgnore` glob patterns into a predicate over `org/repo` keys.
+ * `*` → any run of characters (including `/`), `?` → a single character; all
+ * other regex metacharacters are escaped. Matching is case-insensitive and
+ * anchored to the full key. Blank/non-string patterns are dropped; an empty
+ * pattern set yields a predicate that never matches (zero-cost fast path).
+ */
+export function compileScanIgnore(patterns: readonly unknown[] | undefined): (key: string) => boolean {
+  const globs = (patterns ?? []).filter((p): p is string => typeof p === "string" && p.trim().length > 0);
+  if (globs.length === 0) return () => false;
+  const regexes = globs.map(glob => {
+    const source = glob
+      .trim()
+      .replace(/[.+^${}()|[\]\\]/g, "\\$&") // escape regex metachars (but not * ?)
+      .replace(/\*/g, ".*")
+      .replace(/\?/g, ".");
+    return new RegExp(`^${source}$`, "i");
+  });
+  return (key: string) => regexes.some(re => re.test(key));
+}
+
 // ---------- Local scan ----------
 
 interface ScanLocalDeps {
-  config?: Pick<MawConfig, "node" | "agents">;
+  config?: Pick<MawConfig, "node" | "agents" | "scanIgnore">;
   fleetDir?: string;
   fleetDirs?: string[];
   ghqRoot?: string;
   now?: string;
   fleetLineage?: Map<string, FleetLineage>;
+  /** Override scan-ignore globs directly (tests); falls back to config.scanIgnore. */
+  scanIgnore?: string[];
 }
 
 function parseFleetRepoSlug(key: string): { org: string; repo: string } | null {
@@ -152,6 +176,7 @@ export function scanLocal(verbose = true, deps: ScanLocalDeps = {}): OracleEntry
   const reposRoot = join(deps.ghqRoot ?? getGhqRoot(), "github.com");
   const now = deps.now ?? new Date().toISOString();
   const fleetLineage = deps.fleetLineage ?? readFleetLineage(fleetDirs);
+  const isIgnored = compileScanIgnore(deps.scanIgnore ?? config.scanIgnore);
   const entries: OracleEntry[] = [];
   const seen = new Set<string>();
 
@@ -184,6 +209,10 @@ export function scanLocal(verbose = true, deps: ScanLocalDeps = {}): OracleEntry
         repoCount++;
 
         const key = `${org}/${repo}`;
+        if (isIgnored(key)) {
+          if (verbose) console.log(`  \x1b[90m  ⏭ ignoring ${key} (scanIgnore)\x1b[0m`);
+          continue;
+        }
         const hasPsi = existsSync(join(repoPath, "ψ"));
         const fleetKey = fleetLineage.has(key) ? key : null;
         const endsWithOracle = repo.endsWith("-oracle");
@@ -250,7 +279,7 @@ export function scanLocal(verbose = true, deps: ScanLocalDeps = {}): OracleEntry
   // Also add fleet-referenced repos that aren't on disk
   let fleetOnly = 0;
   for (const [key, lineage] of fleetLineage) {
-    if (!seen.has(key)) {
+    if (!seen.has(key) && !isIgnored(key)) {
       const parsed = parseFleetRepoSlug(key);
       if (parsed) {
         const { org, repo } = parsed;

--- a/test/registry-oracle-scan-local.test.ts
+++ b/test/registry-oracle-scan-local.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { deriveName, readFleetLineage, scanLocal } from "../src/core/fleet/registry-oracle-scan-local";
+import { compileScanIgnore, deriveName, readFleetLineage, scanLocal } from "../src/core/fleet/registry-oracle-scan-local";
 
 const roots: string[] = [];
 
@@ -267,5 +267,65 @@ describe("registry-oracle-scan-local", () => {
     expect(logs.some(line => line.includes("federation-enriched 1"))).toBe(true);
     expect(logs.some(line => line.includes("fleet-only oracles"))).toBe(true);
     expect(warnings.some(line => line.includes("failed to walk repos root"))).toBe(true);
+  });
+
+  test("compileScanIgnore matches exact keys, globs, and single-char wildcards; empty set never matches", () => {
+    const none = compileScanIgnore(undefined);
+    expect(none("Any/Repo")).toBe(false);
+    expect(compileScanIgnore([]) ("Any/Repo")).toBe(false);
+    expect(compileScanIgnore(["  ", "", 42 as unknown as string])("Any/Repo")).toBe(false);
+
+    const match = compileScanIgnore([
+      "Oraclep-World/oracle-vault", // exact
+      "*/opensource-nat-brain-oracle", // any org
+      "Junk/*", // any repo under org
+      "Weird/ui?", // single-char wildcard
+    ]);
+    expect(match("Oraclep-World/oracle-vault")).toBe(true);
+    expect(match("oraclep-world/ORACLE-VAULT")).toBe(true); // case-insensitive
+    expect(match("Anyone/opensource-nat-brain-oracle")).toBe(true);
+    expect(match("Junk/whatever-oracle")).toBe(true);
+    expect(match("Weird/uix")).toBe(true);
+    expect(match("Weird/ui")).toBe(false); // ? requires exactly one char
+    expect(match("Oraclep-World/real-oracle")).toBe(false); // regex metachar '-' stays literal
+  });
+
+  test("scanLocal drops repos and fleet-only refs whose key matches scanIgnore", () => {
+    const root = tmpRoot("ignore");
+    const ghqRoot = join(root, "ghq");
+    const fleetDir = join(root, "fleet");
+    mkdirp(fleetDir);
+
+    // Noise: a vault owning a top-level ψ/, and a -oracle-suffixed non-soul tool.
+    makeRepo(ghqRoot, "Oraclep-World", "oracle-vault", { psi: true });
+    makeRepo(ghqRoot, "Soul-Brews-Studio", "opensource-nat-brain-oracle");
+    // A real soul that must survive.
+    const realDir = makeRepo(ghqRoot, "Soul-Brews-Studio", "keep-oracle", { psi: true });
+
+    writeJson(join(fleetDir, "fleet.json"), {
+      project_repos: ["Missing/ghost-oracle"], // fleet-only ref that should be ignored
+      budded_from: "root-oracle",
+      budded_at: "2026-05-16T01:02:03.000Z",
+    });
+
+    const entries = scanLocal(false, {
+      ghqRoot,
+      fleetDir,
+      now: "2026-05-16T04:05:06.000Z",
+      config: { node: "m5", agents: {} },
+      scanIgnore: [
+        "Oraclep-World/oracle-vault",
+        "*/opensource-nat-brain-oracle",
+        "Missing/ghost-oracle",
+      ],
+    });
+
+    expect(entries.map(e => `${e.org}/${e.repo}`)).toEqual([
+      "Soul-Brews-Studio/keep-oracle",
+    ]);
+    expect(entries.find(e => e.repo === "keep-oracle")).toMatchObject({
+      local_path: realDir,
+      has_psi: true,
+    });
   });
 });


### PR DESCRIPTION
## Problem

`scanLocal()` registers a repo as an oracle when it has a top-level `ψ/` dir, is fleet-referenced, or has a `-oracle` suffix. Non-soul repos that happen to trip these heuristics get re-absorbed on **every** scan with no way to exclude them permanently:

- `Oraclep-World/oracle-vault` — a vault that owns a top-level `ψ/` (detected by the ψ rule)
- `*/opensource-nat-brain-oracle` — a tool named `-oracle` that isn't a fleet member (detected by the suffix rule)

There is currently no ignore/exclude mechanism in the scan (only host-segment and `archive` filtering).

## Change

Add an optional `scanIgnore: string[]` config field — glob patterns matched **case-insensitively** against `org/repo` keys. A matching repo is dropped from detection **and** from fleet-only refs.

- `*` matches any run of characters (incl. `/`), `?` matches a single char; other regex metacharacters are escaped.
- Empty/unset → a zero-cost never-match predicate. **Fully backward compatible** — no behavior change unless configured.
- Config flows through `loadConfig()` via the existing deep-merge passthrough; no parser/validator changes needed.

```jsonc
// maw.config.json
"scanIgnore": ["Oraclep-World/oracle-vault", "*/opensource-nat-brain-oracle"]
```

## Files

- `src/config/types.ts` — document `scanIgnore`
- `src/core/fleet/registry-oracle-scan-local.ts` — `compileScanIgnore()` helper (exported), applied in the walk loop + fleet-only loop
- `test/registry-oracle-scan-local.test.ts` — unit coverage for the matcher (exact/glob/`?`/case/empty) + `scanLocal` exclusion

## Verification

- `bun test test/registry-oracle-scan-local.test.ts` → **11 pass / 0 fail** (9 existing + 2 new, 35 expect calls)
- `bun build src/cli.ts` → clean (710 modules bundled)

---
🤖 ตอบโดย 101ORA จาก พลีม → ora101-oracle