### PR TITLE
fix(tmux): paneInputPending scans the input line above the footer — Enter-eaten TUI stall

### DIFF
--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -523,15 +523,28 @@ export class Tmux {
    */
   private async submitWithConfirm(target: string, sentText: string): Promise<void> {
     for (let attempt = 1; attempt <= MAX_SUBMIT_ATTEMPTS; attempt++) {
-      await this.sendKeys(target, "Enter");
+      if (attempt === MAX_SUBMIT_ATTEMPTS) {
+        // Last-ditch escalation: the named `Enter` key can be swallowed by a
+        // TUI that rebinds Return (the Enter-eaten silent stall). `C-m` is the
+        // raw carriage return and lands even then. Log every escalation — an
+        // eaten Enter is exactly the failure this path guards against, so the
+        // audit trail (stderr, append-only in the pane log) must record it.
+        console.warn(
+          `[tmux] submitWithConfirm: ${target} escalating to literal C-m on final attempt ${attempt}/${MAX_SUBMIT_ATTEMPTS}`,
+        );
+        await this.sendKeys(target, "C-m");
+      } else {
+        await this.sendKeys(target, "Enter");
+      }
       await new Promise(r => setTimeout(r, SUBMIT_CONFIRM_MS));
       if (!(await this.paneInputPending(target, sentText))) return; // submitted — done
     }
-    // Exhausted every retry and the input line still looks non-empty. The
-    // caller has no visibility into tmux pane state, so warn loudly — a
-    // silently-dropped dispatch is the exact failure mode #6 is about.
+    // Exhausted every retry (including the C-m escalation) and the input line
+    // still looks non-empty. The caller has no visibility into tmux pane state,
+    // so warn loudly — a silently-dropped dispatch is the exact failure mode
+    // #6 is about.
     console.warn(
-      `[tmux] sendText: ${target} still shows pending input after ${MAX_SUBMIT_ATTEMPTS} Enter attempts — command may not have submitted`,
+      `[tmux] sendText: ${target} still shows pending input after ${MAX_SUBMIT_ATTEMPTS} submit attempts — command may not have submitted`,
     );
   }
 
@@ -545,16 +558,56 @@ export class Tmux {
    */
   private async paneInputPending(target: string, sentText: string): Promise<boolean> {
     try {
-      const content = await this.capture(target, 5);
-      const lines = content.split("\n").filter(l => l.trim());
-      const last = (lines.at(-1) ?? "").replace(ANSI_RE, "").replace(/\r/g, "");
-      const sentNeedles = pendingInputNeedles(sentText);
-      if (sentNeedles.some(needle => last.includes(needle))) return true;
+      // 8 lines (was 5): in a full-screen TUI (Claude Code / Codex) the input
+      // line is NOT the bottom captured line — a status/footer line ("⏵⏵ …",
+      // "🐾 … ctx", "Context N% left") sits BELOW it and pushes the real input
+      // up. Reading only lines.at(-1) then reads the footer, never the input:
+      // pending input is never seen, submit is green-lit after one Enter, and an
+      // eaten Enter is never retried (the Enter-eaten silent stall Husky hit).
+      const content = await this.capture(target, 8);
+      const lines = content
+        .split("\n")
+        .map(l => l.replace(ANSI_RE, "").replace(/\r/g, ""))
+        .filter(l => l.trim());
+      if (lines.length === 0) return false;
 
-      // Fallback: prompt marker followed by non-whitespace → user/command text
-      // still sitting on the input line. Includes Codex `›` for immediate #2380
-      // relief while sent-text detection handles unknown future engines.
-      return /[#$%>❯»›]\s+\S/.test(last);
+      // Locate the live input line. A TUI carries a prompt marker (❯ Claude
+      // Code / › Codex) at line-start and sits above the footer, so scan for the
+      // LAST marker line. Plain shells keep the prompt on the bottom line with
+      // the marker mid-line ("user@host:~$ cmd"), so fall back to lines.at(-1).
+      let markerIdx = -1;
+      for (let i = 0; i < lines.length; i++) {
+        if (/^\s*[❯›]\s/.test(lines[i])) markerIdx = i;
+      }
+      const inputLine = markerIdx >= 0 ? lines[markerIdx] : (lines.at(-1) ?? "");
+
+      // `❯`/`›` is ALSO a menu selection cursor (permission dialog, /model,
+      // ExitPlanMode, codex confirm). "❯ 1. Yes" must NOT read as pending input:
+      // retrying Enter into it would auto-select the option (auto-approve,
+      // potentially destructive). A numbered/lettered option under the cursor →
+      // NOT pending, so the retry loop stops. Biasing to a missed (loudly
+      // warned) resend is far safer than auto-confirming a dialog. (Collie T4
+      // CRITICAL-1.)
+      const tuiMatch = inputLine.match(/^\s*[❯›]\s+(\S.*)$/);
+      if (tuiMatch) {
+        const rest = tuiMatch[1].trim();
+        if (/^[0-9A-Za-z][.)]\s/.test(rest)) return false;
+        // Empty-state placeholders (codex "Use /skills…", CC hints) are ghost
+        // text, not real input. CC-centric maintained surface — on CC an empty
+        // submit is a harmless no-op, so an unknown placeholder erring to
+        // "pending" costs only a stray Enter, never a wrong action.
+        if (/^(Use \/skills|Try "|Ask |Type |Send a message)/.test(rest)) return false;
+      }
+
+      // Sent text still visible ON THE INPUT LINE → not yet submitted. Scoped to
+      // the input line (not every captured line) so a submitted message echoed
+      // into the conversation area above can't false-trigger an endless retry.
+      const sentNeedles = pendingInputNeedles(sentText);
+      if (sentNeedles.some(needle => inputLine.includes(needle))) return true;
+
+      // Fallback: prompt marker + non-whitespace still on the input line.
+      // Includes Codex `›` for #2380 while sent-text handles unknown engines.
+      return /[#$%>❯»›]\s+\S/.test(inputLine);
     } catch {
       return false;
     }

--- a/test/isolated/tmux-class-coverage.test.ts
+++ b/test/isolated/tmux-class-coverage.test.ts
@@ -153,9 +153,9 @@ describe("tmux-class isolated coverage", () => {
       "exitModeIfNeeded:sess:oracle.0",
       "sendKeysLiteral:deploy now",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
   });
 
@@ -171,7 +171,7 @@ describe("tmux-class isolated coverage", () => {
       `loadBuffer:${longText.length}`,
       "pasteBuffer",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
   });
 
@@ -388,10 +388,17 @@ describe("tmux-class isolated coverage", () => {
       console.warn = realWarn;
     }
 
-    expect(t.calls.filter(call => call === "sendKeys:Enter")).toHaveLength(4);
-    expect(warn).toHaveBeenCalledTimes(1);
+    // Final attempt escalates the named Enter to a literal C-m (Enter-eaten
+    // last-ditch): 3 Enter + 1 C-m. Two warns now — the C-m escalation and the
+    // exhausted-retries warning.
+    expect(t.calls.filter(call => call === "sendKeys:Enter")).toHaveLength(3);
+    expect(t.calls.filter(call => call === "sendKeys:C-m")).toHaveLength(1);
+    expect(warn).toHaveBeenCalledTimes(2);
     expect(warn).toHaveBeenCalledWith(
-      "[tmux] sendText: sess:oracle.0 still shows pending input after 4 Enter attempts — command may not have submitted",
+      "[tmux] submitWithConfirm: sess:oracle.0 escalating to literal C-m on final attempt 4/4",
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "[tmux] sendText: sess:oracle.0 still shows pending input after 4 submit attempts — command may not have submitted",
     );
   });
 });

--- a/test/isolated/tmux-class-fifth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-fifth-pass-coverage.test.ts
@@ -157,7 +157,7 @@ describe("tmux-class fifth-pass isolated coverage", () => {
       "exitModeIfNeeded:alpha:0.0",
       "sendKeysLiteral:hello",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
   });
 });

--- a/test/isolated/tmux-class-fourteenth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-fourteenth-pass-coverage.test.ts
@@ -185,9 +185,9 @@ describe("tmux-class fourteenth-pass isolated coverage", () => {
       "exitModeIfNeeded:alpha:0.0",
       "sendKeysLiteral:still-pending",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
   });
 });

