### PR TITLE
fix(comm-send): resolveMyName falls back to cwd before tmux client-focus

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -24,6 +24,7 @@ import {
 import { checkBusyGuard, queueForDispatch } from "../../core/agent-status-guard";
 import { runPluginEventHooks } from "../../plugin/event-hooks";
 import { notifyLiveInboxReceiver } from "./live-inbox-notify";
+import { bringCwdMetadata } from "./wake-cwd";
 
 /**
  * Resolve a `session:window` target to a specific pane running an agent
@@ -77,10 +78,36 @@ export async function resolveOraclePane(
   }
 }
 
-/** Resolve the current oracle name from CLAUDE_AGENT_NAME or the attached tmux pane. */
+/** Resolve the current oracle name from CLAUDE_AGENT_NAME, the process cwd, or the attached tmux pane. */
 /** @internal */
 export function resolveMyName(config: ReturnType<typeof loadConfig>): string {
   if (process.env.CLAUDE_AGENT_NAME) return process.env.CLAUDE_AGENT_NAME;
+
+  // pulse #159 (2026-07-23): tmux `display-message` reports whichever session the
+  // human's tmux CLIENT currently has focused — not necessarily the pane this
+  // process is actually running in. That mismatch produced real mis-signed sender
+  // envelopes (both from the cc-boss-on-stop hook and from manual interactive/
+  // background-job calls with no CLAUDE_AGENT_NAME set). cwd is a property of
+  // THIS process, not of whatever the human happens to be looking at, so it goes
+  // first: any process running inside a `<name>-oracle` directory gets the right
+  // answer regardless of tmux focus state or whether tmux is even attached
+  // (headless/background-job sessions included).
+  //
+  // Deliberately `bringCwdMetadata(...).oracle`, NOT `deriveOracleFromCwd` — the
+  // latter has a permissive fallback built for `maw wake`'s zero-arg convenience
+  // (treats ANY directory's last path segment as a plausible bare oracle name,
+  // e.g. running from the maw-js repo itself would resolve to "maw-js"). That's
+  // correct for a human typing a bare `maw wake` in some directory, but wrong
+  // here: this fallback must stay silent (return undefined, fall through to
+  // tmux/config.node) unless cwd is a CONFIRMED match against the real
+  // oracle-repo convention, not just "some directory that isn't a tmux session."
+  // (Caught this by running the existing resolveMyName test suite against the
+  // permissive version before opening a PR — see comm-send-xhigh-coverage.test.ts
+  // and comm-list.test.ts, which assert config.node/"cli" fallback behavior that
+  // the permissive fallback silently broke.)
+  const cwdOracle = bringCwdMetadata(process.cwd()).oracle;
+  if (cwdOracle) return cwdOracle;
+
   // Only trust tmux when this process is actually running inside a tmux pane.
   // Outside tmux, `tmux display-message` can still succeed by reporting the
   // server's current/last-active session, which misattributes sender envelopes.

--- a/test/isolated/comm-send-xhigh-coverage.test.ts
+++ b/test/isolated/comm-send-xhigh-coverage.test.ts
@@ -23,8 +23,11 @@ function insideTmux() {
   process.env.TMUX = "/tmp/tmux-test,1,0";
 }
 
+const originalCwd = process.cwd;
+
 afterEach(() => {
   childProcess.execSync = originalExecSync;
+  process.cwd = originalCwd;
   if (originalAgentName === undefined) delete process.env.CLAUDE_AGENT_NAME;
   else process.env.CLAUDE_AGENT_NAME = originalAgentName;
   if (originalTmux === undefined) delete process.env.TMUX;
@@ -72,5 +75,40 @@ describe("resolveMyName tmux fallback coverage", () => {
     childProcess.execSync = (() => { throw new Error("tmux unavailable"); }) as typeof childProcess.execSync;
 
     expect(resolveMyName({} as any)).toBe("cli");
+  });
+});
+
+describe("resolveMyName cwd fallback (pulse #159 — tmux client-focus mis-signature fix)", () => {
+  test("a confirmed <name>-oracle cwd wins even when tmux would report a different session", () => {
+    withoutAgentName();
+    insideTmux();
+    process.cwd = () => "/Users/phathara/ghq/github.com/phatharaxa-svg/spark-oracle";
+    const calls: ExecSyncCall[] = [];
+    childProcess.execSync = ((command: string, options: unknown) => {
+      calls.push({ command, options });
+      return "20-praew\n"; // tmux client focused on a DIFFERENT oracle's session — must not win
+    }) as typeof childProcess.execSync;
+
+    expect(resolveMyName({ node: "ignored" } as any)).toBe("spark");
+    expect(calls).toEqual([]); // cwd match must short-circuit before tmux is ever queried
+  });
+
+  test("a headless/background-job session (no TMUX env at all) still resolves correctly from cwd", () => {
+    withoutAgentName();
+    delete process.env.TMUX;
+    process.cwd = () => "/Users/phathara/ghq/github.com/phatharaxa-svg/intel-nat-oracle";
+
+    expect(resolveMyName({ node: "ignored" } as any)).toBe("intel-nat");
+  });
+
+  test("cwd NOT inside any *-oracle repo falls through to tmux, not a false match", () => {
+    withoutAgentName();
+    insideTmux();
+    process.cwd = () => "/Users/phathara/ghq/github.com/Soul-Brews-Studio/maw-js";
+    childProcess.execSync = (() => "08-mawjs\n") as typeof childProcess.execSync;
+
+    // must NOT resolve to "maw-js" (the permissive deriveOracleFromCwd fallback would
+    // wrongly do this — regression test for that exact bug, caught before merge)
+    expect(resolveMyName({ node: "config-node" } as any)).toBe("mawjs");
   });
 });


### PR DESCRIPTION
## Summary
- `resolveMyName()` fell back to `tmux display-message -p '#{session_name}'` when `CLAUDE_AGENT_NAME` was unset — that reports whichever session the human's tmux **client** currently has focused, not necessarily the pane this process is actually running in. This mis-signed real sender envelopes in production today (fleet incident, ref pulse #170 on `phatharaxa-svg/pulse-oracle`), and left non-tmux/background-job sessions with no fallback at all.
- Fix: check `process.cwd()` for a confirmed match against the `<name>-oracle` repo convention (reusing `bringCwdMetadata`, already production-tested via `maw wake`'s zero-arg resolution) **before** falling through to the tmux-focus guess.
- Deliberately uses `bringCwdMetadata(...).oracle`, not the more permissive `deriveOracleFromCwd` — the latter's "last path segment" fallback (built for `maw wake`'s zero-arg convenience) would wrongly treat *any* directory as a plausible oracle name, including this repo itself (`maw-js`), silently overriding legitimate tmux/`config.node` fallback behavior. Caught this via the existing test suite before finalizing — see "Test plan."
- Additive-only: only engages when `CLAUDE_AGENT_NAME` is already unset (cases that were already broken). Fleet-wide blast radius (`resolveMyName` feeds `resolveSenderIdentity`/`aclSenderOracle`, i.e. every `maw send`/`hey` without an explicit `--from`), but low risk given the above.

## Test plan
- [x] Ran every test file referencing `resolveMyName`/`comm-send`/`wake-cwd` before and after the fix:
  - Baseline (unmodified): 118 pass / 14 fail (pre-existing, unrelated failures — `logMessage`/`emitFeed` tempdir + fetch-intercept tests, confirmed identical on both runs)
  - With the *first* attempt (`deriveOracleFromCwd`, the permissive helper): 110 pass / 22 fail — **caught a real regression** (8 tests broke because cwd=`maw-js` resolved to oracle name `"maw-js"`)
  - With the *fixed* version (`bringCwdMetadata(...).oracle`): 118 pass / 14 fail — matches baseline exactly, zero regressions
- [x] Added 3 new tests in `comm-send-xhigh-coverage.test.ts` covering the new behavior directly: a confirmed `<name>-oracle` cwd wins over a conflicting tmux focus (and short-circuits before ever querying tmux), a headless/no-`TMUX`-env session resolves correctly from cwd alone, and a cwd that does *not* match any oracle repo correctly falls through to tmux/`config.node` (regression test for the exact bug caught above). All 3 pass: 121 pass / 14 fail.
- [ ] Broader `bun test test/isolated/` full sweep — kicked off as extra diligence, still running as of this PR (large suite); will follow up with results in a comment.

## Rollout note (for whoever merges)
Editing this dev-repo source does **not** propagate to the installed `maw` CLI most oracles actually run (`~/.bun/install/global/node_modules/maw-js` is a separate, already-diverged copy) — after merge, run `maw update` fleet-wide or this fix will be silently inert for everyone except direct `bun src/cli.ts` callers.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_01CstRH91yJxkSheGRuDAYfN

