### PR TITLE
fix(test): de-timebomb queue-store legacy TTL test (green alpha CI)

### DIFF
--- a/test/queue-store-default.test.ts
+++ b/test/queue-store-default.test.ts
@@ -71,7 +71,10 @@ describe("queue-store default coverage", () => {
       sender: "old",
       target: "new",
       message: "still pending",
-      sentAt: "2026-05-20T00:00:00.000Z",
+      // Relative to now so the record stays within TTL — a hardcoded past
+      // date silently expires once wall-clock passes sentAt + TTL_MS, which
+      // turned this into a time-bomb that started failing CI after 30 days.
+      sentAt: new Date(Date.now() - 60_000).toISOString(),
       status: "pending",
     }));
 


### PR DESCRIPTION
## Problem
maw-js **alpha** CI has been red since ~June 19 (observed failing in the 2026-07-09 push run, job `test-unit-1of4`) — this is the red badge / "1 failing" check.

Single failing test: `queue-store default coverage > loads legacy config pending files while new writes use state`.

## Root cause — time-bomb test
The legacy pending record hardcoded `sentAt: "2026-05-20T00:00:00.000Z"`. `TTL_MS` is 30 days, so once wall-clock passed **2026-06-19** the record reads back as expired: `loadPendingById()` finds the file, `isExpired()` returns true, it unlinks the file and returns `null` → `?.message` is `undefined` → assertion fails. No code change caused it — just the passage of time.

## Fix
Make the legacy record's `sentAt` relative (`Date.now() - 60_000`) so it always sits inside TTL. **Test-only**, no production code touched.

## Verify
`bun test test/queue-store-default.test.ts` → 10 pass, 0 fail (was 1 fail).