### PR TITLE
fix(windows): T-069 path delimiter, basename, winpty prefix, junction links

### DIFF
--- a/src/cli/plugin-bootstrap.ts
+++ b/src/cli/plugin-bootstrap.ts
@@ -2,6 +2,11 @@ import { mkdirSync, existsSync, readdirSync, symlinkSync, cpSync, readFileSync, 
 import { join } from "path";
 import { info, warn } from "./verbosity";
 
+function createPluginLink(src: string, dest: string) {
+  // Windows non-admin processes can create directory junctions, but not file symlinks (#T-069)
+  symlinkSync(src, dest, process.platform === "win32" ? "junction" : "dir");
+}
+
 /** Allowlist: only http/https URLs may be used as plugin sources */
 const URL_SCHEME_RE = /^https?:\/\//;
 
@@ -17,7 +22,7 @@ function linkBundledPlugins(pluginDir: string, bundled: string): number {
     const dest = join(pluginDir, d);
     if (!isPluginDir(src)) continue;
     if (existsSync(dest)) continue; // already linked / user dir / valid symlink
-    symlinkSync(src, dest);
+    createPluginLink(src, dest);
     linked++;
   }
   return linked;

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -1,7 +1,8 @@
 import { hostExec, tmux, restoreTabOrder, takeSnapshot, getPaneInfos, isAgentCommand } from "../../sdk";
 import { resolve } from "path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { join, basename, dirname } from "path";
+import { execSync } from "child_process";
 import { ghqFind } from "../../core/ghq";
 import { buildCommandInDir, cfgTimeout, loadConfig, saveConfig } from "../../config";
 import { defaultEngineNameForConfig } from "../../config/engine-registry";
@@ -328,7 +329,7 @@ export class WakeSession {
 }
 
 function repoNameFromPath(repoPath: string): string {
-  return repoPath.split("/").filter(Boolean).pop() ?? repoPath;
+  return basename(repoPath) || repoPath;
 }
 
 function stripGitSuffix(name: string): string {
@@ -369,17 +370,17 @@ function mainWindowNameForWakeSession(session: WakeSession, identity: string): s
 async function resolveWorkRepository(target: string, parsedRepoPath: string | null, opts: Pick<WakeOptions, "repoPath" | "urlRepoName">): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
   if (opts.repoPath) {
     const repoPath = opts.repoPath;
-    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: dirname(repoPath) };
   }
   if (parsedRepoPath) {
     const repoPath = parsedRepoPath;
-    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: dirname(repoPath) };
   }
 
   const repoName = repoNameFromTarget(target, opts.urlRepoName);
   const repoPath = await ghqFind(`/${repoName}`);
   if (repoPath) {
-    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: dirname(repoPath) };
   }
 
   throw new UserError(`work repo not found: ${repoName} (try: ghq get <url> OR maw wake ${target} --oracle for oracle mode)`);
@@ -389,6 +390,12 @@ function ensureWakeSessionVault(session: WakeSession, repoPath: string): void {
   if (session.mode !== "work") return;
   const psiDir = join(repoPath, "ψ");
   mkdirSync(psiDir, { recursive: true });
+
+  // If the repo already commits ψ/, do not silently add it to .gitignore (#2569)
+  try {
+    execSync("git ls-files --error-unmatch ψ/", { cwd: repoPath, stdio: "ignore" });
+    return;
+  } catch { /* ψ/ is not tracked — safe to ignore */ }
 
   const gitignorePath = join(repoPath, ".gitignore");
   const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, "utf-8") : "";
@@ -1140,10 +1147,10 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     // just cloned it). Skip resolveOracle so a stale same-named repo in a
     // different org can't shadow the freshly-created one.
     const repoPath = opts.repoPath;
