### PR TITLE
Fix atomic audit appends

### DIFF
--- a/src/core/fleet/audit.ts
+++ b/src/core/fleet/audit.ts
@@ -1,5 +1,5 @@
 import { dirname } from "path";
-import { appendFileSync, readFileSync, existsSync, mkdirSync } from "fs";
+import { appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, writeSync } from "fs";
 import os from "os";
 import { mawStatePath } from "../xdg";
 
@@ -16,6 +16,22 @@ export interface AuditEntry {
   result?: string;
 }
 
+const ATOMIC_APPEND_MAX_BYTES = 4096;
+
+function appendAuditLineAtomic(filePath: string, line: string): void {
+  const bytes = Buffer.byteLength(line, "utf8");
+  if (bytes > ATOMIC_APPEND_MAX_BYTES) {
+    throw new Error(`audit record too large for atomic append: ${bytes} bytes`);
+  }
+  const fd = openSync(filePath, "a");
+  try {
+    const written = writeSync(fd, line, undefined, "utf8");
+    if (written !== bytes) throw new Error(`short audit append: ${written}/${bytes}`);
+  } finally {
+    closeSync(fd);
+  }
+}
+
 /** Append a structured audit log entry to maw's runtime state audit log. */
 export function logAudit(cmd: string, args: string[], result?: string): void {
   const entry: AuditEntry = {
@@ -29,7 +45,7 @@ export function logAudit(cmd: string, args: string[], result?: string): void {
   try {
     const filePath = auditFilePath();
     mkdirSync(dirname(filePath), { recursive: true });
-    appendFileSync(filePath, JSON.stringify(entry) + "\n", "utf-8");
+    appendAuditLineAtomic(filePath, JSON.stringify(entry) + "\n");
   } catch {
     // Silent fail — audit should never break the CLI
   }

--- a/test/isolated/fleet-audit-more-coverage.test.ts
+++ b/test/isolated/fleet-audit-more-coverage.test.ts
@@ -5,6 +5,7 @@
 
 import { afterAll, describe, expect, mock, test } from "bun:test";
 import { join } from "path";
+import { writeFileSync } from "node:fs";
 
 // Reset leaked mocks before importing audit helpers or real node modules.
 mock.restore();
@@ -84,6 +85,39 @@ describe("fleet audit helpers", () => {
       expect(entry).toMatchObject({ cmd: "doctor", args: ["xdg"], result: "ok" });
     } finally {
       process.env.MAW_STATE_DIR = mawStateDir;
+      rmSync(dynamicState, { recursive: true, force: true });
+    }
+  });
+
+  test("logAudit concurrent child processes leave zero corrupt JSONL lines", async () => {
+    const dynamicState = mkdtempSync(join(tmpdir(), "maw-audit-concurrent-state-"));
+    const worker = join(dynamicState, "audit-worker.ts");
+    writeFileSync(worker, `
+      import { logAudit } from ${JSON.stringify(join(process.cwd(), "src/core/fleet/audit.ts"))};
+      const id = process.argv[2] ?? "worker";
+      const count = Number(process.argv[3] ?? "1000");
+      for (let i = 0; i < count; i++) {
+        logAudit("stress", [id, String(i), "x".repeat(3000)], "ok");
+      }
+    `);
+
+    const workers = 24;
+    const perWorker = 1000;
+    const children = Array.from({ length: workers }, (_, index) => Bun.spawn(
+      [process.execPath, worker, `w${index}`, String(perWorker)],
+      { env: { ...process.env, MAW_STATE_DIR: dynamicState }, stdout: "pipe", stderr: "pipe" },
+    ));
+
+    try {
+      const exits = await Promise.all(children.map((child) => child.exited));
+      expect(exits).toEqual(Array(workers).fill(0));
+
+      const lines = readFileSync(join(dynamicState, "audit.jsonl"), "utf8").trim().split("\n");
+      expect(lines).toHaveLength(workers * perWorker);
+      for (const line of lines) {
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+    } finally {
       rmSync(dynamicState, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Fixes #2867

## Summary
- write audit.jsonl records through an explicit single O_APPEND write with a 4096-byte guard
- add a child-process stress regression (24 processes × 1000 records) asserting every audit line parses as JSON

## Tests
- bun test test/isolated/fleet-audit-more-coverage.test.ts
- bun run test (fails on existing unrelated default-suite failures: upload route expectations and queue-store legacy pending; focused audit test passes)