### PR TITLE
fix: resolve maw sender identity outside tmux

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -4,7 +4,7 @@
 
 import {
   listSessions, capture, sendKeys, isAgentCommand, findPeerForTarget, resolveTarget,
-  curlFetch, runHook,
+  curlFetch, runHook, requireOracleIdentity,
 } from "../../sdk";
 import { Tmux } from "../../core/transport/tmux";
 import { AmbiguousMatchError } from "../../core/runtime/find-window";
@@ -69,16 +69,14 @@ export async function resolveOraclePane(
   }
 }
 
-/** Resolve the current oracle name from CLAUDE_AGENT_NAME or tmux session */
+/** Resolve the current oracle name from explicit env, cwd, or tmux session. */
 /** @internal */
 export function resolveMyName(config: ReturnType<typeof loadConfig>): string {
-  if (process.env.CLAUDE_AGENT_NAME) return process.env.CLAUDE_AGENT_NAME;
-  // Try tmux session name: "08-mawjs" → "mawjs"
   try {
-    const tmuxSession = require("child_process").execSync("tmux display-message -p '#{session_name}'", { encoding: "utf-8" }).trim();
-    if (tmuxSession) return tmuxSession.replace(/^\d+-/, "");
-  } catch {}
-  return config.node || "cli";
+    return requireOracleIdentity().name;
+  } catch (error: any) {
+    throw new Error(`${error.message}; config.node=${config.node || "unset"} is node identity, not a safe sender fallback`);
+  }
 }
 
 /**

--- a/src/core/identity.ts
+++ b/src/core/identity.ts
@@ -1,0 +1,82 @@
+import { execSync } from "child_process";
+import { basename } from "path";
+
+export interface IdentityResult {
+  name: string;
+  source: "env" | "cwd" | "tmux";
+}
+
+const ENV_KEYS = [
+  "MAW_IDENTITY",
+  "MAW_FROM",
+  "MAW_AGENT_NAME",
+  "ORACLE_NAME",
+  "CLAUDE_AGENT_NAME",
+  "AGENT_NAME",
+] as const;
+
+export function normalizeOracleName(value: string): string {
+  return value
+    .trim()
+    .replace(/^\[[^\]:]+:/, "")
+    .replace(/\]$/, "")
+    .replace(/^.*:/, "")
+    .replace(/^\d+-/, "")
+    .replace(/-oracle$/, "")
+    .replace(/[^a-zA-Z0-9_-]/g, "")
+    .toLowerCase();
+}
+
+function envIdentity(): IdentityResult | null {
+  for (const key of ENV_KEYS) {
+    const value = process.env[key];
+    if (!value) continue;
+    const name = normalizeOracleName(value);
+    if (name) return { name, source: "env" };
+  }
+  return null;
+}
+
+function cwdIdentity(): IdentityResult | null {
+  const cwd = process.cwd();
+  const oraclePath = cwd.match(/\/oracles\/([^/]+)/);
+  if (oraclePath?.[1]) {
+    const name = normalizeOracleName(oraclePath[1]);
+    if (name) return { name, source: "cwd" };
+  }
+
+  const repoName = basename(cwd);
+  if (repoName.endsWith("-oracle")) {
+    const name = normalizeOracleName(repoName);
+    if (name) return { name, source: "cwd" };
+  }
+
+  return null;
+}
+
+function tmuxIdentity(): IdentityResult | null {
+  if (!process.env.TMUX) return null;
+  try {
+    const session = execSync("tmux display-message -p '#{session_name}'", {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const name = normalizeOracleName(session);
+    if (name) return { name, source: "tmux" };
+  } catch {
+    // Outside tmux, callers must provide env or run from an oracle repo.
+  }
+  return null;
+}
+
+export function resolveOracleIdentity(): IdentityResult | null {
+  return envIdentity() ?? cwdIdentity() ?? tmuxIdentity();
+}
+
+export function requireOracleIdentity(): IdentityResult {
+  const identity = resolveOracleIdentity();
+  if (identity) return identity;
+  throw new Error(
+    "maw cannot determine sender identity — set MAW_FROM, MAW_IDENTITY, MAW_AGENT_NAME, ORACLE_NAME, or CLAUDE_AGENT_NAME, or run from an oracle repo/tmux session",
+  );
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -63,6 +63,8 @@ export type { Session, Window } from "../core/runtime/find-window";
 
 export { runHook } from "../core/runtime/hooks";
 export { getTriggers, getTriggerHistory } from "../core/runtime/triggers";
+export { resolveOracleIdentity, requireOracleIdentity, normalizeOracleName } from "../core/identity";
+export type { IdentityResult } from "../core/identity";
 
 // ─── Fleet ───────────────────────────────────────────────────────────────────
 

--- a/src/vendor/mpr-plugins/whoami/impl.ts
+++ b/src/vendor/mpr-plugins/whoami/impl.ts
@@ -1,15 +1,13 @@
-import { hostExec } from "maw-js/sdk";
+import { requireOracleIdentity } from "maw-js/sdk";
 import { UserError } from "maw-js/core/util/user-error";
 
 /**
- * maw whoami — print the current tmux session name on stdout.
- * Replaces scattered raw `tmux display-message -p '#S'` calls with one
- * canonical, testable command.
+ * maw whoami — print the current oracle identity on stdout.
  */
 export async function cmdWhoami() {
-  if (!process.env.TMUX) {
-    throw new UserError("maw whoami requires an active tmux session — run 'maw wake <oracle>' or attach to tmux first");
+  try {
+    console.log(requireOracleIdentity().name);
+  } catch (error: any) {
+    throw new UserError(error.message);
   }
-  const raw = await hostExec(`tmux display-message -p '#S'`);
-  console.log(raw.trim());
 }

--- a/src/vendor/mpr-plugins/whoami/index.ts
+++ b/src/vendor/mpr-plugins/whoami/index.ts
@@ -1,7 +1,7 @@
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdWhoami } from "./impl";
 