-    resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: dirname(repoPath) };
   } else if (parsedRepoPath) {
     const repoPath = parsedRepoPath;
-    resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: dirname(repoPath) };
   } else if (preResolvedFleetSession) {
     resolved = await resolveWakeFleetSessionRepo(preResolvedFleetSession);
   } else if (opts.incubate) {
@@ -1160,7 +1167,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     const fullPath = await ghqFind(repoSlug);
     if (!fullPath) throw new Error(`ghq could not find ${slug} after clone`);
     const repoPath = fullPath;
-    resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: dirname(repoPath) };
     if (!opts.task && !opts.wt) opts.wt = resolved.repoName.replace(/-/g, "");
   } else {
     resolved = await resolveOracle(oracle, { allLocal: opts.allLocal, quietWorktreeScan: !!opts.dryRun });
@@ -1715,3 +1722,9 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   await recordWakeSnapshot(opts);
   return `${session}:${windowName}`;
 }
+
+/** @internal — exported for isolated unit tests */
+export const _test = {
+  repoNameFromPath,
+  ensureWakeSessionVault,
+};

--- a/src/config/command-logic.ts
+++ b/src/config/command-logic.ts
@@ -250,6 +250,16 @@ export function buildCommandFromConfig(
     cmd = cmd.replace(/\s*--dangerously-skip-permissions\b/g, "");
   }
 
+  // Windows MSYS2 pty needs winpty for interactive TUI engines (#T-069)
+  if (
+    process.platform === "win32" &&
+    process.env.MAW_NO_WINPTY !== "1" &&
+    isClaudeLikeEngine(engine?.name, config) &&
+    !cmd.trim().startsWith("winpty ")
+  ) {
+    cmd = `winpty ${cmd}`;
+  }
+
   return cmd;
 }
 

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -1,6 +1,7 @@
 import { loadConfig } from "../../config";
 import { tmuxCmd, Tmux } from "./tmux";
 import { isAgentCommandForConfig } from "../agent-detect";
+import { delimiter as pathDelimiter } from "path";
 
 export type HostExecTransport = "local" | "ssh";
 
@@ -89,17 +90,24 @@ export function createSshTransport(overrides: Partial<SshDeps> = {}): SshTranspo
 
   function pathWithCommonLocalBins(env: NodeJS.ProcessEnv): string {
     const current = env.PATH ?? process.env.PATH ?? "";
-    const parts = current.split(":").filter(Boolean);
-    return [
-      "/opt/homebrew/bin",
-      "/opt/homebrew/sbin",
-      "/usr/local/bin",
-      "/usr/bin",
-      "/bin",
-      "/usr/sbin",
-      "/sbin",
-      ...parts,
-    ].filter((dir, index, all) => all.indexOf(dir) === index).join(":");
+    const parts = current.split(pathDelimiter).filter(Boolean);
+    const common = process.platform === "win32"
+      ? [
+          "C:\\Windows\\System32",
+          "C:\\Windows",
+          "C:\\Program Files\\Git\\bin",
+          "C:\\Program Files\\Git\\usr\\bin",
+        ]
+      : [
+          "/opt/homebrew/bin",
+          "/opt/homebrew/sbin",
+          "/usr/local/bin",
+          "/usr/bin",
+          "/bin",
+          "/usr/sbin",
+          "/sbin",
+        ];
+    return [...common, ...parts].filter((dir, index, all) => all.indexOf(dir) === index).join(pathDelimiter);
   }
 
   /** Transport — run on oracle host. local → bash -c | remote → ssh */

--- a/test/isolated/ssh-windows-path-delimiter.test.ts
+++ b/test/isolated/ssh-windows-path-delimiter.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { createSshTransport } from "../../src/core/transport/ssh";
+
+describe("ssh transport windows PATH handling (T-069)", () => {
+  test("pathWithCommonLocalBins uses the platform path delimiter", async () => {
+    if (process.platform !== "win32") return;
+
+    let capturedPath: string | undefined;
+    const transport = createSshTransport({
+      env: () => ({ PATH: "C:\\Users\\Test\\bin;C:\\Windows\\System32" }),
+      spawn: ((args: string[], opts: any) => {
+        capturedPath = opts?.env?.PATH;
+        return {
+          exited: Promise.resolve(0),
+          kill: () => {},
+          stdout: new ReadableStream({ start(c) { c.close(); } }),
+          stderr: new ReadableStream({ start(c) { c.close(); } }),
+        } as any;
+      }) as any,
+    });
+
+    await transport.hostExec("echo ok");
+    expect(capturedPath).toBeDefined();
+    // PATH should preserve Windows entries and include common system dirs
+    expect(capturedPath).toContain("C:\\Users\\Test\\bin");
+    expect(capturedPath).toContain("C:\\Windows\\System32");
+    expect(capturedPath).toContain("C:\\Windows");
+  });
+});