--- a/test/isolated/tmux-class-fourth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-fourth-pass-coverage.test.ts
@@ -248,7 +248,7 @@ describe("tmux-class fourth-pass isolated coverage", () => {
       "exitModeIfNeeded:alpha:0.0",
       "sendKeysLiteral:500",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
   });
 
@@ -262,9 +262,9 @@ describe("tmux-class fourth-pass isolated coverage", () => {
       "exitModeIfNeeded:alpha:0.0",
       "sendKeysLiteral:10",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
   });
 });

--- a/test/isolated/tmux-class-seventh-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-seventh-pass-coverage.test.ts
@@ -188,11 +188,11 @@ describe("tmux-class seventh-pass isolated coverage", () => {
       "loadBuffer:run\\nfollowup",
       "pasteBuffer",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
   });
 });

--- a/test/isolated/tmux-class-sixth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-sixth-pass-coverage.test.ts
@@ -220,9 +220,9 @@ describe("tmux-class sixth-pass isolated coverage", () => {
       "exitModeIfNeeded:alpha:0.0",
       "sendKeysLiteral:make test",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
 
     const noWhitespace = new SubmitProbeTmux();
@@ -234,7 +234,7 @@ describe("tmux-class sixth-pass isolated coverage", () => {
       "exitModeIfNeeded:alpha:0.0",
       "sendKeysLiteral:make test",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
   });
 

--- a/test/isolated/tmux-class-tenth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-tenth-pass-coverage.test.ts
@@ -213,7 +213,7 @@ describe("tmux-class tenth-pass isolated coverage", () => {
       "exitModeIfNeeded:alpha:0.0",
       "sendKeysLiteral:already submitted",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
   });
 });

