### PR TITLE
One malformed frame can no longer take the dashboard down

### DIFF
--- a/src/core/process-guards.ts
+++ b/src/core/process-guards.ts
@@ -1,0 +1,51 @@
+/**
+ * Last-resort process guards: no single client frame may take the whole
+ * dashboard down.
+ *
+ * Its own module rather than a function inside server.ts, for a reason the test
+ * suite found the hard way: importing `core/server` runs the plugin lifecycle
+ * and attempts a real `Bun.serve`, so any default-suite test that imported it to
+ * reach this function started a server and fought the live maw for port 3456.
+ * A guard whose test cannot be written safely is a guard that stops being
+ * tested — and nothing here needs server internals.
+ *
+ * Background: on 2026-08-10 a single ws frame carrying `"target": null` reached
+ * `target.replace` inside an async attach(), and the resulting unhandled
+ * rejection killed `maw serve` outright — Colony went blind for the whole fleet
+ * while every oracle under it kept running fine. That specific hole is closed at
+ * its source in transport/pty.ts. This is the net underneath, because the shape
+ * of it — an async handler invoked without await, on any route — is one a future
+ * edit can reintroduce for free, and the blast radius is never proportional to
+ * the mistake.
+ */
+
+let installed = false;
+
+/**
+ * Log fatal async failures and keep serving.
+ *
+ * Deliberately continues rather than exits. That is the wrong default for a
+ * batch job and the right one for a long-lived server whose death costs more
+ * than any single request it is serving.
+ *
+ * Idempotent: startBunGatewayServer can run more than once in a process (tests,
+ * TLS restarts), and re-registering would multiply every future log line by the
+ * number of starts. Returns whether it installed, so callers can assert it.
+ */
+export function installProcessGuards(log: { error: (message: string) => void }): boolean {
+  if (installed) return false;
+  installed = true;
+  process.on("unhandledRejection", (reason) => {
+    const detail = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
+    log.error(`[serve:guard] unhandled rejection (server kept running): ${detail}`);
+  });
+  process.on("uncaughtException", (err) => {
+    log.error(`[serve:guard] uncaught exception (server kept running): ${err?.stack ?? String(err)}`);
+  });
+  return true;
+}
+
+/** Test seam: forget the install so a fresh assertion can be made. */
+export function resetProcessGuardsForTest(): void {
+  installed = false;
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -23,6 +23,7 @@ import { getRuntimeVersionLabel } from "./runtime/build-info";
 import { ServeRouteRegistry } from "./serve-route-registry";
 import { ServeWsRegistry } from "./serve-ws-registry";
 import { addCorsHeaders, handleCorsOptions } from "./serve-cors";
+import { installProcessGuards } from "./process-guards";
 import { createViews } from "../vendor/mpr-plugins/serve-views/index.ts";
 import { serve as registerServeWs } from "../vendor/mpr-plugins/serve-ws/index.ts";
 export { createViews };
@@ -520,6 +521,10 @@ export async function startBunGatewayServer(
     info: (message) => log.info(message),
     warn: (message) => log.warn(message),
   });