--- a/test/isolated/wake-cmd-windows-coverage.test.ts
+++ b/test/isolated/wake-cmd-windows-coverage.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { execSync } from "child_process";
+
+import { _test } from "../../src/commands/shared/wake-cmd";
+
+const tempRepos: string[] = [];
+let gitAvailable = false;
+
+beforeAll(() => {
+  try {
+    execSync("git --version", { stdio: "ignore" });
+    gitAvailable = true;
+  } catch {}
+});
+
+function tempRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "maw-wake-cmd-win-"));
+  tempRepos.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempRepos.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("wake-cmd windows path support (T-069)", () => {
+  test("repoNameFromPath handles Unix, Windows and trailing slash", () => {
+    expect(_test.repoNameFromPath("/gh/Soul-Brews-Studio/neo-oracle")).toBe("neo-oracle");
+    expect(_test.repoNameFromPath("/gh/Soul-Brews-Studio/neo-oracle/")).toBe("neo-oracle");
+    expect(_test.repoNameFromPath("C:\\gh\\Soul-Brews-Studio\\Neo-Oracle")).toBe("Neo-Oracle");
+    expect(_test.repoNameFromPath("single")).toBe("single");
+  });
+
+  test("ensureWakeSessionVault creates ψ dir and ignores ψ/ in gitignore", () => {
+    const repo = tempRepo();
+    _test.ensureWakeSessionVault({ mode: "work" } as any, repo);
+    expect(readFileSync(join(repo, ".gitignore"), "utf-8")).toContain("ψ/");
+  });
+
+  test("ensureWakeSessionVault skips gitignore when ψ/ is already tracked", () => {
+    if (!gitAvailable) return;
+    const repo = tempRepo();
+    mkdirSync(join(repo, "ψ"), { recursive: true });
+    writeFileSync(join(repo, "ψ", "hello.md"), "hi");
+    writeFileSync(join(repo, "readme.md"), "repo");
+    execSync("git init", { cwd: repo, stdio: "ignore" });
+    execSync("git config user.email test@test.com", { cwd: repo, stdio: "ignore" });
+    execSync("git config user.name Test", { cwd: repo, stdio: "ignore" });
+    execSync("git add .", { cwd: repo, stdio: "ignore" });
+    execSync('git commit -m "init"', { cwd: repo, stdio: "ignore" });
+
+    _test.ensureWakeSessionVault({ mode: "work" } as any, repo);
+    expect(() => readFileSync(join(repo, ".gitignore"), "utf-8")).toThrow();
+  });
+
+  test("ensureWakeSessionVault is a no-op for oracle mode", () => {
+    const repo = tempRepo();
+    _test.ensureWakeSessionVault({ mode: "oracle" } as any, repo);
+    expect(() => readFileSync(join(repo, ".gitignore"), "utf-8")).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- `ssh.ts`: split PATH with `path.delimiter`; add Windows common bin dirs.
- `wake-cmd.ts`: use `path.basename`/`dirname` for repo name/parent; guard `?/` gitignore when ? already tracked.
- `command-logic.ts`: prefix `winpty` for claude-like engines on Windows.
- `plugin-bootstrap.ts`: use directory junctions on Windows to avoid EPERM for non-admin symlinks.
- Add isolated tests for Windows path handling.

All isolated tests pass.

?? Generated with [Claude Code](https://claude.com/code)