### PR TITLE
fix(engine): match agent pattern engines before requiring a default engine

### DIFF
--- a/src/config/command-logic.ts
+++ b/src/config/command-logic.ts
@@ -131,7 +131,7 @@ function commandKeyForAgent(
     throw new UserError(`engine '${opts.engine}' not resolvable — known: [${knownList}]; define it in config.engines/config.commands or check charter`);
   }
 
-  let key = defaultEngineNameForConfig(config);
+  let key = "";
 
   for (const pattern of keys) {
     if (pattern === "default") continue;
@@ -140,6 +140,8 @@ function commandKeyForAgent(
       break;
     }
   }
+
+  if (!key) key = defaultEngineNameForConfig(config);
 
   return key;
 }


### PR DESCRIPTION
## Problem

`commandKeyForAgent` in `src/config/command-logic.ts` called `defaultEngineNameForConfig(config)` **eagerly**, before the engine-pattern loop ran. On hosts with no `engines.default` / `commands.default` / `config.defaultEngine`, that throws `no default engine configured` — even when a pattern/glob engine key (e.g. `gac-geekmagic*`) would have matched the agent name.

Observed: `maw wake gac-geekmagic` failed with `no default engine configured` despite `engines."gac-geekmagic*"` being registered, because the throw happened before pattern matching.

## Fix

Match agent-name pattern engines first; only consult `defaultEngineNameForConfig` when no pattern matched:

```ts
let key = "";
for (const pattern of keys) {
  if (pattern === "default") continue;
  if (matchesAgentPattern(pattern, agentName)) { key = pattern; break; }
}
if (!key) key = defaultEngineNameForConfig(config);
```

## Verification

- `maw wake gac-geekmagic` (no flags) now resolves to `hermes --profile gac-geekmagic` via the `gac-geekmagic*` pattern
- `--engine hermes` still resolves to `hermes`
- Full default test suite: 2795 pass / 0 fail across 29 files
- `bun run build`: exit 0 (713 modules bundled)