+
+  // Installed before the socket opens, so the first frame a client can possibly
+  // send is already covered.
+  installProcessGuards({ error: (message) => log.error(message) });
 
   let server: ReturnType<typeof Bun.serve>;
   try {

--- a/src/core/transport/pty.ts
+++ b/src/core/transport/pty.ts
@@ -67,6 +67,44 @@ function replayLinesFromControl(value: unknown): number {
   return Math.max(0, Math.min(10_000, Math.floor(n)));
 }
 
+/** A control message's `target`, or null when the client sent something unusable.
+ *
+ * Split out of attach() rather than checked inside it, because attach() is
+ * `async`: anything it throws becomes a *rejected promise*, and the try/catch
+ * around the dispatch in handlePtyMessage only ever sees synchronous throws. On
+ * 2026-08-10 one `{"type":"attach","target":null}` frame reached `target.replace`
+ * and the resulting unhandled rejection took the whole `maw serve` process down,
+ * blinding Colony for the entire fleet while every oracle kept running. So the
+ * check has to happen on this side of the call, before the promise exists.
+ */
+export function controlTarget(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** Tell the client its frame was rejected, and why.
+ *
+ * Refusing in silence is what made the original bug expensive to diagnose: a
+ * client sending a malformed target got the same nothing back as a client whose
+ * pane was simply quiet. Sending never throws upward — the socket may already be
+ * gone, and a failure to explain a refusal must not itself become a refusal.
+ */
+function sendControlError(ws: MawWS, message: string): void {
+  try {
+    // `message`, not `detail`, to match the error frame this module already
+    // sends ("Failed to create PTY session" below). The web client ships as a
+    // separate dist and is not in this repo, so a new field name here would very
+    // likely be read by nobody — a refusal the client cannot see is the silence
+    // this change exists to remove.
+    ws.send(JSON.stringify({ type: "error", message }));
+  } catch { /* expected: viewer may have disconnected mid-refusal */ }
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 function replayCapture(ws: MawWS, target: string, lines: number, io: PtyDeps) {
   if (lines <= 0) return;
   try {
@@ -162,7 +200,20 @@ function handlePtyMessage(ws: MawWS, msg: string | Buffer) {
   // JSON control message
   try {
     const data = JSON.parse(msg);
-    if (data.type === "attach") attach(ws, data.target, data.cols || 120, data.rows || 40, replayLinesFromControl(data.replayLines));
+    if (data.type === "attach") {
+      const target = controlTarget(data.target);
+      if (!target) {
+        sendControlError(ws, `attach: "target" must be a non-empty string, got ${JSON.stringify(data.target) ?? "undefined"}`);
+        return;
+      }
+      // attach() is async, so this call cannot be left bare: a rejection would
+      // escape the try/catch below, become an unhandled rejection, and take the
+      // process with it. Awaiting is not an option either — handlePtyMessage is
+      // the ws `message` callback and must stay synchronous — so the rejection
+      // is claimed here instead, and reported to the client that caused it.
+      void attach(ws, target, data.cols || 120, data.rows || 40, replayLinesFromControl(data.replayLines))
+        .catch((err) => sendControlError(ws, `attach failed: ${errText(err)}`));
+    }
     else if (data.type === "resize") resize(ws, data.cols, data.rows);
     else if (data.type === "detach") detach(ws);
   } catch { /* expected: malformed WS message */ }
@@ -175,7 +226,14 @@ function handlePtyClose(ws: MawWS) {
 async function attach(ws: MawWS, target: string, cols: number, rows: number, replayLines: number) {
   // Sanitize target: only allow safe characters
   const safe = target.replace(/[^a-zA-Z0-9\-_:.]/g, "");
-  if (!safe) return;
+  // Was a bare `return` — indistinguishable, from the client's side, from an
+  // attach that worked and then had nothing to show. Callers reach this only
+  // with a non-empty string (controlTarget), so an empty result here means every
+  // character was stripped, which is worth saying out loud.
+  if (!safe) {
+    sendControlError(ws, `attach: "target" has no usable characters after sanitizing: ${JSON.stringify(target)}`);
+    return;
+  }
 
   // Detach from any existing session
   detach(ws);

--- a/test/pty-transport-default.test.ts
+++ b/test/pty-transport-default.test.ts
@@ -3,7 +3,7 @@
  * process/tmux/config seams instead of global Bun/tmux mocks.
  */
 import { describe, expect, test } from "bun:test";
-import { createPtyHandlers, ptyDeps, type PtyDeps } from "../src/core/transport/pty";
+import { controlTarget, createPtyHandlers, ptyDeps, type PtyDeps } from "../src/core/transport/pty";
 
 const encode = (text: string) => new TextEncoder().encode(text);
 const decode = (data: unknown) => data instanceof Uint8Array ? new TextDecoder().decode(data) : String(data);
@@ -192,7 +192,7 @@ describe("ptyDeps", () => {
 });
 
 describe("createPtyHandlers", () => {
-  test("ignores malformed controls, empty sanitized targets, resize/detach, and binary before attach", () => {
+  test("ignores malformed controls, resize/detach, and binary before attach — but says so when a target sanitizes away", () => {
     const h = makeHarness();
     const ws = makeWs();
 
@@ -200,9 +200,18 @@ describe("createPtyHandlers", () => {
     h.handlePtyMessage(ws as any, "not json");
     h.handlePtyMessage(ws as any, JSON.stringify({ type: "resize", cols: 10, rows: 5 }));
     h.handlePtyMessage(ws as any, JSON.stringify({ type: "detach" }));
-    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "!!!" }));
 
+    // Everything above is genuinely nothing to report: a keystroke before any
+    // attach, a frame that is not JSON, and two controls that did their job.
     expect(ws.sent).toEqual([]);
+
+    // "!!!" is different — the client asked for something and got refused. It
+    // used to be refused in silence, which reads identically to a pane that has
+    // nothing to show, so the refusal now goes back down the socket.
+    h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "!!!" }));
+    expect(ws.sent).toHaveLength(1);
+    expect(JSON.parse(ws.sent[0] as string).type).toBe("error");
+
     expect(h.spawnCalls).toEqual([]);
     expect(h.groupedCalls).toEqual([]);
   });
@@ -422,5 +431,114 @@ describe("createPtyHandlers", () => {
     await eventually(() => h.killSessionCalls.includes("maw-pty-stale"), "P3 stale-orphan kill");
     expect(h.killSessionCalls).not.toContain("maw-pty-other");
     await h.finishReaders();
+  });
+});
+
+/**
+ * Regression: on 2026-08-10 a single ws frame carrying `"target": null` reached
+ * `target.replace` inside the *async* attach(), and the resulting unhandled
+ * rejection killed the whole `maw serve` process — Colony went blind for the
+ * entire fleet while every oracle underneath it kept running normally.
+ *
+ * The try/catch that already wrapped the dispatch could not help: attach() is
+ * async, so it rejects rather than throws, and a rejection does not travel up
+ * into a synchronous catch. These tests therefore assert two separate things —
+ * that the frame is refused *and explained*, and that nothing about handling it
+ * produces an unhandled rejection.
+ */
+describe("createPtyHandlers — a malformed attach must not kill the process", () => {
+  const badTargets: Array<[string, unknown]> = [
+    ["null", null],
+    ["a number", 42],
+    ["an object", { name: "01-labubu" }],
+    ["an array", ["01-labubu"]],
+    ["a boolean", true],
+    ["the empty string", ""],
+    ["whitespace only", "   "],
+    ["missing entirely", undefined],
+  ];
+
+  for (const [label, target] of badTargets) {
+    test(`refuses target = ${label} with an error the client can read, and keeps serving`, async () => {
+      const h = makeHarness();
+      const ws = makeWs();
+      const rejections: unknown[] = [];
+      const onRejection = (reason: unknown) => rejections.push(reason);
+      process.on("unhandledRejection", onRejection);
+
+      try {
+        h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target }));
+        await flush();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        // Refused...
+        expect(h.spawnCalls).toEqual([]);
+        expect(h.groupedCalls).toEqual([]);
+        // ...out loud, so the client learns what it did wrong.
+        expect(ws.sent).toHaveLength(1);
+        const reply = JSON.parse(ws.sent[0] as string);
+        expect(reply.type).toBe("error");
+        expect(reply.message).toContain("target");
+        // ...and without the rejection that took the process down.
+        expect(rejections).toEqual([]);
+
+        // Still serving: a good frame right after a bad one still attaches.
+        h.handlePtyMessage(ws as any, JSON.stringify({ type: "attach", target: "01-labubu:0" }));
+        await eventually(() => h.spawnCalls.length === 1, "attach after a malformed frame");
+        await h.finishReaders();
+      } finally {
+        process.off("unhandledRejection", onRejection);
+      }
+    });
+  }
+
+  test("a rejection raised past attach()'s own try/catch never reaches the process", async () => {
+    // Session creation already had an internal try/catch, so that path was never
+    // the one that killed serve. The unguarded surface is everything *outside*
+    // it — here, the bare `ws.send({type:"attached"})` on the cached-session
+    // branch. A viewer that goes away between JOIN and that send makes send()
+    // throw, and before the .catch() this rejected into the process exactly the
+    // way `target.replace` on null did.
+    const h = makeHarness({ spawnPlans: [{ autoEnd: false }] });
+    const first = makeWs();
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onRejection);
+
+    try {
+      h.handlePtyMessage(first as any, JSON.stringify({ type: "attach", target: "01-labubu:0" }));
+      await eventually(() => h.spawnCalls.length === 1, "first attach creates the session");
+
+      // Second viewer joins the cached session, then dies mid-send.
+      const dying = {
+        sent: [] as unknown[],
+        send() { throw new Error("WebSocket is already closed"); },
+      };
+      h.handlePtyMessage(dying as any, JSON.stringify({ type: "attach", target: "01-labubu:0" }));
+      await flush();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(rejections).toEqual([]);
+
+      // And the server is still serving the viewer that is still there.
+      h.handlePtyMessage(first as any, JSON.stringify({ type: "detach" }));
+      await flush();
+      expect(rejections).toEqual([]);
+      await h.finishReaders();
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+  });
+
+  test("controlTarget accepts what a real client sends and nothing else", () => {
+    expect(controlTarget("01-labubu:0")).toBe("01-labubu:0");
+    expect(controlTarget("  01-labubu:0  ")).toBe("01-labubu:0");
+    expect(controlTarget(null)).toBeNull();
+    expect(controlTarget(undefined)).toBeNull();
+    expect(controlTarget("")).toBeNull();
+    expect(controlTarget("   ")).toBeNull();
+    expect(controlTarget(42)).toBeNull();
+    expect(controlTarget({})).toBeNull();
+    expect(controlTarget([])).toBeNull();
   });
 });

--- a/test/serve-process-guards.test.ts
+++ b/test/serve-process-guards.test.ts
@@ -1,0 +1,102 @@
+/**
+ * process-guards.ts — the last-resort process guards.
+ *
+ * Imported from its own module, not from core/server: importing core/server runs
+ * the plugin lifecycle and attempts a real Bun.serve, which in the default suite
+ * fought the live maw for port 3456 and failed a neighbouring pty test.
+ *
+ * Context: on 2026-08-10 a single ws frame with `"target": null` produced an
+ * unhandled rejection and Bun took `maw serve` down with it, blinding Colony for
+ * the whole fleet. That specific hole is closed at its source in pty.ts; these
+ * guards exist because the *shape* of it — an async handler invoked without
+ * await — is one a future edit can reintroduce anywhere on any route, and the
+ * cost is never proportional to the mistake.
+ *
+ * These tests install real process listeners, so every one of them removes what
+ * it added: a leaked "uncaughtException" listener would silently swallow genuine
+ * failures in whatever test file runs next.
+ */
+import { describe, expect, test } from "bun:test";
+import { installProcessGuards, resetProcessGuardsForTest } from "../src/core/process-guards";
+
+function withGuards<T>(body: (logs: string[]) => T): T {
+  const before = {
+    rejection: process.listeners("unhandledRejection").slice(),
+    exception: process.listeners("uncaughtException").slice(),
+  };
+  const logs: string[] = [];
+  try {
+    return body(logs);
+  } finally {
+    // Remove only what this test added, and restore the install flag.
+    for (const l of process.listeners("unhandledRejection")) {
+      if (!before.rejection.includes(l)) process.off("unhandledRejection", l as never);
+    }
+    for (const l of process.listeners("uncaughtException")) {
+      if (!before.exception.includes(l)) process.off("uncaughtException", l as never);
+    }
+    resetProcessGuardsForTest();
+  }
+}
+
+describe("installProcessGuards", () => {
+  test("registers one listener per fatal signal and is idempotent", () => {
+    withGuards((logs) => {
+      const rejectionsBefore = process.listenerCount("unhandledRejection");
+      const exceptionsBefore = process.listenerCount("uncaughtException");
+
+      expect(installProcessGuards({ error: (m) => logs.push(m) })).toBe(true);
+      expect(process.listenerCount("unhandledRejection")).toBe(rejectionsBefore + 1);
+      expect(process.listenerCount("uncaughtException")).toBe(exceptionsBefore + 1);
+
+      // startBunGatewayServer can run more than once in a process (tests, TLS
+      // restarts). Re-registering would multiply every future log line by the
+      // number of starts.
+      expect(installProcessGuards({ error: (m) => logs.push(m) })).toBe(false);
+      expect(process.listenerCount("unhandledRejection")).toBe(rejectionsBefore + 1);
+      expect(process.listenerCount("uncaughtException")).toBe(exceptionsBefore + 1);
+    });
+  });
+
+  test("logs a rejection and keeps going instead of ending the process", () => {
+    withGuards((logs) => {
+      installProcessGuards({ error: (m) => logs.push(m) });
+      const handler = process.listeners("unhandledRejection").at(-1) as (r: unknown) => void;
+
+      // The real thing: what `target.replace` on null produced.
+      expect(() => handler(new TypeError("null is not an object (evaluating 'target.replace')"))).not.toThrow();
+
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toContain("unhandled rejection");
+      expect(logs[0]).toContain("server kept running");
+      expect(logs[0]).toContain("target.replace");
+    });
+  });
+
+  test("logs a non-Error rejection reason without throwing on it", () => {
+    withGuards((logs) => {
+      installProcessGuards({ error: (m) => logs.push(m) });
+      const handler = process.listeners("unhandledRejection").at(-1) as (r: unknown) => void;
+
+      // A rejection reason is whatever was thrown — frequently not an Error.
+      expect(() => handler("plain string reason")).not.toThrow();
+      expect(() => handler(undefined)).not.toThrow();
+
+      expect(logs).toHaveLength(2);
+      expect(logs[0]).toContain("plain string reason");
+    });
+  });
+
+  test("logs an uncaught exception and keeps going", () => {
+    withGuards((logs) => {
+      installProcessGuards({ error: (m) => logs.push(m) });
+      const handler = process.listeners("uncaughtException").at(-1) as (e: Error) => void;
+
+      expect(() => handler(new Error("boom"))).not.toThrow();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toContain("uncaught exception");
+      expect(logs[0]).toContain("server kept running");
+      expect(logs[0]).toContain("boom");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- On 2026-08-10 a single WebSocket message with `"target": null` killed `maw serve` outright — Colony went blind for the whole fleet while every oracle under it kept working normally, and recovery was slow because the Windows relay stayed pointed at a listener that no longer existed.
- `attach()` is `async`; `target.replace` on `null` didn't throw into the existing synchronous try/catch — it returned a rejected promise nobody awaited, and Bun ends the process on an unhandled rejection. Fixed in three places:
  1. **Validate before the promise exists** — `controlTarget()` decides whether `target` is a usable string on the synchronous side of the call.
  2. **Claim the rejection** — the `attach()` call now carries a `.catch()` (await wasn't an option; `handlePtyMessage` is the synchronous ws `message` callback), reporting the failure back instead of letting it escape.
  3. **Say no out loud** — a refused frame now sends `{type:"error",message}` back instead of returning silently.
  4. **A net underneath** — `process-guards.ts` (new, separate module) installs `unhandledRejection`/`uncaughtException` listeners that log and keep serving, wired in via `installProcessGuards()` in `server.ts`.

This has been sitting as a verified local commit since 2026-08-10 (a full week) without being pushed — only symptom-level mitigations existed in the meantime (a downstream caller blocking `null` before it reaches this server, and a watchdog auto-restart). This PR lands the root-cause fix.

## Test plan
- [x] `test/pty-transport-default.test.ts` + `test/serve-process-guards.test.ts` — 26/26 pass (re-verified fresh on this cherry-picked commit, standalone against current `alpha`)
- [x] `bun run build` — clean, 711 modules
- [x] End-to-end (per the original commit): a real Bun WebSocket server behind the real handler, fed `null`, `42`, `{}`, `""`, `"   "`, `"!!!@#$"`, a missing target, and a non-JSON frame — before the fix the process dies on the first one; after, it survives all eight, returns seven error frames (the non-JSON frame is correctly ignored), and a fresh client is still served
- [x] Sabotage check: reverting the guard fails 7-of-22 regression tests with 5 errors, proving the tests actually detect the bug
- [x] Full `scripts/test-default-safe.sh` — 2825 pass / 0 fail (re-run fresh against current `alpha` HEAD before cherry-picking this fix on top)

Original author: HelloMAF <hello@maf.co.th>, 2026-08-10, commit `0cd777d2`. This PR cherry-picks that commit onto current upstream `alpha` (isolated from unrelated local-only work sitting on top of it in that checkout).

🤖 ตอบโดย git-manager จาก HelloMAF → git-manager-oracle

https://claude.ai/code/session_01RPqbHJzBcN8UVVH1unBtnt