--- a/test/isolated/tmux-class-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/tmux-class-thirteenth-pass-coverage.test.ts
@@ -168,15 +168,16 @@ describe("tmux-class thirteenth-pass isolated coverage", () => {
       "loadBuffer:501",
       "pasteBuffer",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
       "sendKeys:Enter",
-      "capture:5",
-      "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
+      "sendKeys:C-m", // final attempt escalates to a literal C-m (Enter-eaten last-ditch)
+      "capture:8",
     ]);
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    // two warns now: the C-m escalation + the exhausted-retries warning.
+    expect(console.warn).toHaveBeenCalledTimes(2);
 
     const captureFails = new SubmitProbeTmux();
     captureFails.captureScript = [new Error("capture unavailable")];
@@ -187,7 +188,7 @@ describe("tmux-class thirteenth-pass isolated coverage", () => {
       "exitModeIfNeeded:alpha:0.0",
       "sendKeysLiteral:13:short comman",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
   });
 });

--- a/test/tmux-class-command-builders.test.ts
+++ b/test/tmux-class-command-builders.test.ts
@@ -265,9 +265,9 @@ describe("Tmux command wrapper coverage", () => {
       "exitModeIfNeeded:s:main.0",
       "sendKeysLiteral:pending",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8", // 8 lines: a TUI footer sits below the input and pushes it up
       "sendKeys:Enter",
-      "capture:5",
+      "capture:8",
     ]);
   });
 