-export const command = { name: "whoami", description: "Print the current tmux session name." };
+export const command = { name: "whoami", description: "Print the current oracle identity." };
 
 export default async function handler(_ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];

--- a/src/vendor/mpr-plugins/whoami/plugin.json
+++ b/src/vendor/mpr-plugins/whoami/plugin.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Print the current tmux session name (closes raw `tmux display-message -p '#S'` sweep).",
+  "description": "Print the current oracle identity.",
   "cli": {
     "command": "whoami",
-    "help": "maw whoami — print the current tmux session name"
+    "help": "maw whoami — print the current oracle identity"
   },
   "weight": 10,
   "license": "MIT",

--- a/test/identity.test.ts
+++ b/test/identity.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { requireOracleIdentity, resolveOracleIdentity } from "../src/core/identity";
+
+const ENV_KEYS = [
+  "MAW_IDENTITY",
+  "MAW_FROM",
+  "MAW_AGENT_NAME",
+  "ORACLE_NAME",
+  "CLAUDE_AGENT_NAME",
+  "AGENT_NAME",
+  "TMUX",
+] as const;
+
+let originalCwd = "";
+let tempRoot = "";
+let originalEnv: Record<string, string | undefined> = {};
+
+describe("oracle identity resolution", () => {
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    originalEnv = {};
+    for (const key of ENV_KEYS) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    tempRoot = mkdtempSync(join(tmpdir(), "maw-identity-"));
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  test("uses explicit sender env outside tmux", () => {
+    process.env.MAW_FROM = "mac-mini:hermes";
+    expect(requireOracleIdentity()).toEqual({ name: "hermes", source: "env" });
+  });
+
+  test("derives background-job identity from oracle repo cwd without tmux", () => {
+    const oracleDir = join(tempRoot, "oracles", "hermes");
+    mkdirSync(oracleDir, { recursive: true });
+    process.chdir(oracleDir);
+    expect(requireOracleIdentity()).toEqual({ name: "hermes", source: "cwd" });
+  });
+
+  test("does not query tmux when TMUX is absent", () => {
+    process.chdir(tempRoot);
+    expect(resolveOracleIdentity()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes maw sender attribution for background jobs that run outside an attached tmux client.

Root cause:
- `maw whoami` hard-required an active tmux session.
- `maw hey` sender attribution could fall back to unsafe identity sources.
- Outside literal `$TMUX`, `tmux display-message` can report an unrelated attached client, producing rotating/wrong sender tags.

Change:
- Add shared `src/core/identity.ts` resolver.
- Identity precedence is explicit env (`MAW_IDENTITY`, `MAW_FROM`, `MAW_AGENT_NAME`, `ORACLE_NAME`, `CLAUDE_AGENT_NAME`, `AGENT_NAME`) → oracle repo cwd → tmux only when literal `$TMUX` exists → fail closed.
- `config.node` is no longer used as sender identity fallback.
- `maw whoami` and `comm-send` both use the shared resolver.
- Add regression coverage for env, cwd, and no-identity/fail-closed behavior.

## Proof

Old repro before fix:

```bash
env -u TMUX -u CLAUDE_AGENT_NAME maw whoami
# maw whoami requires an active tmux session — exit 1
```

After fix:

```bash
env -u TMUX -u CLAUDE_AGENT_NAME maw whoami
# from /Users/nh/repos/nh/oracles/hermes => hermes, exit 0

MAW_FROM=mac-mini:hermes env -u TMUX -u CLAUDE_AGENT_NAME maw whoami
# from /tmp => hermes, exit 0

env -u TMUX -u CLAUDE_AGENT_NAME -u MAW_FROM -u MAW_IDENTITY -u MAW_AGENT_NAME -u ORACLE_NAME -u AGENT_NAME maw whoami
# from /tmp => fails closed, exit 1
```

Verification from clean PR worktree:

```bash
bun test test/identity.test.ts test/comm-send-signing.test.ts test/comm-send-deprecation-759.test.ts
# 15 pass, 0 fail

bun run build
# passed
```
