### PR TITLE
fix(config): whitelist autoRestart in validator (was silently stripped)

### DIFF
--- a/src/config/validate-ext.ts
+++ b/src/config/validate-ext.ts
@@ -61,6 +61,21 @@ function validateExtFields(
     }
   }
 
+  // autoRestart: boolean. Consumed by engine-crash.ts to respawn crashed
+  // agents. Field was declared in types.ts + wired to engine but never
+  // whitelisted here, so validateConfig() silently stripped it and
+  // /api/config returned undefined even when the user set it. Symptom:
+  // operators enabling autoRestart in maw.config.json saw no effect and
+  // no warning — a UX bug where documented behavior was unreachable via
+  // config. Reproduced symmetrically on both vm200 and oracle-world.
+  if ("autoRestart" in raw) {
+    if (typeof raw.autoRestart === "boolean") {
+      result.autoRestart = raw.autoRestart;
+    } else {
+      warn("autoRestart", "must be a boolean");
+    }
+  }
+
   // pin: string if present
   if ("pin" in raw) {
     if (typeof raw.pin === "string") {

--- a/test/config-validate-ext.test.ts
+++ b/test/config-validate-ext.test.ts
@@ -22,6 +22,7 @@ describe("validateConfig extended fields", () => {
       federationToken: "0123456789abcdef",
       allowPeersWithoutToken: true,
       trustLoopback: false,
+      autoRestart: true,
       pin: "1234",
       zenoh: {
         locator: "ws/127.0.0.1:7447",
@@ -57,6 +58,7 @@ describe("validateConfig extended fields", () => {
       federationToken: "0123456789abcdef",
       allowPeersWithoutToken: true,
       trustLoopback: false,
+      autoRestart: true,
       pin: "1234",
       zenoh: {
         locator: "ws/127.0.0.1:7447",
@@ -93,6 +95,7 @@ describe("validateConfig extended fields", () => {
       federationToken: "too-short",
       allowPeersWithoutToken: "true",
       trustLoopback: "false",
+      autoRestart: "true",
       pin: 123,
       zenoh: {
         locator: 123,
@@ -135,6 +138,7 @@ describe("validateConfig extended fields", () => {
       "[maw] config warning: federationToken must be at least 16 characters, using default",
       "[maw] config warning: allowPeersWithoutToken must be a boolean, using default",
       "[maw] config warning: trustLoopback must be a boolean, using default",
+      "[maw] config warning: autoRestart must be a boolean, using default",
       "[maw] config warning: pin must be a string, using default",
       "[maw] config warning: scout must be a boolean, using default",
       "[maw] config warning: discovery.transport must be one of: scout, zenoh, both, off, using default",


### PR DESCRIPTION
## Problem

The `autoRestart` field is declared in `src/config/types.ts:153` and consumed by `src/engine/engine-crash.ts` (line 17: `if (!config.autoRestart) return;`), but `validateConfig()` in `src/config/validate-ext.ts` uses an explicit field whitelist that never included `autoRestart`. Result: users who set `"autoRestart": true` in `maw.config.json` see:

- No effect at runtime (crashed agents are not respawned)
- No warning in logs (the field is silently stripped)
- `/api/config` returns `undefined` for the field, so operators cannot introspect the actual runtime posture

## Reproduction

Discovered symmetrically on two federated nodes during interop testing:

- `vm200` (100.110.208.27) — Ubuntu, maw v26.6.14-alpha.2110
- `oracle-world` (100.119.170.36) — separate operator, same maw version

Both nodes set `autoRestart: true` in their bare `maw.config.json`. Both nodes' `/api/config` responses omitted the field. Both nodes' `engine-crash.ts` short-circuit returned because `config.autoRestart` evaluated falsy. Root cause traced to `validate-ext.ts:279-286` (the `validateConfig` whitelist wrapper).

## Fix

Add the same boolean-validation clause used for `trustLoopback` right after it in `validateExtFields()`. The pattern is:

```ts
if ("autoRestart" in raw) {
  if (typeof raw.autoRestart === "boolean") {
    result.autoRestart = raw.autoRestart;
  } else {
    warn("autoRestart", "must be a boolean");
  }
}
```

Also extends the accept-case and reject-case blocks of `test/config-validate-ext.test.ts` with one entry each, so future regressions are caught.

## Impact

- No behavior change for configs that don't set `autoRestart`.
- Configs that do set `autoRestart: true` will now respawn crashed agents as documented.
- Configs that set `autoRestart` to a non-boolean now emit a warning instead of silently accepting the misuse.

## Tests

```
$ bun test test/config-validate-ext.test.ts
 4 pass
 0 fail
 14 expect() calls

$ bun test test/config-validate.test.ts test/config-command-tombstone.test.ts
 16 pass
 0 fail
 50 expect() calls
```

## Related

Symmetric findings during federation interop are being tracked in an internal G2 report; other symmetric bugs discovered in the same session (`/api/agents` empty live-bodies, message truncation at 2000 chars) will be filed as separate issues/PRs.