### PR TITLE
fix(windows): cross-platform path handling + winpty for claude-like engines

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -1,6 +1,7 @@
 import { hostExec, tmux, restoreTabOrder, takeSnapshot, getPaneInfos, isAgentCommand } from "../../sdk";
 import { resolve } from "path";
-import { existsSync, mkdirSync, readFileSync, writeFileSync, execFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { execFileSync } from "child_process";
 import { join } from "path";
 import { ghqFind } from "../../core/ghq";
 import { buildCommandInDir, cfgTimeout, loadConfig, saveConfig } from "../../config";

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -328,7 +328,15 @@ export class WakeSession {
 }
 
 function repoNameFromPath(repoPath: string): string {
-  return repoPath.split("/").filter(Boolean).pop() ?? repoPath;
+  // #T069 — split on either POSIX or Windows separator so `C:\Users\x\repo`
+  // yields `repo` instead of the entire path. Empty entries (from leading
+  // slashes or `C:\`) are filtered.
+  return repoPath.split(/[\\/]+/).filter(Boolean).pop() ?? repoPath;
+}
+
+/** Strip the last path segment. Cross-platform: handles both `/` and `\\`. */
+function parentDirOf(p: string): string {
+  return p.replace(/[\\/][^\\/]+$/, "");
 }
 
 function stripGitSuffix(name: string): string {
@@ -361,17 +369,17 @@ function mainWindowNameForWakeSession(session: WakeSession, identity: string): s
 async function resolveWorkRepository(target: string, parsedRepoPath: string | null, opts: Pick<WakeOptions, "repoPath" | "urlRepoName">): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
   if (opts.repoPath) {
     const repoPath = opts.repoPath;
-    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: parentDirOf(repoPath) };
   }
   if (parsedRepoPath) {
     const repoPath = parsedRepoPath;
-    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: parentDirOf(repoPath) };
   }
 
   const repoName = repoNameFromTarget(target, opts.urlRepoName);
   const repoPath = await ghqFind(`/${repoName}`);
   if (repoPath) {
-    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    return { repoPath, repoName: repoNameFromPath(repoPath), parentDir: parentDirOf(repoPath) };
   }
 
   throw new UserError(`work repo not found: ${repoName} (try: ghq get <url> OR maw wake ${target} --oracle for oracle mode)`);
@@ -1129,10 +1137,10 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     // just cloned it). Skip resolveOracle so a stale same-named repo in a
     // different org can't shadow the freshly-created one.
     const repoPath = opts.repoPath;
-    resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    resolved = { repoPath, repoName: repoNameFromPath(repoPath), parentDir: parentDirOf(repoPath) };
   } else if (parsedRepoPath) {
     const repoPath = parsedRepoPath;
-    resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    resolved = { repoPath, repoName: repoNameFromPath(repoPath), parentDir: parentDirOf(repoPath) };
   } else if (preResolvedFleetSession) {
     resolved = await resolveWakeFleetSessionRepo(preResolvedFleetSession);
   } else if (opts.incubate) {
@@ -1149,7 +1157,7 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
     const fullPath = await ghqFind(repoSlug);
     if (!fullPath) throw new Error(`ghq could not find ${slug} after clone`);
     const repoPath = fullPath;
-    resolved = { repoPath, repoName: repoPath.split("/").pop()!, parentDir: repoPath.replace(/\/[^/]+$/, "") };
+    resolved = { repoPath, repoName: repoNameFromPath(repoPath), parentDir: parentDirOf(repoPath) };
     if (!opts.task && !opts.wt) opts.wt = resolved.repoName.replace(/-/g, "");
   } else {
     resolved = await resolveOracle(oracle, { allLocal: opts.allLocal, quietWorktreeScan: !!opts.dryRun });

--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -1,6 +1,6 @@
 import { hostExec, tmux, restoreTabOrder, takeSnapshot, getPaneInfos, isAgentCommand } from "../../sdk";
 import { resolve } from "path";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, execFileSync } from "fs";
 import { join } from "path";
 import { ghqFind } from "../../core/ghq";
 import { buildCommandInDir, cfgTimeout, loadConfig, saveConfig } from "../../config";
@@ -391,6 +391,19 @@ function ensureWakeSessionVault(session: WakeSession, repoPath: string): void {
   mkdirSync(psiDir, { recursive: true });
 
   const gitignorePath = join(repoPath, ".gitignore");
+  // #T069 — respect the repo's existing commitment to ψ/. If the repo already
+  // tracks ψ/ in git (AoengAoey-style), DO NOT silently add it to .gitignore —
+  // that would clobber the repo author's design. Only append when ψ/ is
+  // untracked (the wake host is creating local-only scratch state).
+  let tracked = false;
+  try {
+    const out = execFileSync("git", ["-C", repoPath, "ls-files", "--error-unmatch", "ψ"], { stdio: ["ignore", "pipe", "ignore"] });
+    tracked = out.length > 0;
+  } catch {
+    tracked = false;
+  }
+  if (tracked) return;
+
   const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, "utf-8") : "";
   const lines = existing.split(/\r?\n/);
   if (lines.some(line => line.trim() === "ψ/" || line.trim() === "ψ")) return;

--- a/src/config/command-logic.ts
+++ b/src/config/command-logic.ts
@@ -245,6 +245,14 @@ export function buildCommandFromConfig(
     cmd = cmd.replace(/\s*--dangerously-skip-permissions\b/g, "");
   }
 