--- a/test/tmux-sendtext-submit.test.ts
+++ b/test/tmux-sendtext-submit.test.ts
@@ -53,6 +53,36 @@ class FakeTmux extends Tmux {
 const PROMPT_IDLE = "agent@host:~$ "; // prompt marker + trailing space → submitted
 const PROMPT_PENDING = "agent@host:~$ unsent command text"; // input still on the line
 const enterCount = (calls: string[]) => calls.filter(c => c === "sendKeys:Enter").length;
+const cmCount = (calls: string[]) => calls.filter(c => c === "sendKeys:C-m").length;
+
+// Full-screen TUI captures: the input line sits ABOVE a footer/status line, so
+// lines.at(-1) is the footer, never the input. Mirrors real captures in the
+// stall-fix evidence (T1-root-cause-at-object / T5-real-codex-pane-probe).
+const CC_PENDING = [
+  "✻ Churned for 20s",
+  "────────────────────────────────────",
+  "❯ commit the ψ brain writes", // real un-submitted input, marker at line-start
+  "────────────────────────────────────",
+  "   🐾 Opus 4.8  █░░░░░░░░░ 6% ctx 57k/1000k  ~/ghq/github.com/sutthikit/akita-oracle",
+  "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 1 agent", // footer = bottom line
+].join("\n");
+const CC_SUBMITTED_ECHO = [
+  "> commit the ψ brain writes", // submitted turn echoed into the conversation area
+  "✻ Churned for 2s",
+  "❯ ", // input line now empty — must read as submitted despite the echo above
+  "   🐾 Opus 4.8  █░░░░░░░░░ 6% ctx 57k/1000k  ~/ghq/github.com/sutthikit/akita-oracle",
+  "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 1 agent",
+].join("\n");
+const CODEX_PLACEHOLDER = [
+  "─ Worked for 4m 03s ──────────────────────",
+  "› Use /skills to list available skills", // empty-state ghost, NOT real input
+  "  gpt-5.6-sol xhigh · pharaoh-oracle-horo · Context 47% left · 26.3M in · 317K out",
+].join("\n");
+const MENU_DIALOG = [
+  "Do you want to proceed?",
+  "❯ 1. Yes", // selection cursor + option — must NOT loop Enter into an auto-approve
+  "  2. No",
+].join("\n");
 
 describe("Tmux.sendText — confirmed submit (#6)", () => {
   test(
@@ -125,11 +155,81 @@ describe("Tmux.sendText — confirmed submit (#6)", () => {
         console.warn = origWarn;
       }
 
-      // capped — not an unbounded spin
-      expect(enterCount(t.calls)).toBe(4);
+      // capped — not an unbounded spin. Final attempt escalates the named
+      // `Enter` to a literal `C-m` (Enter-eaten last-ditch): 3 Enter + 1 C-m.
+      expect(enterCount(t.calls)).toBe(3);
+      expect(cmCount(t.calls)).toBe(1);
+      // condition #3: every C-m escalation is logged (append-only audit).
+      expect(warnings.some(w => w.includes("escalating to literal C-m") && w.includes("sess:win"))).toBe(true);
       expect(warnings.some(w => w.includes("pending input") && w.includes("sess:win"))).toBe(true);
     },
     15_000,
+  );
+
+  test(
+    "TUI (Claude Code): reads the ❯ input line ABOVE the footer, not lines.at(-1) — retries the eaten Enter",
+    async () => {
+      const t = new FakeTmux();
+      // pending (footer is the bottom line, input is above it) then cleared
+      t.captureScript = [CC_PENDING, PROMPT_IDLE];
+      await t.sendText("sess:cc", "commit the ψ brain writes");
+
+      // The old lines.at(-1)-only probe read the '⏵⏵ …' footer → saw no pending
+      // input → stopped at 1 Enter (the silent stall). The scan retries.
+      expect(enterCount(t.calls)).toBe(2);
+    },
+    15_000,
+  );
+
+  test(
+    "TUI (Claude Code): a submitted turn echoed into the conversation area is NOT read as pending",
+    async () => {
+      const t = new FakeTmux();
+      // input line is empty ('❯ ') but the sent text still shows in scrollback
+      // above. Scoping the sent-text check to the input line prevents an endless
+      // retry / duplicate submit on that echo.
+      t.captureScript = [CC_SUBMITTED_ECHO];
+      await t.sendText("sess:cc", "commit the ψ brain writes");
+
+      expect(enterCount(t.calls)).toBe(1); // submitted on first check, no spin
+      expect(cmCount(t.calls)).toBe(0);
+    },
+    10_000,
+  );
+
+  test(
+    "TUI (Codex): empty-state placeholder '› Use /skills…' is NOT pending — no false retry (condition #2)",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [CODEX_PLACEHOLDER]; // repeats → a misread would spin to the cap
+      await t.sendText("sess:codex", "x");
+
+      expect(enterCount(t.calls)).toBe(1);
+      expect(cmCount(t.calls)).toBe(0);
+    },
+    10_000,
+  );
+
+  test(
+    "menu/dialog cursor '❯ 1. Yes' is NOT read as pending — never loops Enter into an auto-approve (Collie CRIT-1)",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [MENU_DIALOG]; // if the option were read as pending, Enter would auto-select
+
+      const warnings: string[] = [];
+      const origWarn = console.warn;
+      console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+      try {
+        await t.sendText("sess:menu", "some dispatch");
+      } finally {
+        console.warn = origWarn;
+      }
+
+      expect(enterCount(t.calls)).toBe(1); // treated as submitted → stops, no C-m
+      expect(cmCount(t.calls)).toBe(0);
+      expect(warnings.length).toBe(0);
+    },
+    10_000,
   );
 
   test(


### PR DESCRIPTION
## What & why

`Tmux.sendText`'s submit-confirm (`paneInputPending`) read only `lines.at(-1)`. In a full-screen TUI (Claude Code `❯`, Codex `›`) the input line sits **above** a status/footer line (`⏵⏵ …`, `🐾 … ctx`, `Context N% left`), so `lines.at(-1)` is the **footer** — both the sent-text check (#2380) and the marker fallback ran against the wrong line. Pending input was never seen → submit green-lit after a single `Enter` → an **eaten `Enter` was never retried** = the silent stall that idled a real Husky dispatch (unsubmitted text sitting in the input box).

This **builds on** the existing sent-text approach, it does not replace it.

## The fix (single file, single method + its escalation)

- Capture **8** lines (was 5) so the footer can't push the input out of view.
- Locate the input line by scanning for the **last `❯`/`›` marker line**; fall back to `lines.at(-1)` for plain shells (marker is mid-line there, e.g. `user@host:~$ cmd`).
- Run **both** the sent-text needle check and the `❯»›#$%>` marker fallback against that **identified input line**.

### Safety guards
- **Echo-safe**: the sent-text match is scoped to the *input line*, not every captured line — a submitted turn echoed into the conversation area above cannot false-trigger an endless retry / duplicate submit.
- **Menu-safe (Collie T4 CRITICAL-1)**: `❯`/`›` is also a menu/dialog selection cursor (`❯ 1. Yes`). A numbered/lettered option under the cursor is treated as **not-pending**, so the retry loop can never loop `Enter` into an auto-approve. Biasing to a missed (loudly-warned) resend is far safer than auto-confirming a dialog.
- **Codex placeholder**: `› Use /skills…` stays not-pending.

### 5 binding conditions (Aussie)
1. **branch + PR** — this PR. **Merge gate = 2-stamp (Akita craft + Collie architect) + CI green. Do NOT merge before both stamps + CI.**
2. **Real codex pane tested** — a real scratch-tmux probe painted the actual Pharaoh/Codex frame; U+203A `›` survives `capture-pane`, the scan picks the `›` input line over the footer, and the placeholder reads not-pending. Evidence: `tantan-oracle ψ/memory/logs/stall-fix-evidence/T5-real-codex-pane-probe.txt`.
3. **Every C-m escalation logged** — final attempt escalates the named `Enter` to a literal `C-m` (raw carriage return, lands even when a TUI rebinds Return) and emits an append-only `console.warn`. Covered by test.
4. **Rollback** — single-file, single-method change. Rollback = `git revert 7d4d1f28` (this PR's commit), or restore `paneInputPending` + `submitWithConfirm` to their pre-PR state on `alpha`. *(Note: the "revert to 18abbef" phrasing in the T3 draft was imprecise — 18abbef was merely the file's last-touch on `main`; `alpha` is the real base here and the pre-patch state is `alpha`'s prior version of these two methods.)*
5. **Live-stall bonus evidence** — per Tantan's request: Aussie caught a real Enter-eaten stall on Shepherd's own pane during session rotation (unsubmitted text idle in the buffer). That is precisely the failure mode this PR closes: text placed, `Enter` swallowed, old probe read the footer and declared "submitted", dispatch silently dropped.

## Testing
- `tmux-sendtext-submit` **11/11** (adds TUI-footer, conversation-echo safety, codex-placeholder, menu-guard, C-m-escalation)
- `tmux-class-command-builders` **10/10**
- default-safe suite **2813 pass / 0 fail**; mock-smoke **6/6**; plugin **214/0**; CLI build OK
- Isolated suite: blocked *locally* only by macOS lacking GNU `timeout` (`test-isolated.sh:121` → exit 127 for all files); the tmux/comm-send isolated tests pass when run directly, and CI (Linux) has `timeout`.

## Base
Targets `alpha` (active dev line). `main` and `alpha` have diverged; `main`'s `paneInputPending` still lacks the `sentText` threading, so this fix is authored against `alpha`'s current implementation.

---
🤖 ตอบโดย shepherd จาก เปรม → shepherd-oracle · `[mini-m4:shepherd]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
