### PR TITLE
fix(serve): eliminate event-loop freezes from sync file/subprocess scans

### DIFF
--- a/src/api/costs.ts
+++ b/src/api/costs.ts
@@ -1,7 +1,47 @@
 import { Elysia} from "elysia";
-import { readdirSync, readFileSync, statSync } from "fs";
+import { readdir, stat } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
+
+// A session transcript is streamed line-by-line rather than read whole: some
+// real transcripts are 500MB+, so readFile + split("\n") would allocate ~1GB
+// and block the event loop in one shot. Streaming keeps memory bounded (to the
+// longest single line) and lets the scan yield between chunks.
+type ReadLinesAsync = (path: string) => AsyncIterable<string>;
+type ReaddirAsync = (path: string) => Promise<string[]>;
+type StatAsync = (path: string) => Promise<{ isDirectory: () => boolean; mtimeMs?: number; size?: number }>;
+
+/** Default line reader: stream a file and split into lines without buffering it whole. */
+async function* streamLines(path: string): AsyncIterable<string> {
+  const decoder = new TextDecoder();
+  let buf = "";
+  // @ts-ignore Bun global
+  for await (const chunk of Bun.file(path).stream()) {
+    buf += decoder.decode(chunk as Uint8Array, { stream: true });
+    // Split off complete lines in one pass (O(n)); keep the trailing partial.
+    const parts = buf.split("\n");
+    buf = parts.pop() ?? "";
+    for (const line of parts) yield line;
+  }
+  buf += decoder.decode();
+  if (buf) yield buf;
+}
+
+// Tiny concurrency pool (no new dependency): reads/parses session files
+// concurrently but bounded, so a costs scan never monopolizes the event loop.
+async function mapPool<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+  return results;
+}
 
 // Cost per million tokens (USD)
 const COST_PER_MTOK: Record<string, { input: number; output: number }> = {
@@ -76,42 +116,99 @@ function makeBuckets(n: number): string[] {
 
 export interface CostsApiDeps {
   projectsDir: string;
-  readdirSync: typeof readdirSync;
-  readFileSync: typeof readFileSync;
-  statSync: typeof statSync;
+  readdir: ReaddirAsync;
+  readLines: ReadLinesAsync;
+  stat: StatAsync;
   join: typeof join;
 }
 
+interface ScannedFile { agentName: string; usage: SessionUsage }
+
+const SCAN_TTL_MS = 30_000;
+
 export function createCostsApi(deps: CostsApiDeps = {
   projectsDir: join(homedir(), ".claude", "projects"),
-  readdirSync,
-  readFileSync,
-  statSync,
+  readdir: (path) => readdir(path),
+  readLines: streamLines,
+  stat: (path) => stat(path),
   join,
 }) {
-  function scanSessionWithDeps(filePath: string): SessionUsage | null {
+  // Per-instance cache so /costs and /costs/daily share a single async scan and
+  // frequent dashboard polls don't re-read every ~/.claude/projects/*.jsonl.
+  // Scoped to the factory (not module) so injected test apps never cross-talk.
+  let scanCache: { data: ScannedFile[]; ts: number } | null = null;
+
+  // Per-file usage cache keyed by (mtimeMs, size). jsonl transcripts are
+  // append-only and some are 500MB+; without this a cold scan would re-read
+  // gigabytes every time. A file is read once, then skipped until it changes.
+  // (When stat lacks mtime/size — e.g. injected test stubs — caching is off.)
+  const fileCache = new Map<string, { mtimeMs: number; size: number; usage: SessionUsage | null }>();
+
+  async function scanSessionWithDeps(filePath: string): Promise<SessionUsage | null> {
     try {
-      const content = deps.readFileSync(filePath, "utf-8");
-      return scanSessionContent(String(content));
+      return await scanSessionContent(deps.readLines(filePath));
     } catch {
       return null;
     }
   }
 
-  function projectDirs(set: { status?: number }) {
+  async function projectDirs(set: { status?: number }): Promise<string[] | null> {
     try {
-      return deps.readdirSync(deps.projectsDir).filter((d) => {
-        try { return deps.statSync(deps.join(deps.projectsDir, d)).isDirectory(); } catch { return false; }
-      });
+      const all = await deps.readdir(deps.projectsDir);
+      const flags = await Promise.all(all.map(async (d) => {
+        try { return (await deps.stat(deps.join(deps.projectsDir, d))).isDirectory(); }
+        catch { return false; }
+      }));
+      return all.filter((_, i) => flags[i]);
     } catch {
       set.status = 500;
       return null;
     }
   }
 
+  // Scan every session file once (concurrently, cached). Returns per-file usage
+  // tagged with agent name; both endpoints aggregate from this.
+  async function collectUsages(set: { status?: number }): Promise<ScannedFile[] | null> {
+    const now = Date.now();
+    if (scanCache && now - scanCache.ts < SCAN_TTL_MS) return scanCache.data;
+
+    const dirs = await projectDirs(set);
+    if (!dirs) return null;
+
+    const targets: { filePath: string; agentName: string }[] = [];
+    for (const dir of dirs) {
+      const dirPath = deps.join(deps.projectsDir, dir);
+      let files: string[];
+      try { files = (await deps.readdir(dirPath)).filter((f) => f.endsWith(".jsonl")); }
+      catch { continue; }
+      const agentName = agentNameFromDir(dir);
+      for (const file of files) targets.push({ filePath: deps.join(dirPath, file), agentName });
+    }
+
+    const scanned = await mapPool(targets, 8, async ({ filePath, agentName }) => {
+      let st: { mtimeMs?: number; size?: number } | null = null;
+      try { st = await deps.stat(filePath); } catch { /* file vanished mid-scan */ }
+      const mtimeMs = st?.mtimeMs;
+      const size = st?.size;
+
+      let usage: SessionUsage | null;
+      const cached = (mtimeMs !== undefined && size !== undefined) ? fileCache.get(filePath) : undefined;
+      if (cached && cached.mtimeMs === mtimeMs && cached.size === size) {
+        usage = cached.usage; // unchanged since last scan — skip the (re)read
+      } else {
+        usage = await scanSessionWithDeps(filePath);
+        if (mtimeMs !== undefined && size !== undefined) fileCache.set(filePath, { mtimeMs, size, usage });
+      }
+      return usage ? { agentName, usage } : null;
+    });
+    const data = scanned.filter((x): x is ScannedFile => x !== null);
+    scanCache = { data, ts: now };
+    return data;
+  }
+
   const api = new Elysia();
 
-  api.get("/costs/daily", ({ query, set }) => {
+  api.get("/costs/daily", async ({ query, set }) => {
     const days = Number(query.days ?? 7);
     if (isNaN(days) || days < 1 || days > 365) {
       set.status = 400;
@@ -121,22 +218,13 @@ export function createCostsApi(deps: CostsApiDeps = {
     const buckets = makeBuckets(days);
     const bucketIndex = new Map(buckets.map((b, i) => [b, i]));
 
-    const dirs = projectDirs(set);
-    if (!dirs) return { error: "Cannot read ~/.claude/projects/" };
+    const scanned = await collectUsages(set);
+    if (!scanned) return { error: "Cannot read ~/.claude/projects/" };
 
     // agentName → { costs: number[], hadActivity: boolean[] }
     const agentDailyMap = new Map<string, { costs: number[]; hadActivity: boolean[] }>();
 
-    for (const dir of dirs) {
-      const dirPath = deps.join(deps.projectsDir, dir);
-      let files: string[];
-      try {
-        files = deps.readdirSync(dirPath).filter((f) => f.endsWith(".jsonl"));
-      } catch { continue; }
-
-      if (files.length === 0) continue;
-      const agentName = agentNameFromDir(dir);
-
+    for (const { agentName, usage } of scanned) {
       if (!agentDailyMap.has(agentName)) {
         agentDailyMap.set(agentName, {
           costs: Array(days).fill(0),
@@ -146,17 +234,13 @@ export function createCostsApi(deps: CostsApiDeps = {
 
       const entry = agentDailyMap.get(agentName)!;
 
-      for (const file of files) {
-        const usage = scanSessionWithDeps(deps.join(dirPath, file));
-        if (!usage || !usage.lastTimestamp) continue;
+      if (!usage.lastTimestamp) continue;
+      const dateStr = localDateStr(usage.lastTimestamp);
+      const idx = bucketIndex.get(dateStr);
+      if (idx === undefined) continue; // outside the window
 
-        const dateStr = localDateStr(usage.lastTimestamp);
-        const idx = bucketIndex.get(dateStr);
-        if (idx === undefined) continue; // outside the window
-
-        entry.costs[idx] += estimateCost(usage);
-        entry.hadActivity[idx] = true;
-      }
+      entry.costs[idx] += estimateCost(usage);
+      entry.hadActivity[idx] = true;
     }
 
     const agents = [...agentDailyMap.entries()]
@@ -173,9 +257,9 @@ export function createCostsApi(deps: CostsApiDeps = {
     return { window: days, buckets, agents, total: { cost: totalCost, agents: agents.length } };
   });
 
-  api.get("/costs", ({ set }) => {
-    const dirs = projectDirs(set);
-    if (!dirs) return { error: "Cannot read ~/.claude/projects/" };
+  api.get("/costs", async ({ set }) => {
+    const scanned = await collectUsages(set);
+    if (!scanned) return { error: "Cannot read ~/.claude/projects/" };
 
     const agents: Record<string, {
       name: string;
@@ -191,16 +275,7 @@ export function createCostsApi(deps: CostsApiDeps = {
       lastActive: string;
     }> = {};
 
-    for (const dir of dirs) {
-      const dirPath = deps.join(deps.projectsDir, dir);
-      let files: string[];
-      try {
-        files = deps.readdirSync(dirPath).filter((f) => f.endsWith(".jsonl"));
-      } catch { continue; }
-
-      if (files.length === 0) continue;
-      const agentName = agentNameFromDir(dir);
-
+    for (const { agentName, usage } of scanned) {
       if (!agents[agentName]) {
         agents[agentName] = {
           name: agentName,
@@ -217,25 +292,20 @@ export function createCostsApi(deps: CostsApiDeps = {
         };
       }
 
-      for (const file of files) {
-        const usage = scanSessionWithDeps(deps.join(dirPath, file));
-        if (!usage) continue;
+      const a = agents[agentName];
+      a.inputTokens += usage.inputTokens;
+      a.outputTokens += usage.outputTokens;
+      a.cacheReadTokens += usage.cacheReadTokens;
+      a.cacheCreateTokens += usage.cacheCreateTokens;
+      a.totalTokens += usage.inputTokens + usage.outputTokens + usage.cacheReadTokens + usage.cacheCreateTokens;
+      a.estimatedCost += estimateCost(usage);
+      a.sessions++;
+      a.turns += usage.turns;
 
-        const a = agents[agentName];
-        a.inputTokens += usage.inputTokens;
-        a.outputTokens += usage.outputTokens;
-        a.cacheReadTokens += usage.cacheReadTokens;
-        a.cacheCreateTokens += usage.cacheCreateTokens;
-        a.totalTokens += usage.inputTokens + usage.outputTokens + usage.cacheReadTokens + usage.cacheCreateTokens;
-        a.estimatedCost += estimateCost(usage);
-        a.sessions++;
-        a.turns += usage.turns;
+      const tier = modelTier(usage.model);
+      a.models[tier] = (a.models[tier] || 0) + usage.turns;
 
-        const tier = modelTier(usage.model);
-        a.models[tier] = (a.models[tier] || 0) + usage.turns;
-
-        if (usage.lastTimestamp > a.lastActive) a.lastActive = usage.lastTimestamp;
-      }
+      if (usage.lastTimestamp > a.lastActive) a.lastActive = usage.lastTimestamp;
     }
 
     const agentList = Object.values(agents)
@@ -255,9 +325,10 @@ export function createCostsApi(deps: CostsApiDeps = {
   return api;
 }
 
-function scanSessionContent(content: string): SessionUsage | null {
-  const lines = content.split("\n").filter(Boolean);
+/** Yield control back to the event loop so a large parse never freezes serve. */
+const yieldToLoop = (): Promise<void> => new Promise<void>((r) => setImmediate(r));
 
+async function scanSessionContent(lines: AsyncIterable<string>): Promise<SessionUsage | null> {
   let inputTokens = 0;
   let outputTokens = 0;
   let cacheReadTokens = 0;
@@ -266,7 +337,16 @@ function scanSessionContent(content: string): SessionUsage | null {
   let model = "";
   let lastTimestamp = "";
 
-  for (const line of lines) {
+  let seen = 0;
+  for await (const line of lines) {
+    // Periodically hand the event loop back so websockets/keystrokes stay
+    // responsive while a big transcript is being scanned.
+    if ((++seen & 2047) === 0) await yieldToLoop();
+
+    // Cheap pre-filter: only usage-bearing assistant lines matter, so skip the
+    // JSON.parse for the (vast majority of) lines that can't contribute.
+    if (!line || line.indexOf('"usage"') === -1) continue;
+
     let obj: any;
     try { obj = JSON.parse(line); } catch { continue; }
     if (obj.type !== "assistant" || !obj.message?.usage) continue;

--- a/src/commands/shared/receiver-inbox.ts
+++ b/src/commands/shared/receiver-inbox.ts
@@ -1,7 +1,7 @@
 import { existsSync as fsExistsSync, mkdirSync as fsMkdirSync, writeFileSync as fsWriteFileSync } from "fs";
 import { basename, isAbsolute, join } from "path";
 import { getGhqRoot as defaultGetGhqRoot } from "../../config/ghq-root";
-import { ghqFindSync as defaultGhqFindSync } from "../../core/ghq";
+import { ghqFind as defaultGhqFind } from "../../core/ghq";
 import { loadManifestCached, type OracleManifestEntry } from "../../lib/oracle-manifest";
 import { resolveTargetCwd as defaultResolveTargetCwd } from "./target-cwd";
 
@@ -42,7 +42,7 @@ interface ReceiverInboxDeps {
   writeFileSync?: typeof fsWriteFileSync;
   loadManifest?: () => OracleManifestEntry[];
   getGhqRoot?: typeof defaultGetGhqRoot;
-  ghqFindSync?: typeof defaultGhqFindSync;
+  ghqFind?: typeof defaultGhqFind;
   resolveTargetCwd?: typeof defaultResolveTargetCwd;
   now?: () => Date;
 }
@@ -98,11 +98,11 @@ export function resolveReceiverOracle(input: ReceiverInboxInput): string | null 
     ?? normalizeOracleName(input.query);
 }
 
-function repoPathCandidates(
+async function repoPathCandidates(
   oracle: string,
   input: ReceiverInboxInput,
-  deps: Required<Pick<ReceiverInboxDeps, "existsSync" | "loadManifest" | "getGhqRoot" | "ghqFindSync" | "resolveTargetCwd">>,
-): string[] {
+  deps: Required<Pick<ReceiverInboxDeps, "existsSync" | "loadManifest" | "getGhqRoot" | "ghqFind" | "resolveTargetCwd">>,
+): Promise<string[]> {
   const candidates: string[] = [];
 
   if (input.config?.psiPath && input.config.oracle && normalizeOracleName(input.config.oracle) === oracle) {
@@ -135,7 +135,7 @@ function repoPathCandidates(
   }
 
   try {
-    const ghqPath = deps.ghqFindSync(`/${oracle}-oracle$`);
+    const ghqPath = await deps.ghqFind(`/${oracle}-oracle$`);
     if (ghqPath) candidates.push(ghqPath);
   } catch {
     // Best effort.
@@ -191,7 +191,7 @@ function isExistingFileError(error: unknown): boolean {
   );
 }
 
-export function persistReceiverInbox(input: ReceiverInboxInput, deps: ReceiverInboxDeps = {}): ReceiverInboxResult {
+export async function persistReceiverInbox(input: ReceiverInboxInput, deps: ReceiverInboxDeps = {}): Promise<ReceiverInboxResult> {
   const existsSync = deps.existsSync ?? fsExistsSync;
   const mkdirSync = deps.mkdirSync ?? fsMkdirSync;
   const writeFileSync = deps.writeFileSync ?? fsWriteFileSync;
@@ -199,14 +199,14 @@ export function persistReceiverInbox(input: ReceiverInboxInput, deps: ReceiverIn
     existsSync,
     loadManifest: deps.loadManifest ?? loadManifestCached,
     getGhqRoot: deps.getGhqRoot ?? defaultGetGhqRoot,
-    ghqFindSync: deps.ghqFindSync ?? defaultGhqFindSync,
+    ghqFind: deps.ghqFind ?? defaultGhqFind,
     resolveTargetCwd: deps.resolveTargetCwd ?? defaultResolveTargetCwd,
   };
 
   const oracle = resolveReceiverOracle(input);
   if (!oracle) return { ok: false, reason: "receiver oracle could not be inferred" };
 
-  const repoPath = repoPathCandidates(oracle, input, resolvedDeps)[0];
+  const repoPath = (await repoPathCandidates(oracle, input, resolvedDeps))[0];
   if (!repoPath) return { ok: false, oracle, reason: `receiver repo not found for ${oracle}` };
 
   const now = deps.now?.() ?? new Date();

--- a/src/core/fleet/claude-sessions.ts
+++ b/src/core/fleet/claude-sessions.ts
@@ -14,8 +14,8 @@
  * directly with fs/promises.
  */
 
-import { readdirSync, statSync } from "fs";
-import { open } from "fs/promises";
+import type { Stats } from "fs";
+import { open, readdir, stat } from "fs/promises";
 import { join, resolve } from "path";
 import { homedir } from "os";
 import { execFile } from "child_process";
@@ -314,24 +314,26 @@ export async function listClaudeSessions(deps: ClaudeSessionDeps = {}): Promise<
   const gitInfoFor = makeGitInfoResolver(exec);
 
   let projectDirs: string[];
-  try { projectDirs = readdirSync(claudeDir).filter(d => d.startsWith("-")); }
+  try { projectDirs = (await readdir(claudeDir)).filter(d => d.startsWith("-")); }
   catch { return []; }
 
-  const entries: SessionFileEntry[] = [];
-  for (const encoded of projectDirs) {
+  // Read each project dir's listing concurrently (async, off the event loop)
+  // instead of a blocking readdirSync per directory.
+  const perDir = await mapPool(projectDirs, PER_SESSION_CONCURRENCY, async (encoded) => {
     const projectPath = decodeProjectDir(encoded);
     const dirPath = join(claudeDir, encoded);
     let files: string[];
-    try { files = readdirSync(dirPath).filter(f => f.endsWith(".jsonl") && !f.includes("subagents")); }
-    catch { continue; }
-    for (const file of files) entries.push({ projectPath, dirPath, file });
-  }
+    try { files = (await readdir(dirPath)).filter(f => f.endsWith(".jsonl") && !f.includes("subagents")); }
+    catch { return [] as SessionFileEntry[]; }
+    return files.map(file => ({ projectPath, dirPath, file }));
+  });
+  const entries: SessionFileEntry[] = perDir.flat();
 
   const perFile = await mapPool(entries, PER_SESSION_CONCURRENCY, async ({ projectPath, dirPath, file }) => {
     const sessionId = file.replace(".jsonl", "");
     const filePath = join(dirPath, file);
-    let st: ReturnType<typeof statSync>;
-    try { st = statSync(filePath); } catch { return null; }
+    let st: Stats;
+    try { st = await stat(filePath); } catch { return null; }
 
     const mtimeMs = st.mtimeMs;
     const ageMs = now - mtimeMs;

--- a/src/core/fleet/claude-sessions.ts
+++ b/src/core/fleet/claude-sessions.ts
@@ -5,17 +5,28 @@
  * running `claude` processes via /proc/<pid>/cwd (Linux) or lsof (macOS).
  *
  * Localhost-only. Never expose via federation in Phase 1.
+ *
+ * Fully async: every subprocess call goes through an async exec seam so a
+ * fleet scan never blocks the single Bun event loop backing `maw serve`.
+ * Per-session work runs concurrently (small pool) and per-cwd git/worktree
+ * resolution is deduped within a scan via a Map of in-flight promises.
+ * Message tail/count no longer shell out at all — they read the jsonl file
+ * directly with fs/promises.
  */
 
 import { readdirSync, statSync } from "fs";
+import { open } from "fs/promises";
 import { join, resolve } from "path";
 import { homedir } from "os";
-import { execSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
 
-type ExecSyncString = (
+const execFileAsync = promisify(execFile);
+
+type ExecAsync = (
   command: string,
-  options?: { encoding: BufferEncoding; timeout?: number; maxBuffer?: number },
-) => string;
+  options?: { timeout?: number; maxBuffer?: number },
+) => Promise<string>;
 
 export interface ClaudeSession {
   sessionId: string;
@@ -38,10 +49,44 @@ export interface ClaudeSession {
 interface PidInfo { pid: number; ppid: number; cwd: string; command: string }
 
 export interface ClaudeSessionDeps {
-  execSync?: ExecSyncString;
+  /** Async shell-out seam. Runs `command` via a shell and resolves with stdout. */
+  execSync?: ExecAsync;
 }
 
-const defaultExecSync = execSync as ExecSyncString;
+/**
+ * Default async exec: runs a shell command via execFile("/bin/sh", ["-c", ...])
+ * so callers can keep passing shell strings (pipes, redirects) as before,
+ * without ever blocking the event loop.
+ */
+const defaultExecAsync: ExecAsync = async (command, options) => {
+  const { stdout } = await execFileAsync("/bin/sh", ["-c", command], {
+    encoding: "utf-8",
+    timeout: options?.timeout,
+    maxBuffer: options?.maxBuffer ?? 1024 * 1024,
+  });
+  return stdout;
+};
+
+// ── Tiny concurrency pool (no new dependencies) ──────────────────
+
+async function mapPool<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  }
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
 
 // ── Path encoding ────────────────────────────────────────────────
 
@@ -51,31 +96,32 @@ export function decodeProjectDir(encoded: string): string {
   return encoded.replace(/^-/, "/").replace(/-/g, "/");
 }
 
-// ── PID discovery (cached 5s) ────────────────────────────────────
+// ── PID discovery (cached 5s, invoked once per scan) ─────────────
 
 let pidCache: { data: PidInfo[]; ts: number } | null = null;
 
-function listClaudePids(exec: ExecSyncString): PidInfo[] {
+async function listClaudePids(exec: ExecAsync): Promise<PidInfo[]> {
   if (process.env.MAW_CLAUDE_SKIP_PID_SCAN === "1") return [];
   const now = Date.now();
   if (pidCache && now - pidCache.ts < 5_000) return pidCache.data;
   const results: PidInfo[] = [];
   try {
-    const raw = exec(`ps -eo pid,ppid,command 2>/dev/null | grep '[c]laude'`, {
-      encoding: "utf-8", timeout: 3000,
-    });
+    const raw = await exec(`ps -eo pid,ppid,command 2>/dev/null | grep '[c]laude'`, { timeout: 3000 });
+    const rows: { pidStr: string; ppidStr: string; command: string }[] = [];
     for (const line of raw.split("\n").filter(Boolean)) {
       const m = line.trim().match(/^(\d+)\s+(\d+)\s+(.*)$/);
       if (!m || m[3].includes("grep")) continue;
-      const [, pidStr, ppidStr, command] = m;
+      rows.push({ pidStr: m[1], ppidStr: m[2], command: m[3] });
+    }
+    await mapPool(rows, 8, async ({ pidStr, ppidStr, command }) => {
       let cwd = "";
       try {
         cwd = process.platform === "linux"
-          ? exec(`readlink /proc/${pidStr}/cwd 2>/dev/null`, { encoding: "utf-8", timeout: 1000 }).trim()
-          : exec(`lsof -p ${pidStr} -Fn 2>/dev/null | grep '^n/' | head -1`, { encoding: "utf-8", timeout: 2000 }).replace(/^n/, "").trim();
+          ? (await exec(`readlink /proc/${pidStr}/cwd 2>/dev/null`, { timeout: 1000 })).trim()
+          : (await exec(`lsof -p ${pidStr} -Fn 2>/dev/null | grep '^n/' | head -1`, { timeout: 2000 })).replace(/^n/, "").trim();
       } catch { /* cwd not resolvable */ }
       if (cwd) results.push({ pid: +pidStr, ppid: +ppidStr, cwd, command });
-    }
+    });
   } catch { /* no claude processes */ }
   pidCache = { data: results, ts: now };
   return results;
@@ -83,17 +129,17 @@ function listClaudePids(exec: ExecSyncString): PidInfo[] {
 
 // ── Parent chain + trigger classification ────────────────────────
 
-function classifyTrigger(
+async function classifyTrigger(
   ppid: number,
-  exec: ExecSyncString,
-): { chain: string[]; trigger: ClaudeSession["triggeredFrom"] } {
+  exec: ExecAsync,
+): Promise<{ chain: string[]; trigger: ClaudeSession["triggeredFrom"] }> {
   const chain: string[] = [];
   let cur = ppid;
   const seen = new Set<number>();
   for (let i = 0; i < 10 && cur > 1 && !seen.has(cur); i++) {
     seen.add(cur);
     try {
-      const info = exec(`ps -o comm=,ppid= -p ${cur} 2>/dev/null`, { encoding: "utf-8", timeout: 1000 }).trim();
+      const info = (await exec(`ps -o comm=,ppid= -p ${cur} 2>/dev/null`, { timeout: 1000 })).trim();
       const parts = info.split(/\s+/);
       const comm = parts.slice(0, -1).join(" ");
       cur = +(parts.at(-1) || "0");
@@ -110,16 +156,16 @@ function classifyTrigger(
 
 // ── Git helpers ──────────────────────────────────────────────────
 
-function resolveRepo(cwd: string, exec: ExecSyncString): string | null {
+async function resolveRepo(cwd: string, exec: ExecAsync): Promise<string | null> {
   try {
-    return exec(`git -C '${cwd}' remote get-url origin 2>/dev/null`, { encoding: "utf-8", timeout: 2000 })
-      .trim().replace(/^(ssh:\/\/)?git@/, "").replace(/^https?:\/\//, "").replace(/:/, "/").replace(/\.git$/, "");
+    const raw = await exec(`git -C '${cwd}' remote get-url origin 2>/dev/null`, { timeout: 2000 });
+    return raw.trim().replace(/^(ssh:\/\/)?git@/, "").replace(/^https?:\/\//, "").replace(/:/, "/").replace(/\.git$/, "");
   } catch { return null; }
 }
 
-function resolveWorktree(cwd: string, exec: ExecSyncString): ClaudeSession["worktree"] {
+async function resolveWorktree(cwd: string, exec: ExecAsync): Promise<ClaudeSession["worktree"]> {
   try {
-    const raw = exec(`git -C '${cwd}' worktree list --porcelain 2>/dev/null`, { encoding: "utf-8", timeout: 2000 });
+    const raw = await exec(`git -C '${cwd}' worktree list --porcelain 2>/dev/null`, { timeout: 2000 });
     for (const block of raw.split("\n\n").filter(Boolean)) {
       const lines = block.split("\n");
       const wt = lines.find(l => l.startsWith("worktree "))?.slice(9);
@@ -130,19 +176,56 @@ function resolveWorktree(cwd: string, exec: ExecSyncString): ClaudeSession["work
   return null;
 }
 
-// ── Last-message extraction (tail-based, avoids full read) ───────
+interface GitInfo {
+  repo: string | null;
+  worktree: ClaudeSession["worktree"];
+}
 
-function extractLastMessages(
+/** Per-cwd git metadata, deduped within a scan (many sessions share a projectPath). */
+function makeGitInfoResolver(exec: ExecAsync): (cwd: string) => Promise<GitInfo> {
+  const cache = new Map<string, Promise<GitInfo>>();
+  return (cwd: string) => {
+    let p = cache.get(cwd);
+    if (!p) {
+      p = Promise.all([resolveRepo(cwd, exec), resolveWorktree(cwd, exec)])
+        .then(([repo, worktree]) => ({ repo, worktree }));
+      cache.set(cwd, p);
+    }
+    return p;
+  };
+}
+
+// ── Last-message extraction (reads only the tail of the file, no subprocess) ─
+
+const TAIL_READ_BYTES = 64 * 1024;
+
+async function readTail(filePath: string, maxBytes: number): Promise<{ text: string; truncated: boolean }> {
+  const handle = await open(filePath, "r");
+  try {
+    const { size } = await handle.stat();
+    const start = Math.max(0, size - maxBytes);
+    const length = size - start;
+    if (length <= 0) return { text: "", truncated: false };
+    const buf = Buffer.alloc(length);
+    await handle.read(buf, 0, length, start);
+    return { text: buf.toString("utf-8"), truncated: start > 0 };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function extractLastMessages(
   filePath: string,
-  exec: ExecSyncString,
-): { lastUser: string | null; lastAssistant: string | null } {
+): Promise<{ lastUser: string | null; lastAssistant: string | null }> {
   let lastUser: string | null = null;
   let lastAssistant: string | null = null;
   try {
-    const tail = exec(`tail -100 '${filePath}' 2>/dev/null`, {
-      encoding: "utf-8", timeout: 2000, maxBuffer: 512 * 1024,
-    });
-    for (const line of tail.split("\n").filter(Boolean).reverse()) {
+    const { text, truncated } = await readTail(filePath, TAIL_READ_BYTES);
+    const lines = text.split("\n").filter(Boolean);
+    // A tail read may start mid-line; drop a possibly-truncated first line,
+    // but only when the read actually started past byte 0.
+    if (truncated && lines.length > 1) lines.shift();
+    for (const line of lines.reverse()) {
       try {
         const e = JSON.parse(line);
         if (!lastUser && e.type === "user" && e.message?.content) {
@@ -163,13 +246,37 @@ function extractLastMessages(
   return { lastUser, lastAssistant };
 }
 
-function countSessionMessages(filePath: string, exec: ExecSyncString): number {
+/** Count newline-delimited records without buffering the whole file or shelling out. */
+async function countSessionMessages(filePath: string): Promise<number> {
+  const CHUNK = 64 * 1024;
   try {
-    const raw = exec(`awk 'END { print NR }' '${filePath}' 2>/dev/null`, {
-      encoding: "utf-8", timeout: 2000, maxBuffer: 64 * 1024,
-    });
-    const count = Number.parseInt(raw.trim(), 10);
-    return Number.isFinite(count) && count > 0 ? count : 0;
+    const handle = await open(filePath, "r");
+    try {
+      const { size } = await handle.stat();
+      if (size === 0) return 0;
+      let count = 0;
+      let sawAnyByte = false;
+      let lastByte = -1;
+      const buf = Buffer.alloc(CHUNK);
+      let pos = 0;
+      while (pos < size) {
+        const toRead = Math.min(CHUNK, size - pos);
+        const { bytesRead } = await handle.read(buf, 0, toRead, pos);
+        if (bytesRead <= 0) break;
+        sawAnyByte = true;
+        for (let i = 0; i < bytesRead; i++) {
+          if (buf[i] === 0x0a) count++;
+        }
+        lastByte = buf[bytesRead - 1];
+        pos += bytesRead;
+      }
+      // A final line without a trailing newline still counts as a record
+      // (matches `awk 'END{print NR}'` semantics).
+      if (sawAnyByte && lastByte !== 0x0a) count++;
+      return count;
+    } finally {
+      await handle.close();
+    }
   } catch {
     return 0;
   }
@@ -178,6 +285,8 @@ function countSessionMessages(filePath: string, exec: ExecSyncString): number {
 // ── Main discovery ───────────────────────────────────────────────
 
 let sessionCache: { data: ClaudeSession[]; ts: number } | null = null;
+const SESSION_CACHE_TTL_MS = 15_000;
+const PER_SESSION_CONCURRENCY = 8;
 
 export function __resetClaudeSessionCachesForTests(): void {
   pidCache = null;
@@ -188,67 +297,80 @@ function claudeProjectsDir(): string {
   return process.env.MAW_CLAUDE_PROJECTS_DIR || join(homedir(), ".claude", "projects");
 }
 
+interface SessionFileEntry {
+  projectPath: string;
+  dirPath: string;
+  file: string;
+}
+
 export async function listClaudeSessions(deps: ClaudeSessionDeps = {}): Promise<ClaudeSession[]> {
-  const exec = deps.execSync ?? defaultExecSync;
+  const exec = deps.execSync ?? defaultExecAsync;
   const now = Date.now();
-  if (sessionCache && now - sessionCache.ts < 5_000) return sessionCache.data;
+  if (sessionCache && now - sessionCache.ts < SESSION_CACHE_TTL_MS) return sessionCache.data;
 
   const claudeDir = claudeProjectsDir();
-  const pids = listClaudePids(exec);
+  const pids = await listClaudePids(exec);
   const pidByCwd = new Map(pids.map(p => [p.cwd, p]));
-  const results: ClaudeSession[] = [];
+  const gitInfoFor = makeGitInfoResolver(exec);
 
   let projectDirs: string[];
   try { projectDirs = readdirSync(claudeDir).filter(d => d.startsWith("-")); }
   catch { return []; }
 
+  const entries: SessionFileEntry[] = [];
   for (const encoded of projectDirs) {
     const projectPath = decodeProjectDir(encoded);
     const dirPath = join(claudeDir, encoded);
     let files: string[];
     try { files = readdirSync(dirPath).filter(f => f.endsWith(".jsonl") && !f.includes("subagents")); }
     catch { continue; }
-
-    for (const file of files) {
-      const sessionId = file.replace(".jsonl", "");
-      const filePath = join(dirPath, file);
-      let st: ReturnType<typeof statSync>;
-      try { st = statSync(filePath); } catch { continue; }
-
-      const mtimeMs = st.mtimeMs;
-      const ageMs = now - mtimeMs;
-      if (ageMs > 86_400_000) continue; // skip > 24h old
-
-      const pidInfo = pidByCwd.get(projectPath);
-      const status: ClaudeSession["status"] = pidInfo
-        ? (ageMs < 120_000 ? "active" : "idle")
-        : "ended";
-
-      const { chain, trigger } = pidInfo
-        ? classifyTrigger(pidInfo.ppid, exec)
-        : { chain: [] as string[], trigger: "unknown" as const };
-
-      const tmuxTarget = chain.some(c => c.toLowerCase().includes("tmux"))
-        ? `(tmux: ${projectPath.split("/").pop()})` : null;
-
-      const { lastUser, lastAssistant } = extractLastMessages(filePath, exec);
-      const messageCount = countSessionMessages(filePath, exec);
-
-      results.push({
-        sessionId, projectPath,
-        repo: resolveRepo(projectPath, exec),
-        worktree: resolveWorktree(projectPath, exec),
-        pid: pidInfo?.pid ?? null,
-        ppid: pidInfo?.ppid ?? null,
-        parentChain: chain, tmuxTarget, triggeredFrom: trigger, status,
-        lastActivityAt: new Date(mtimeMs).toISOString(),
-        lastUserMessage: lastUser,
-        lastAssistantMessage: lastAssistant,
-        messageCount,
-        sizeBytes: st.size,
-      });
-    }
+    for (const file of files) entries.push({ projectPath, dirPath, file });
   }
+
+  const perFile = await mapPool(entries, PER_SESSION_CONCURRENCY, async ({ projectPath, dirPath, file }) => {
+    const sessionId = file.replace(".jsonl", "");
+    const filePath = join(dirPath, file);
+    let st: ReturnType<typeof statSync>;
+    try { st = statSync(filePath); } catch { return null; }
+
+    const mtimeMs = st.mtimeMs;
+    const ageMs = now - mtimeMs;
+    if (ageMs > 86_400_000) return null; // skip > 24h old
+
+    const pidInfo = pidByCwd.get(projectPath);
+    const status: ClaudeSession["status"] = pidInfo
+      ? (ageMs < 120_000 ? "active" : "idle")
+      : "ended";
+
+    const [{ chain, trigger }, gitInfo, { lastUser, lastAssistant }, messageCount] = await Promise.all([
+      pidInfo
+        ? classifyTrigger(pidInfo.ppid, exec)
+        : Promise.resolve({ chain: [] as string[], trigger: "unknown" as const }),
+      gitInfoFor(projectPath),
+      extractLastMessages(filePath),
+      countSessionMessages(filePath),
+    ]);
+
+    const tmuxTarget = chain.some(c => c.toLowerCase().includes("tmux"))
+      ? `(tmux: ${projectPath.split("/").pop()})` : null;
+
+    const session: ClaudeSession = {
+      sessionId, projectPath,
+      repo: gitInfo.repo,
+      worktree: gitInfo.worktree,
+      pid: pidInfo?.pid ?? null,
+      ppid: pidInfo?.ppid ?? null,
+      parentChain: chain, tmuxTarget, triggeredFrom: trigger, status,
+      lastActivityAt: new Date(mtimeMs).toISOString(),
+      lastUserMessage: lastUser,
+      lastAssistantMessage: lastAssistant,
+      messageCount,
+      sizeBytes: st.size,
+    };
+    return session;
+  });
+
+  const results = perFile.filter((s): s is ClaudeSession => s !== null);
 
   results.sort((a, b) => {
     const ord = { active: 0, idle: 1, ended: 2 };

--- a/src/core/transport/pty.ts
+++ b/src/core/transport/pty.ts
@@ -4,7 +4,11 @@ import type { MawWS } from "../types";
 
 type PtyProc = ReturnType<typeof Bun.spawn>;
 type PtySpawn = typeof Bun.spawn;
-type PtySpawnSync = typeof Bun.spawnSync;
+// Async capture-pane seam. Returns decoded stdout bytes (matches the binary
+// frame shape the websocket wants) and the process exit code. Replaces the
+// old spawnSync-based seam so replayCapture no longer blocks the event loop.
+export type PtyCaptureResult = { stdout: Uint8Array; exitCode: number };
+export type PtySpawnCapture = (args: string[]) => Promise<PtyCaptureResult>;
 // listSessionGroups is optional: production always has it (real `tmux` is
 // spread into ptyDeps), but injected test mocks may omit it — in which case
 // the orphan sweep (#P2) and attach-time grouped-orphan kill (#P3) no-op
@@ -19,12 +23,20 @@ export interface PtyDeps {
   cfgTimeout: typeof cfgTimeout;
   cfgLimit: typeof cfgLimit;
   spawn: PtySpawn;
-  spawnSync: PtySpawnSync;
+  /** Async replacement for the old `spawnSync` capture-pane seam. */
+  spawnCapture: PtySpawnCapture;
   env: () => NodeJS.ProcessEnv;
   platform: () => NodeJS.Platform;
   now: () => number;
   setTimeout: typeof setTimeout;
   clearTimeout: typeof clearTimeout;
+}
+
+async function defaultSpawnCapture(args: string[]): Promise<PtyCaptureResult> {
+  const proc = Bun.spawn(args, { stdout: "pipe", stderr: "ignore" });
+  const stdout = new Uint8Array(await new Response(proc.stdout).arrayBuffer());
+  const exitCode = await proc.exited;
+  return { stdout, exitCode };
 }
 
 export function ptyDeps(overrides: Partial<PtyDeps> = {}): PtyDeps {
@@ -35,7 +47,7 @@ export function ptyDeps(overrides: Partial<PtyDeps> = {}): PtyDeps {
     cfgTimeout,
     cfgLimit,
     spawn: ((args, opts) => Bun.spawn(args, opts)) as PtySpawn,
-    spawnSync: ((args) => Bun.spawnSync(args)) as PtySpawnSync,
+    spawnCapture: defaultSpawnCapture,
     env: () => process.env,
     platform: () => process.platform,
     now: () => Date.now(),
@@ -67,10 +79,14 @@ function replayLinesFromControl(value: unknown): number {
   return Math.max(0, Math.min(10_000, Math.floor(n)));
 }
 
-function replayCapture(ws: MawWS, target: string, lines: number, io: PtyDeps) {
+// Runs tmux capture-pane asynchronously and sends the scrollback to `ws`.
+// Ordering guarantee: callers must not let live PTY output reach `ws` until
+// this promise settles (see attach()'s two call sites for how each is kept
+// safe now that capture is no longer a blocking spawnSync call).
+async function replayCapture(ws: MawWS, target: string, lines: number, io: PtyDeps): Promise<void> {
   if (lines <= 0) return;
   try {
-    const cap = io.spawnSync(["tmux", "capture-pane", "-t", target, "-p", "-e", "-J", "-S", `-${lines}`]);
+    const cap = await io.spawnCapture(["tmux", "capture-pane", "-t", target, "-p", "-e", "-J", "-S", `-${lines}`]);
     if (cap.stdout && cap.stdout.length > 0) {
       ws.send(cap.stdout);
       ws.send(new TextEncoder().encode("\r\n"));
@@ -164,12 +180,35 @@ function handlePtyMessage(ws: MawWS, msg: string | Buffer) {
     const data = JSON.parse(msg);
     if (data.type === "attach") attach(ws, data.target, data.cols || 120, data.rows || 40, replayLinesFromControl(data.replayLines));
     else if (data.type === "resize") resize(ws, data.cols, data.rows);
-    else if (data.type === "detach") detach(ws);
+    else if (data.type === "detach") { detach(ws); bumpAttachEpoch(ws); }
   } catch { /* expected: malformed WS message */ }
 }
 
 function handlePtyClose(ws: MawWS) {
   detach(ws);
+  bumpAttachEpoch(ws);
+}
+
+// Per-ws attach epoch. Because replayCapture() is now async, an attach() has a
+// suspension window (the awaited capture) during which the socket can close,
+// send {type:"detach"}, or fire another {type:"attach"} — and by the time it
+// resumes, registering `ws` as a live viewer or sending "attached" may be
+// wrong. Each of those events bumps this counter; attach() snapshots it at
+// entry (`myEpoch`) and re-checks after every await that precedes viewer
+// registration or a ws.send. If it changed, a newer event superseded this
+// attach, so it aborts its registration. This is correct under all
+// interleavings — a *stale* detach can never abort a *later* attach, because
+// that later attach bumped the epoch past the detach's value. (The previous
+// one-shot `abandonedAttach` WeakSet flag was not: a detach set a sticky flag
+// that a subsequent re-attach on the same socket would wrongly consume,
+// silently dropping the re-attach. A duplicate concurrent attach likewise just
+// bumps the epoch, so the newest attach wins and the older in-flight one aborts
+// — which also subsumes the old `joiningCached` guard.)
+const attachEpoch = new WeakMap<MawWS, number>();
+function bumpAttachEpoch(ws: MawWS): number {
+  const next = (attachEpoch.get(ws) ?? 0) + 1;
+  attachEpoch.set(ws, next);
+  return next;
 }
 
 async function attach(ws: MawWS, target: string, cols: number, rows: number, replayLines: number) {
@@ -180,19 +219,32 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
   // Detach from any existing session
   detach(ws);
 
+  // Snapshot the attach epoch: any detach/close/re-attach on this socket during
+  // an awaited replayCapture() below bumps it, and we re-check before joining.
+  const myEpoch = bumpAttachEpoch(ws);
+
   // Join existing PTY session?
-  let session = sessions.get(safe);
-  if (session) {
-    if (session.cleanupTimer) {
-      io.clearTimeout(session.cleanupTimer);
-      session.cleanupTimer = null;
+  const cached = sessions.get(safe);
+  if (cached) {
+    if (cached.cleanupTimer) {
+      io.clearTimeout(cached.cleanupTimer);
+      cached.cleanupTimer = null;
     }
-    session.viewers.add(ws);
-    // Late viewer: cached PTY only streams *new* output, so without a replay
-    // the screen stays empty until something happens in the pane → looks like
-    // "black pane covering tmux". Mirror the new-session capture-pane block.
-    replayCapture(ws, safe, replayLines, io);
-    ws.send(JSON.stringify({ type: "attached", target: safe }));
+    // ORDERING GUARANTEE: the replay must reach `ws` before any live PTY
+    // output does. The PTY output loop below only ever sends to sockets in
+    // `session.viewers` — so as long as `ws` is deferred out of that set
+    // until replayCapture() has finished sending, no live frame can reach it
+    // early. That's exactly what happens here: `ws` is not added to
+    // `cached.viewers` until after the await below, so this is a deferred
+    // *registration* rather than a buffer-and-flush — there is nothing to
+    // buffer because `ws` was never a valid delivery target during capture.
+    await replayCapture(ws, safe, replayLines, io);
+
+    // Socket closed/detached, or a newer attach for this socket started, while
+    // capture was in flight → don't (re)join or write further (see attachEpoch).
+    if (attachEpoch.get(ws) !== myEpoch) return;
+    cached.viewers.add(ws);
+    try { ws.send(JSON.stringify({ type: "attached", target: safe })); } catch { /* expected: viewer may have disconnected */ }
     return;
   }
 
@@ -227,7 +279,7 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
   } catch {
     creatingPtyNames.delete(ptySessionName);
     attaching.delete(safe);
-    ws.send(JSON.stringify({ type: "error", message: "Failed to create PTY session" }));
+    try { ws.send(JSON.stringify({ type: "error", message: "Failed to create PTY session" })); } catch { /* expected: viewer may have disconnected */ }
     return;
   }
 
@@ -235,7 +287,13 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
   // attach only redraws current pane → viewer's local buffer has no history.
   // capture-pane reads tmux server-side history (limit set by history-limit).
   // -p stdout, -e include ANSI attrs, -S -2000 last 2000 lines, -J join wrapped.
-  replayCapture(ws, safe, replayLines, io);
+  //
+  // ORDERING GUARANTEE: this is awaited BEFORE io.spawn() below creates the
+  // live PTY wrapper process. No PTY process (and therefore no live output
+  // loop) exists yet at this point, so there is no possibility of live data
+  // reaching `ws` ahead of the replay — the guarantee holds structurally
+  // rather than by buffering.
+  await replayCapture(ws, safe, replayLines, io);
 
   // Spawn PTY wrapper — attach to our grouped session (not the original).
   //
@@ -277,7 +335,16 @@ async function attach(ws: MawWS, target: string, cols: number, rows: number, rep
     windowsHide: true,
   });
 
-  session = { proc, target: safe, ptySessionName, viewers: new Set([ws]), cleanupTimer: null };
+  // Viewer may have closed/detached (or started a newer attach) while we were
+  // creating the grouped tmux session and awaiting replayCapture() above. The
+  // grouped session is still spawned and tracked either way — abandoning it
+  // here would leak an untracked maw-pty-* session outside `sessions`
+  // (unreachable by #P2/#P3 until the wrapper process exits on its own) — but
+  // we don't register the departed/superseded socket as a viewer, matching the
+  // pre-async behavior where a vanished `ws` simply wouldn't receive further
+  // sends (see attachEpoch).
+  const initialViewers = attachEpoch.get(ws) === myEpoch ? [ws] : [];
+  const session: PtySession = { proc, target: safe, ptySessionName, viewers: new Set(initialViewers), cleanupTimer: null };
   sessions.set(safe, session);
   creatingPtyNames.delete(ptySessionName); // now tracked via `sessions`
   attaching.delete(safe);

--- a/test/claude-sessions-default.test.ts
+++ b/test/claude-sessions-default.test.ts
@@ -2,7 +2,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   mkdirSync,
-  readFileSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -79,7 +78,7 @@ function initGitRepo(path: string) {
   });
 }
 
-const execSyncFixture: NonNullable<ClaudeSessionDeps["execSync"]> = (cmd) => {
+const execSyncFixture: NonNullable<ClaudeSessionDeps["execSync"]> = async (cmd) => {
   const remoteMatch = cmd.match(/^git -C '([^']+)' remote get-url origin/);
   if (remoteMatch) {
     if (remoteMatch[1].endsWith("/repo")) return "git@github.com:Org/claude-repo.git\n";
@@ -92,14 +91,6 @@ const execSyncFixture: NonNullable<ClaudeSessionDeps["execSync"]> = (cmd) => {
       return `worktree ${worktreeMatch[1]}\nHEAD fixture\nbranch refs/heads/main\n\n`;
     }
     throw new Error(`not a git fixture: ${worktreeMatch[1]}`);
-  }
-
-  const tailMatch = cmd.match(/^tail -100 '([^']+)'/);
-  if (tailMatch) return readFileSync(tailMatch[1], "utf-8").split("\n").slice(-100).join("\n");
-
-  const lineCountMatch = cmd.match(/^awk 'END \{ print NR \}' '([^']+)'/);
-  if (lineCountMatch) {
-    return `${readFileSync(lineCountMatch[1], "utf-8").split("\n").filter(Boolean).length}\n`;
   }
 
   throw new Error(`unexpected fixture exec: ${cmd}`);

--- a/test/claude-sessions.test.ts
+++ b/test/claude-sessions.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, utimesSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, utimesSync, writeFileSync } from "fs";
 import { join } from "path";
 
 const tempDirs: string[] = [];
@@ -71,8 +71,7 @@ describe("Claude Code session discovery", () => {
 
     const { listClaudeSessions } = await freshModule();
     const sessions = await listClaudeSessions({
-      execSync: (command) => {
-        if (command.startsWith("tail ")) return readFileSync(freshSession, "utf-8");
+      execSync: async (command) => {
         throw new Error(`unexpected execSync call: ${command}`);
       },
     });
@@ -118,14 +117,12 @@ describe("Claude Code session discovery", () => {
     const { listClaudeSessions, __resetClaudeSessionCachesForTests } = await freshModule();
     __resetClaudeSessionCachesForTests();
     const commands: string[] = [];
-    const execSync = (command: string) => {
+    const execSync = async (command: string) => {
       commands.push(command);
       if (command.startsWith("ps -eo")) return `123 45 claude --dangerously-skip-permissions`;
       if (command.startsWith("readlink /proc/123/cwd")) return `${projectPath}\n`;
       if (command.startsWith("lsof -p 123")) return `n${projectPath}\n`;
       if (command.startsWith("ps -o comm=,ppid= -p 45")) return "tmux 1\n";
-      if (command.startsWith("tail ")) return readFileSync(sessionFile, "utf-8");
-      if (command.startsWith("awk ")) return "2\n";
       if (command.includes("remote get-url") || command.includes("worktree list")) throw new Error("not a git repo");
       throw new Error(`unexpected execSync call: ${command}`);
     };

--- a/test/costs-api-default.test.ts
+++ b/test/costs-api-default.test.ts
@@ -27,21 +27,21 @@ function appWithFiles(files: Record<string, string>, dirs = Object.keys(files).m
   const deps: CostsApiDeps = {
     projectsDir,
     join: (...parts) => parts.join("/"),
-    readdirSync: ((path: string) => {
+    readdir: (async (path: string) => {
       if (path === projectsDir) return dirEntries;
       if (path.endsWith("/dir-throws")) throw new Error("dir vanished");
       return Object.keys(files)
         .filter((file) => file.startsWith(`${path}/`))
         .map((file) => file.slice(path.length + 1));
-    }) as CostsApiDeps["readdirSync"],
-    readFileSync: ((path: string) => {
+    }) as CostsApiDeps["readdir"],
+    readLines: ((path: string) => (async function* () {
       if (path.endsWith("/read-throws.jsonl")) throw new Error("read failed");
-      return files[path] ?? "";
-    }) as CostsApiDeps["readFileSync"],
-    statSync: ((path: string) => {
+      for (const l of (files[path] ?? "").split("\n")) yield l;
+    })()) as CostsApiDeps["readLines"],
+    stat: (async (path: string) => {
       if (path.endsWith("/stat-throws")) throw new Error("stat failed");
       return { isDirectory: () => !path.endsWith("/not-a-dir") } as any;
-    }) as CostsApiDeps["statSync"],
+    }) as CostsApiDeps["stat"],
   };
   return new Elysia().use(createCostsApi(deps));
 }
@@ -55,9 +55,9 @@ describe("costs API default-suite coverage", () => {
     const unreadable = new Elysia().use(createCostsApi({
       projectsDir: "/missing",
       join: (...parts) => parts.join("/"),
-      readdirSync: (() => { throw new Error("denied"); }) as CostsApiDeps["readdirSync"],
-      readFileSync: (() => "") as CostsApiDeps["readFileSync"],
-      statSync: (() => ({ isDirectory: () => true })) as CostsApiDeps["statSync"],
+      readdir: (async () => { throw new Error("denied"); }) as CostsApiDeps["readdir"],
+      readLines: (() => (async function* () { /* never reached: readdir throws first */ })()) as CostsApiDeps["readLines"],
+      stat: (async () => ({ isDirectory: () => true })) as CostsApiDeps["stat"],
     }));
 
     let res = await unreadable.handle(new Request("http://local/costs/daily?days=0"));

--- a/test/isolated/claude-sessions-runtime-coverage.test.ts
+++ b/test/isolated/claude-sessions-runtime-coverage.test.ts
@@ -1,8 +1,8 @@
 /**
  * Runtime coverage for Claude session discovery. A single isolated module import
- * drives pid discovery/cache, trigger classification, git metadata, tail parsing,
- * project scanning fallbacks, and session cache behavior without touching local
- * Claude/tmux/git state.
+ * drives pid discovery/cache, trigger classification, git metadata, direct-file
+ * message parsing, project scanning fallbacks, and session cache behavior
+ * without touching local Claude/tmux/git state.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "fs";
@@ -23,14 +23,29 @@ mock.module(import.meta.resolve("os"), () => ({
   homedir: () => homeDir,
 }));
 
+// Our module's default exec seam shells out via execFile("/bin/sh", ["-c", cmd], ...)
+// so it never blocks the event loop. Mock execFile (node-callback style) and
+// translate the shelled-out command back into the same test fixtures used
+// before the async conversion.
 mock.module(import.meta.resolve("child_process"), () => ({
-  execSync: (cmd: string) => {
+  execFile: (
+    _file: string,
+    args: string[],
+    _options: unknown,
+    callback: (err: Error | null, result?: { stdout: string; stderr: string }) => void,
+  ) => {
+    const cmd = args[args.length - 1];
     execCalls.push(cmd);
-    return execSyncImpl(cmd);
+    try {
+      const stdout = execSyncImpl(cmd);
+      callback(null, { stdout, stderr: "" });
+    } catch (err) {
+      callback(err as Error);
+    }
   },
 }));
 
-const { decodeProjectDir, listClaudeSessions } = await import("../../src/core/fleet/claude-sessions.ts?claude-sessions-runtime-coverage");
+const { decodeProjectDir, listClaudeSessions, __resetClaudeSessionCachesForTests } = await import("../../src/core/fleet/claude-sessions.ts?claude-sessions-runtime-coverage");
 
 function setPlatform(value: NodeJS.Platform) {
   Object.defineProperty(process, "platform", { value, configurable: true });
@@ -49,11 +64,11 @@ function encodeProjectPath(path: string): string {
   return path.replace(/^\//, "-").replace(/[/.]/g, "-");
 }
 
-function writeSession(projectsRoot: string, projectPath: string, sessionId: string, ageMs = 1_000) {
+function writeSession(projectsRoot: string, projectPath: string, sessionId: string, ageMs = 1_000, body = `${sessionId}\n`) {
   const dir = join(projectsRoot, encodeProjectPath(projectPath));
   mkdirSync(dir, { recursive: true });
   const file = join(dir, `${sessionId}.jsonl`);
-  writeFileSync(file, `${sessionId}\n`);
+  writeFileSync(file, body);
   const d = new Date(now - ageMs);
   utimesSync(file, d, d);
   return file;
@@ -106,7 +121,10 @@ describe("claude-sessions runtime discovery", () => {
     expect(psCalls).toBe(1);
     expect(execCalls.filter((cmd) => cmd.startsWith("lsof -p 201"))).toHaveLength(1);
 
-    // Explicit skip flag bypasses pid scanning entirely.
+    // Explicit skip flag bypasses pid scanning entirely. Force past the
+    // (now 15s) session cache so this phase exercises a real scan rather
+    // than replaying the previous phase's cached result.
+    __resetClaudeSessionCachesForTests();
     execCalls = [];
     process.env.MAW_CLAUDE_SKIP_PID_SCAN = "1";
     process.env.MAW_CLAUDE_PROJECTS_DIR = join(tempDir(), "missingprojects");
@@ -116,6 +134,7 @@ describe("claude-sessions runtime discovery", () => {
     delete process.env.MAW_CLAUDE_SKIP_PID_SCAN;
 
     // ps failure is tolerated and cached while project dir is absent.
+    __resetClaudeSessionCachesForTests();
     now += 5_100;
     let failingPsCalls = 0;
     execSyncImpl = (cmd) => {
@@ -131,6 +150,7 @@ describe("claude-sessions runtime discovery", () => {
     expect(failingPsCalls).toBe(1);
 
     // Full Linux discovery matrix after pid cache expiry.
+    __resetClaudeSessionCachesForTests();
     now += 5_100;
     setPlatform("linux");
     execCalls = [];
@@ -149,12 +169,23 @@ describe("claude-sessions runtime discovery", () => {
     };
     for (const p of Object.values(paths)) mkdirSync(p, { recursive: true });
 
-    const mawFile = writeSession(projectsRoot, paths.maw, "maw-session", 1_000);
-    const tmuxFile = writeSession(projectsRoot, paths.tmux, "tmux-session", 300_000);
+    const mawBody = [
+      JSON.stringify({ type: "user", message: { content: "hello from user" } }),
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "hello from assistant" }] } }),
+      "{bad json",
+    ].join("\n");
+    const tmuxBody = [
+      JSON.stringify({ type: "user", message: { content: [{ type: "text", text: "array user" }] } }),
+      JSON.stringify({ type: "assistant", message: { content: "assistant string ignored" } }),
+    ].join("\n");
+    writeSession(projectsRoot, paths.maw, "maw-session", 1_000, mawBody);
+    writeSession(projectsRoot, paths.tmux, "tmux-session", 300_000, tmuxBody);
     writeSession(projectsRoot, paths.cron, "cron-session", 2_000);
     writeSession(projectsRoot, paths.desktop, "desktop-session", 3_000);
     writeSession(projectsRoot, paths.unknown, "unknown-session", 4_000);
-    writeSession(projectsRoot, paths.broken, "broken-session", 5_000);
+    // Empty body mirrors the old "tail failed" fixture: no parsable lines,
+    // so both last-message fields stay null.
+    writeSession(projectsRoot, paths.broken, "broken-session", 5_000, "");
     writeSession(projectsRoot, paths.ended, "ended-session", 6_000);
 
     const endedDir = join(projectsRoot, encodeProjectPath(paths.ended));
@@ -212,23 +243,6 @@ describe("claude-sessions runtime discovery", () => {
         }
         if (cmd.includes(paths.tmux)) return "worktree /elsewhere\nbranch refs/heads/other";
         throw new Error("not worktree");
-      }
-      if (cmd.includes("tail -100")) {
-        if (cmd.includes(mawFile)) {
-          return [
-            JSON.stringify({ type: "user", message: { content: "hello from user" } }),
-            JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "hello from assistant" }] } }),
-            "{bad json",
-          ].join("\n");
-        }
-        if (cmd.includes(tmuxFile)) {
-          return [
-            JSON.stringify({ type: "user", message: { content: [{ type: "text", text: "array user" }] } }),
-            JSON.stringify({ type: "assistant", message: { content: "assistant string ignored" } }),
-          ].join("\n");
-        }
-        if (cmd.includes("broken-session.jsonl")) throw new Error("tail failed");
-        return "";
       }
       throw new Error(`unexpected command: ${cmd}`);
     };

--- a/test/isolated/pty-attach-replay.test.ts
+++ b/test/isolated/pty-attach-replay.test.ts
@@ -35,10 +35,40 @@ const originalSpawnSync = Bun.spawnSync;
 let spawnCalls: unknown[][] = [];
 let spawnSyncImpl: (args: string[]) => { stdout: Uint8Array } = () => ({ stdout: encode("captured-pane") });
 
+// capture-pane now runs via Bun.spawn (async, streamed to completion) instead
+// of the old blocking Bun.spawnSync — see pty.ts's default spawnCapture. This
+// mock detects the ["tmux","capture-pane",...] shape and answers it with a
+// one-shot ReadableStream built from spawnSyncImpl's result, while any other
+// Bun.spawn call (the live PTY wrapper) keeps the original never-resolving
+// reader stub used throughout this file.
+function isCapturePaneArgs(args: unknown[]): boolean {
+  return args[0] === "tmux" && args[1] === "capture-pane";
+}
+
 function installSpawnMocks() {
   spawnCalls = [];
   (Bun as any).spawnSync = (args: string[]) => spawnSyncImpl(args);
   (Bun as any).spawn = (args: unknown[]) => {
+    if (isCapturePaneArgs(args)) {
+      let result: { stdout: Uint8Array };
+      let thrown: unknown;
+      try {
+        result = spawnSyncImpl(args as string[]);
+      } catch (err) {
+        thrown = err;
+        result = { stdout: new Uint8Array(0) };
+      }
+      return {
+        stdout: new ReadableStream<Uint8Array>({
+          start(controller) {
+            if (thrown) { controller.error(thrown); return; }
+            controller.enqueue(result.stdout);
+            controller.close();
+          },
+        }),
+        exited: thrown ? Promise.reject(thrown).catch(() => 1) : Promise.resolve(0),
+      };
+    }
     spawnCalls.push(args);
     return {
       stdin: { write() {}, flush() {} },
@@ -87,6 +117,11 @@ describe("PTY attach scrollback replay (#1588)", async () => {
     const lateViewer = makeWs();
     handlePtyMessage(lateViewer as any, JSON.stringify({ type: "attach", target }));
 
+    // Capture-pane is async now (Bun.spawn instead of Bun.spawnSync), so the
+    // "attached" control message — sent only after the deferred join
+    // completes — arrives on a later microtask/tick than this call.
+    await eventually(() => lateViewer.sent.length >= 3, "cached replay + attached delivery");
+
     expect(lateViewer.sent.map(decode)).toEqual([
       "cached screen",
       "\r\n",
@@ -103,6 +138,18 @@ describe("PTY attach scrollback replay (#1588)", async () => {
       return { stdout: encode("fresh screen") };
     };
     (Bun as any).spawn = (args: unknown[]) => {
+      if (isCapturePaneArgs(args)) {
+        const result = spawnSyncImpl(args as string[]);
+        return {
+          stdout: new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(result.stdout);
+              controller.close();
+            },
+          }),
+          exited: Promise.resolve(0),
+        };
+      }
       sequence.push(`spawn:${JSON.stringify(args)}`);
       spawnCalls.push(args);
       return {
@@ -137,6 +184,8 @@ describe("PTY attach scrollback replay (#1588)", async () => {
     spawnSyncImpl = () => { throw new Error("tmux target disappeared"); };
     const lateViewer = makeWs();
     handlePtyMessage(lateViewer as any, JSON.stringify({ type: "attach", target }));
+
+    await eventually(() => lateViewer.sent.length >= 1, "attached delivery despite capture failure");
 
     expect(lateViewer.sent.map(decode)).toEqual([
       JSON.stringify({ type: "attached", target }),

--- a/test/isolated/pty-transport-coverage.test.ts
+++ b/test/isolated/pty-transport-coverage.test.ts
@@ -49,6 +49,11 @@ let spawnPlans: SpawnPlan[] = [];
 let spawnCalls: Array<{ args: string[]; opts: any }> = [];
 let spawnSyncCalls: string[][] = [];
 let spawnSyncImpl: (args: string[]) => { stdout?: Uint8Array } = () => ({ stdout: encode("scrollback") });
+// spawnSyncCalls/spawnSyncImpl are named for parity with the old synchronous
+// seam, but capture-pane now goes through the same Bun.spawn mock as the live
+// PTY wrapper (both call the global Bun.spawn — see installSpawnMocks below,
+// which routes ["tmux","capture-pane",...] invocations to spawnSyncImpl's
+// result instead of the spawnPlans queue used for the live wrapper process).
 let readers: ControlledReader[] = [];
 let stdinWrites: Uint8Array[] = [];
 let procKills = 0;
@@ -108,12 +113,45 @@ function makeWs(): MockWs {
   };
 }
 
+// A capture-pane invocation ["tmux","capture-pane",...] now goes through the
+// same Bun.spawn seam as the live PTY wrapper (pty.ts's default spawnCapture
+// shells out via Bun.spawn + reads its stdout stream to completion, replacing
+// the old Bun.spawnSync call). This mock detects that shape and returns a
+// process whose `stdout` is a one-shot ReadableStream instead of a live
+// reader, honoring spawnSyncImpl/spawnSyncCalls so existing assertions keep
+// working unchanged.
+function isCapturePaneArgs(args: string[]): boolean {
+  return args[0] === "tmux" && args[1] === "capture-pane";
+}
+
 function installSpawnMocks() {
   (Bun as any).spawnSync = (args: string[]) => {
     spawnSyncCalls.push(args);
     return spawnSyncImpl(args);
   };
   (Bun as any).spawn = (args: string[], opts: any) => {
+    if (isCapturePaneArgs(args)) {
+      spawnSyncCalls.push(args);
+      let result: { stdout?: Uint8Array };
+      let thrown: unknown;
+      try {
+        result = spawnSyncImpl(args);
+      } catch (err) {
+        thrown = err;
+        result = { stdout: new Uint8Array(0) };
+      }
+      const bytes = result.stdout ?? new Uint8Array(0);
+      return {
+        stdout: new ReadableStream<Uint8Array>({
+          start(controller) {
+            if (thrown) { controller.error(thrown); return; }
+            controller.enqueue(bytes);
+            controller.close();
+          },
+        }),
+        exited: thrown ? Promise.reject(thrown).catch(() => 1) : Promise.resolve(0),
+      };
+    }
     spawnCalls.push({ args, opts });
     const plan = spawnPlans.shift() ?? { autoEnd: true };
     const reader = new ControlledReader(plan.chunks ?? [], plan.autoEnd ?? true);
@@ -238,6 +276,7 @@ describe("PTY websocket bridge", () => {
     spawnSyncImpl = () => ({ stdout: encode("cached screen") });
     const late = makeWs();
     handlePtyMessage(late as any, JSON.stringify({ type: "attach", target: "cached:main" }));
+    await eventually(() => late.sent.length >= 3, "cached replay + attached delivery");
 
     expect(late.sent.map(decode)).toEqual([
       "cached screen",

--- a/test/pty-transport-default.test.ts
+++ b/test/pty-transport-default.test.ts
@@ -52,7 +52,7 @@ function makeHarness(options: {
   colsLimit?: number;
   rowsLimit?: number;
   spawnPlans?: SpawnPlan[];
-  spawnSync?: (args: string[]) => { stdout?: Uint8Array };
+  spawnCapture?: (args: string[]) => Promise<{ stdout?: Uint8Array }> | { stdout?: Uint8Array };
   groupedImpl?: (sessionName: string, ptySessionName: string, opts: unknown) => Promise<void>;
   setOptionImpl?: (session: string, option: string, value: string) => Promise<void>;
   listSessionGroupsImpl?: () => Promise<Array<{ name: string; group: string }>>;
@@ -61,7 +61,7 @@ function makeHarness(options: {
   const readers: ControlledReader[] = [];
   const stdinWrites: Uint8Array[] = [];
   const spawnCalls: Array<{ args: string[]; opts: any }> = [];
-  const spawnSyncCalls: string[][] = [];
+  const spawnCaptureCalls: string[][] = [];
   const groupedCalls: Array<{ sessionName: string; ptySessionName: string; opts: any }> = [];
   const setOptionCalls: Array<{ session: string; option: string; value: string }> = [];
   const killSessionCalls: string[] = [];
@@ -77,9 +77,11 @@ function makeHarness(options: {
     env: () => options.envHost === undefined ? {} as NodeJS.ProcessEnv : { MAW_HOST: options.envHost } as NodeJS.ProcessEnv,
     platform: () => options.platform ?? "linux",
     now: () => 123456,
-    spawnSync: (args: string[]) => {
-      spawnSyncCalls.push(args);
-      return (options.spawnSync ?? (() => ({ stdout: encode("scrollback") })))(args) as ReturnType<typeof Bun.spawnSync>;
+    spawnCapture: async (args: string[]) => {
+      spawnCaptureCalls.push(args);
+      const impl = options.spawnCapture ?? (() => ({ stdout: encode("scrollback") }));
+      const result = await impl(args);
+      return { stdout: result.stdout ?? new Uint8Array(0), exitCode: 0 };
     },
     spawn: (args: string[], opts: any) => {
       spawnCalls.push({ args, opts });
@@ -143,7 +145,7 @@ function makeHarness(options: {
     readers,
     stdinWrites,
     spawnCalls,
-    spawnSyncCalls,
+    spawnCaptureCalls,
     groupedCalls,
     setOptionCalls,
     killSessionCalls,
@@ -182,7 +184,7 @@ describe("ptyDeps", () => {
     expect(typeof deps.cfgTimeout).toBe("function");
     expect(typeof deps.cfgLimit).toBe("function");
     expect(typeof deps.spawn).toBe("function");
-    expect(typeof deps.spawnSync).toBe("function");
+    expect(typeof deps.spawnCapture).toBe("function");
     expect(typeof deps.env()).toBe("object");
     expect(typeof deps.platform()).toBe("string");
     expect(typeof deps.now()).toBe("number");
@@ -220,7 +222,7 @@ describe("createPtyHandlers", () => {
       opts: { cols: 200, rows: 1, window: "oracle" },
     });
     expect(h.setOptionCalls[0]).toEqual({ session: "maw-pty-123456-1", option: "status", value: "off" });
-    expect(h.spawnSyncCalls[0]).toEqual(["tmux", "capture-pane", "-t", "demo:oracle", "-p", "-e", "-J", "-S", "-2000"]);
+    expect(h.spawnCaptureCalls[0]).toEqual(["tmux", "capture-pane", "-t", "demo:oracle", "-p", "-e", "-J", "-S", "-2000"]);
     expect(h.spawnCalls[0].args[0]).toBe("/usr/bin/expect");
     expect(h.spawnCalls[0].opts).toMatchObject({ stdin: "pipe", stdout: "pipe", stderr: "ignore", windowsHide: true });
     expect(h.spawnCalls[0].opts.env.TERM).toBe("xterm-256color");
@@ -251,6 +253,7 @@ describe("createPtyHandlers", () => {
     const late = makeWs();
     h.handlePtyMessage(late as any, JSON.stringify({ type: "attach", target: "cached:main" }));
     expect(h.clearedTimers).toHaveLength(1);
+    await eventually(() => late.sent.length >= 3, "cached replay + attached delivery");
     expect(late.sent.map(decode)).toEqual([
       "scrollback",
       "\r\n",
@@ -268,7 +271,7 @@ describe("createPtyHandlers", () => {
     const h = makeHarness({
       host: "remote.example",
       setOptionImpl: async () => { throw new Error("option unsupported"); },
-      spawnSync: () => { throw new Error("capture failed"); },
+      spawnCapture: () => { throw new Error("capture failed"); },
       spawnPlans: [{ autoEnd: true }],
     });
     const ws = makeWs();
@@ -323,7 +326,7 @@ describe("createPtyHandlers", () => {
   });
 
   test("fresh and cached capture failures do not abort attach", async () => {
-    const h = makeHarness({ spawnSync: () => { throw new Error("tmux target disappeared"); }, spawnPlans: [{ chunks: ["first"], autoEnd: false }] });
+    const h = makeHarness({ spawnCapture: () => { throw new Error("tmux target disappeared"); }, spawnPlans: [{ chunks: ["first"], autoEnd: false }] });
     const first = makeWs();
     h.handlePtyMessage(first as any, JSON.stringify({ type: "attach", target: "capture-fail:0" }));
     await eventually(() => first.sent.map(decode).includes("first"), "capture failure fresh output");
@@ -335,6 +338,7 @@ describe("createPtyHandlers", () => {
 
     const late = makeWs();
     h.handlePtyMessage(late as any, JSON.stringify({ type: "attach", target: "capture-fail:0" }));
+    await eventually(() => late.sent.length >= 1, "attached delivery despite capture failure");
     expect(late.sent.map(decode)).toEqual([
       JSON.stringify({ type: "attached", target: "capture-fail:0" }),
     ]);
@@ -347,7 +351,7 @@ describe("createPtyHandlers", () => {
     noReplay.handlePtyMessage(liveOnly as any, JSON.stringify({ type: "attach", target: "follow:0", replayLines: 0 }));
     await eventually(() => liveOnly.sent.map(decode).includes(JSON.stringify({ type: "detached", target: "follow:0" })), "no-replay detach");
 
-    expect(noReplay.spawnSyncCalls).toEqual([]);
+    expect(noReplay.spawnCaptureCalls).toEqual([]);
     expect(liveOnly.sent.map(decode)).toEqual([
       JSON.stringify({ type: "attached", target: "follow:0" }),
       "live",
@@ -358,11 +362,12 @@ describe("createPtyHandlers", () => {
     const firstViewer = makeWs();
     shared.handlePtyMessage(firstViewer as any, JSON.stringify({ type: "attach", target: "follow:shared", replayLines: 0 }));
     await eventually(() => firstViewer.sent.map(decode).includes("first"), "shared follow output");
-    expect(shared.spawnSyncCalls).toEqual([]);
+    expect(shared.spawnCaptureCalls).toEqual([]);
 
     const secondViewer = makeWs();
     shared.handlePtyMessage(secondViewer as any, JSON.stringify({ type: "attach", target: "follow:shared", replayLines: 0 }));
-    expect(shared.spawnSyncCalls).toEqual([]);
+    await eventually(() => secondViewer.sent.length >= 1, "no-replay cached join delivery");
+    expect(shared.spawnCaptureCalls).toEqual([]);
     expect(secondViewer.sent.map(decode)).toEqual([
       JSON.stringify({ type: "attached", target: "follow:shared" }),
     ]);
@@ -373,7 +378,7 @@ describe("createPtyHandlers", () => {
     bounded.handlePtyMessage(withReplay as any, JSON.stringify({ type: "attach", target: "follow:1", replayLines: 12 }));
     await eventually(() => bounded.spawnCalls.length === 1, "bounded replay spawn");
 
-    expect(bounded.spawnSyncCalls[0]).toEqual(["tmux", "capture-pane", "-t", "follow:1", "-p", "-e", "-J", "-S", "-12"]);
+    expect(bounded.spawnCaptureCalls[0]).toEqual(["tmux", "capture-pane", "-t", "follow:1", "-p", "-e", "-J", "-S", "-12"]);
   });
 
   test("#P2 sweep kills untracked maw-pty-* sessions, sparing tracked and non-maw sessions", async () => {
@@ -421,6 +426,94 @@ describe("createPtyHandlers", () => {
     // P3 is fire-and-forget alongside session creation — poll for the kill.
     await eventually(() => h.killSessionCalls.includes("maw-pty-stale"), "P3 stale-orphan kill");
     expect(h.killSessionCalls).not.toContain("maw-pty-other");
+    await h.finishReaders();
+  });
+
+  test("ordering: replay bytes reach a joining viewer before live output that arrives mid-capture", async () => {
+    // Regression guard for the spawnSync→async conversion: capture-pane is no
+    // longer a blocking call, so there is a real await gap between a second
+    // viewer's cached-session join starting and it being registered into
+    // session.viewers. If live PTY output were (incorrectly) delivered to
+    // that viewer during the gap, it would arrive before — or interleaved
+    // with — the replay. This pins the correct order: replay text, then
+    // "\r\n", then "attached", then (only after that) any live bytes.
+    let releaseCapture!: (bytes: Uint8Array) => void;
+    const captureGate = new Promise<Uint8Array>((resolve) => { releaseCapture = resolve; });
+    let captureCallCount = 0;
+    const h = makeHarness({
+      spawnPlans: [{ chunks: [], autoEnd: false }], // first (owning) viewer's live PTY; no output yet
+      // First call is the owner's own fresh-attach replay (resolves right
+      // away, matching the structural guarantee for that path). Only the
+      // second call — the joiner's cached-session replay — hangs on the gate,
+      // isolating the race we actually want to exercise.
+      spawnCapture: async () => {
+        captureCallCount += 1;
+        if (captureCallCount === 1) return { stdout: new Uint8Array(0) };
+        return { stdout: await captureGate };
+      },
+    });
+
+    const owner = makeWs();
+    h.handlePtyMessage(owner as any, JSON.stringify({ type: "attach", target: "race:0" }));
+    await eventually(() => h.spawnCalls.length === 1, "owner session created");
+
+    // Second viewer joins the now-cached session — this kicks off another
+    // replayCapture() that hangs on captureGate until we release it below.
+    const joiner = makeWs();
+    h.handlePtyMessage(joiner as any, JSON.stringify({ type: "attach", target: "race:0" }));
+    await flush(); // let the join reach the (still-pending) replayCapture await
+
+    // Capture is still in flight. The invariant under test: `joiner` must not
+    // be a registered viewer yet, so even though the owner's live PTY stream
+    // is open and could emit at any moment, nothing can reach `joiner` ahead
+    // of its replay — there is no live frame in its queue.
+    expect(joiner.sent).toEqual([]);
+
+    releaseCapture(new TextEncoder().encode("replayed screen"));
+    await eventually(() => joiner.sent.length >= 3, "joiner replay + attached delivery");
+
+    expect(joiner.sent.map(decode)).toEqual([
+      "replayed screen",
+      "\r\n",
+      JSON.stringify({ type: "attached", target: "race:0" }),
+    ]);
+
+    await h.finishReaders();
+  });
+
+  test("re-attach after detach on the same socket rejoins (epoch supersedes the stale detach)", async () => {
+    // Regression guard for the spawnSync→async conversion's first cut, which
+    // tracked abandon state in a one-shot WeakSet flag set on every detach and
+    // close. A client that detached and later re-attached on the SAME socket
+    // would have that stale flag consumed after the re-attach's (now async)
+    // replay, silently aborting the join → the terminal never came back. The
+    // attach-epoch snapshot supersedes the stale detach instead, so a
+    // detach→re-attach cycle rejoins normally (as it did pre-async).
+    const h = makeHarness({ spawnPlans: [{ chunks: ["initial output"], autoEnd: false, killThrows: true }] });
+    const ws = makeWs();
+
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "reattach:0" }));
+    await eventually(() => ws.sent.map(decode).includes("initial output"), "initial attach output");
+
+    // Detach — under the old one-shot flag this poisoned the socket for any
+    // future attach; the session stays cached with a pending cleanup timer.
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "detach" }));
+    expect(h.timerCallbacks).toHaveLength(1);
+
+    // Re-attach on the same socket to the still-cached session — must rejoin.
+    ws.sent.length = 0;
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "reattach:0" }));
+    await eventually(
+      () => ws.sent.map(decode).includes(JSON.stringify({ type: "attached", target: "reattach:0" })),
+      "re-attach rejoin",
+    );
+
+    expect(ws.sent.map(decode)).toEqual([
+      "scrollback",
+      "\r\n",
+      JSON.stringify({ type: "attached", target: "reattach:0" }),
+    ]);
+
     await h.finishReaders();
   });
 });

--- a/test/receiver-inbox-collision.test.ts
+++ b/test/receiver-inbox-collision.test.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 import { persistReceiverInbox } from "../src/commands/shared/receiver-inbox";
 
 describe("receiver inbox filename collisions (#1967)", () => {
-  test("keeps same-minute messages with matching first six words", () => {
+  test("keeps same-minute messages with matching first six words", async () => {
     const root = mkdtempSync(join(tmpdir(), "maw-receiver-inbox-collision-"));
     const repo = join(root, "digger-oracle");
     mkdirSync(repo, { recursive: true });
@@ -13,17 +13,17 @@ describe("receiver inbox filename collisions (#1967)", () => {
       resolveTargetCwd: () => repo,
       loadManifest: () => [],
       getGhqRoot: () => root,
-      ghqFindSync: () => null,
+      ghqFind: async () => null,
       now: () => new Date("2026-05-17T08:00:42.000Z"),
     };
 
-    const first = persistReceiverInbox({
+    const first = await persistReceiverInbox({
       query: "digger",
       target: "54-digger:digger-oracle.0",
       from: "m5:sender",
       message: "one two three four five six alpha",
     }, deps);
-    const second = persistReceiverInbox({
+    const second = await persistReceiverInbox({
       query: "digger",
       target: "54-digger:digger-oracle.0",
       from: "m5:sender",

--- a/test/receiver-inbox-default.test.ts
+++ b/test/receiver-inbox-default.test.ts
@@ -39,12 +39,12 @@ describe("receiver inbox auto-write helpers", () => {
     expect(resolveReceiverOracle({ query: "digger-oracle", from: "m5:sender", message: "hi" })).toBe("digger");
   });
 
-  test("writes markdown frontmatter to the receiver ψ/inbox using target cwd first", () => {
+  test("writes markdown frontmatter to the receiver ψ/inbox using target cwd first", async () => {
     const root = mkdtempSync(join(tmpdir(), "maw-receiver-inbox-"));
     const repo = join(root, "digger-oracle");
     mkdirSync(repo, { recursive: true });
 
-    const result = persistReceiverInbox({
+    const result = await persistReceiverInbox({
       query: "m5:digger",
       target: "54-digger:digger-oracle.0",
       from: "m5:sender",
@@ -54,7 +54,7 @@ describe("receiver inbox auto-write helpers", () => {
       resolveTargetCwd: () => repo,
       loadManifest: () => [],
       getGhqRoot: () => root,
-      ghqFindSync: () => null,
+      ghqFind: async () => null,
       now: () => new Date("2026-05-17T08:00:00.000Z"),
     });
 
@@ -68,12 +68,12 @@ describe("receiver inbox auto-write helpers", () => {
     expect(readFileSync(result.path, "utf-8")).toContain("[m5:sender] ralph-dig: oracle-status-tray");
   });
 
-  test("accepts an absolute repo path target for locate-resolved no-live queues (#2056)", () => {
+  test("accepts an absolute repo path target for locate-resolved no-live queues (#2056)", async () => {
     const root = mkdtempSync(join(tmpdir(), "maw-receiver-inbox-absolute-"));
     const repo = join(root, "renamed-oracle");
     mkdirSync(repo, { recursive: true });
 
-    const result = persistReceiverInbox({
+    const result = await persistReceiverInbox({
       query: "renamed",
       target: repo,
       from: "m5:sender",
@@ -82,7 +82,7 @@ describe("receiver inbox auto-write helpers", () => {
       resolveTargetCwd: () => null,
       loadManifest: () => [],
       getGhqRoot: () => root,
-      ghqFindSync: () => null,
+      ghqFind: async () => null,
       now: () => new Date("2026-06-06T07:00:00.000Z"),
     });
 
@@ -92,12 +92,12 @@ describe("receiver inbox auto-write helpers", () => {
     expect(readFileSync(result.path, "utf-8")).toContain("queued via locate path");
   });
 
-  test("falls back to manifest repo path and reports misses without throwing", () => {
+  test("falls back to manifest repo path and reports misses without throwing", async () => {
     const root = mkdtempSync(join(tmpdir(), "maw-receiver-inbox-manifest-"));
     const repo = join(root, "github.com", "Soul-Brews-Studio", "digger-oracle");
     mkdirSync(repo, { recursive: true });
 
-    const ok = persistReceiverInbox({
+    const ok = await persistReceiverInbox({
       query: "digger",
       from: "m5:sender",
       message: "queue me",
@@ -105,14 +105,14 @@ describe("receiver inbox auto-write helpers", () => {
       resolveTargetCwd: () => null,
       loadManifest: () => [{ name: "digger", sources: ["fleet"], repo: "Soul-Brews-Studio/digger-oracle", isLive: false }],
       getGhqRoot: () => root,
-      ghqFindSync: () => null,
+      ghqFind: async () => null,
       now: () => new Date("2026-05-17T08:01:00.000Z"),
     });
 
     expect(ok.ok).toBe(true);
     if (ok.ok) expect(ok.inboxDir).toBe(join(repo, "ψ", "inbox"));
 
-    const miss = persistReceiverInbox({
+    const miss = await persistReceiverInbox({
       query: "ghost",
       from: "m5:sender",
       message: "lost",
@@ -120,44 +120,44 @@ describe("receiver inbox auto-write helpers", () => {
       resolveTargetCwd: () => null,
       loadManifest: () => [],
       getGhqRoot: () => root,
-      ghqFindSync: () => null,
+      ghqFind: async () => null,
     });
     expect(miss).toEqual({ ok: false, oracle: "ghost", reason: "receiver repo not found for ghost" });
   });
 
-  test("handles psiPath, discovery exceptions, and write failures safely", () => {
+  test("handles psiPath, discovery exceptions, and write failures safely", async () => {
     const root = mkdtempSync(join(tmpdir(), "maw-receiver-inbox-errors-"));
     const repo = join(root, "current-oracle");
     mkdirSync(repo, { recursive: true });
 
-    const psi = persistReceiverInbox({
+    const psi = await persistReceiverInbox({
       query: "current",
       from: "m5:sender",
       message: "via psi path",
       config: { oracle: "current", psiPath: join(repo, "ψ") },
     }, {
       loadManifest: () => { throw new Error("manifest boom"); },
-      ghqFindSync: () => { throw new Error("ghq boom"); },
+      ghqFind: async () => { throw new Error("ghq boom"); },
       getGhqRoot: () => root,
       now: () => new Date("2026-05-17T08:02:00.000Z"),
     });
     expect(psi.ok).toBe(true);
     if (psi.ok) expect(psi.inboxDir).toBe(join(repo, "ψ", "inbox"));
 
-    const noRepo = persistReceiverInbox({
+    const noRepo = await persistReceiverInbox({
       query: "current",
       from: "m5:sender",
       message: "exists throws",
       config: { oracle: "current", psiPath: join(root, "bad", "ψ") },
     }, {
       loadManifest: () => { throw new Error("manifest boom"); },
-      ghqFindSync: () => { throw new Error("ghq boom"); },
+      ghqFind: async () => { throw new Error("ghq boom"); },
       getGhqRoot: () => root,
       existsSync: () => { throw new Error("exists boom"); },
     });
     expect(noRepo).toEqual({ ok: false, oracle: "current", reason: "receiver repo not found for current" });
 
-    const writeFail = persistReceiverInbox({
+    const writeFail = await persistReceiverInbox({
       query: "current",
       from: "m5:sender",
       message: "write fails",


### PR DESCRIPTION
## Problem

`maw serve` runs everything on a single Bun event loop. Several serve-reachable code paths did blocking work (synchronous subprocess spawns and full synchronous file reads), which froze **all** websockets, terminals, and HTTP for the duration. On a busy host this showed up as periodic "type → freeze → resume" stutters.

Measured on a real host (≈138 Claude session `.jsonl` files, two of them 500MB+): the live event-loop was blocked up to **~5.4s on a ~15s cadence**. After this PR: **≤8ms, zero stalls >30ms over 120s**.

## Root cause (biggest offender: `/api/costs`)

`src/api/costs.ts` (`/costs` + `/costs/daily`) read **every** `~/.claude/projects/*.jsonl` in full via `readFileSync` and `JSON.parse`-d every line, synchronously, with no caching, on every request. With 500MB+ transcripts (one line 2.6M chars) each call blocked the loop ~5.4s, and the costs dashboard polls ~every 15s. Converting fs to async alone does **not** help — the bottleneck is CPU parsing, not I/O.

## Changes (each commit is standalone)

- **fix(fleet): make claude session scan fully async** — `listClaudeSessions` fired hundreds of blocking `execSync` per scan (ps, readlink/lsof, git remote/worktree per session, `awk`/`tail`). Now an async exec seam + concurrency pool (cap 8) + per-cwd git dedupe; message count/tail via direct file reads. Cache TTL 5s→15s.
- **fix(transport): make pty `replayCapture` async** — tmux `capture-pane` (up to 10k lines) ran via `Bun.spawnSync` on every terminal attach. Now async; the replay-before-live-output ordering is preserved via deferred viewer registration + a per-ws attach epoch (correct under detach→re-attach and duplicate-attach races). `#P2`/`#P3` orphan sweep + `creatingPtyNames` protections unchanged.
- **fix(inbox): move serve-reachable ghq lookup off the sync path** — `/send` route resolved a repo via sync `ghqFindSync` (`execSync "ghq list"`). Switched to async `ghqFind`. (CLI-only sync ghq/oracle-scan paths intentionally left sync.)
- **fix(fleet): convert claude session dir/stat reads to async fs** — remaining `readdirSync`/`statSync` in the scan → `fs/promises`.
- **fix(costs): stream + prefilter + per-file cache** — stream each transcript line-by-line (bounded memory, no ~1GB `split`); cheap string pre-filter so only lines containing `"usage"` are `JSON.parse`d; `await setImmediate` yield every ~2048 lines; per-file cache keyed by `(mtimeMs, size)` so append-only transcripts are read once then skipped; shared 30s result cache across both endpoints.

All conversions preserve the existing dependency-injection test seams (converted to async equivalents).

## Testing

- All touched files' existing bun tests pass (96 batch + isolated across claude-sessions, pty, receiver-inbox, ghq-helper, costs, sessions-api, deprecated).
- Added regression tests: pty replay-before-live ordering, and detach→re-attach rejoin.
- Verified live on the affected host: event-loop max block **5420ms → 8ms**, 0 stalls >30ms over 120s.

Based on `alpha` (following the precedent of `fix/config-api-weighted-read`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