+  // #T069 — on Windows, claude-like engines need a `winpty` wrapper or they
+  // drop into print mode and exit instead of running as an interactive TUI.
+  // The prefix is a no-op on POSIX. `MAW_NO_WINPTY=1` lets users with custom
+  // PTY setups (e.g. ConEmu, Windows Terminal) opt out.
+  if (process.platform === "win32" && isClaudeLikeEngine(engine.name, config) && !process.env.MAW_NO_WINPTY) {
+    cmd = `winpty ${cmd}`;
+  }
+
   return cmd;
 }
 

--- a/src/core/transport/ssh.ts
+++ b/src/core/transport/ssh.ts
@@ -1,6 +1,7 @@
 import { loadConfig } from "../../config";
 import { tmuxCmd, Tmux } from "./tmux";
 import { isAgentCommandForConfig } from "../agent-detect";
+import { delimiter as pathDelimiter } from "path";
 
 export type HostExecTransport = "local" | "ssh";
 
@@ -89,7 +90,11 @@ export function createSshTransport(overrides: Partial<SshDeps> = {}): SshTranspo
 
   function pathWithCommonLocalBins(env: NodeJS.ProcessEnv): string {
     const current = env.PATH ?? process.env.PATH ?? "";
-    const parts = current.split(":").filter(Boolean);
+    // #T069 — split on the platform PATH delimiter (`:` on POSIX, `;` on Windows)
+    // so pm2-launched processes on Windows pick up the prefix bins instead of
+    // collapsing the whole PATH into one bucket. Joins with the same delimiter
+    // so the resulting string is parseable by both bash (POSIX) and cmd.exe.
+    const parts = current.split(pathDelimiter).filter(Boolean);
     return [
       "/opt/homebrew/bin",
       "/opt/homebrew/sbin",
@@ -99,7 +104,7 @@ export function createSshTransport(overrides: Partial<SshDeps> = {}): SshTranspo
       "/usr/sbin",
       "/sbin",
       ...parts,
-    ].filter((dir, index, all) => all.indexOf(dir) === index).join(":");
+    ].filter((dir, index, all) => all.indexOf(dir) === index).join(pathDelimiter);
   }
 
   /** Transport — run on oracle host. local → bash -c | remote → ssh */

--- a/test/ssh-transport-default.test.ts
+++ b/test/ssh-transport-default.test.ts
@@ -140,6 +140,11 @@ describe("createSshTransport", () => {
   });
 
   test("local hostExec augments PATH for pm2-launched Apple Silicon Homebrew tmux", async () => {
+    // #T069 — split on the platform PATH delimiter (':' on POSIX, ';' on Windows)
+    // so the assertion works on both. On Linux/macOS this matches the historical
+    // behavior exactly; on Windows it exercises the fix that prevents the PATH
+    // from collapsing into a single bucket.
+    const { delimiter } = await import("path");
     const h = makeHarness({
       env: { PATH: "/custom/bin" } as NodeJS.ProcessEnv,
       spawnResults: [{ stdout: "ok\n", code: 0 }],
@@ -148,7 +153,7 @@ describe("createSshTransport", () => {
     await expect(h.transport.hostExec("tmux list-sessions")).resolves.toBe("ok");
 
     const env = (h.spawnCalls[0].opts as { env?: NodeJS.ProcessEnv }).env!;
-    expect(env.PATH?.split(":").slice(0, 7)).toEqual([
+    expect(env.PATH?.split(delimiter).slice(0, 7)).toEqual([
       "/opt/homebrew/bin",
       "/opt/homebrew/sbin",
       "/usr/local/bin",
@@ -157,7 +162,7 @@ describe("createSshTransport", () => {
       "/usr/sbin",
       "/sbin",
     ]);
-    expect(env.PATH?.split(":")).toContain("/custom/bin");
+    expect(env.PATH?.split(delimiter)).toContain("/custom/bin");
   });
 
   test("config local host keeps explicit remote-looking host on the local transport", async () => {


### PR DESCRIPTION
## Summary
4 fixes for Windows support in maw-js. Tracked in T-069.

| # | File | What |
|---|------|------|
| 1 | `src/core/transport/ssh.ts` | `pathWithCommonLocalBins` now uses `path.delimiter` (`:` on POSIX, `;` on Windows) for split + join. Fixes pm2-on-Windows tmux exit 127. |
| 2 | `src/commands/shared/wake-cmd.ts` | `repoNameFromPath` and new `parentDirOf()` helper split/replace on `/[\/]+/`. 6 inline sites routed through helpers. Fixes tmux target corruption on Windows paths. |
| 3 | `src/commands/shared/wake-cmd.ts` | `ensureWakeSessionVault` checks `git ls-files --error-unmatch ψ` before appending ψ/ to .gitignore. Respects repos that intentionally track ψ/ (e.g. AoengAoey). |
| 4 | `src/config/command-logic.ts` | On `process.platform === 'win32'`, prefix claude-like engine commands with `winpty`. Opt-out via `MAW_NO_WINPTY=1`. Fixes claude.exe print-mode exit. |

## Test plan
- Existing `test/ssh-transport-default.test.ts` `hostExec augments PATH...` test still passes (POSIX path still splits on `:`).
- New test (TODO): Windows PATH with `;` delimiter preserves all entries.
- Manual: `maw team up` on Windows Bash (Git for Windows / MSYS2 / WSL) should produce interactive TUI panes instead of print-mode exits.

## Why now
- AoengAoey Oracle brain is tracked in ψ/, so fix #3 was needed before any agent could open a worktree without corrupting the repo.
- Fix #1 unblocks pm2-launched maw fleets on Windows (CFO/finance teams running maw in production).
- Fix #4 was the most user-visible bug: agents appeared to start, then vanished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)