### PR TITLE
fix(hey): refuse an unknown flag instead of delivering it as the message

### DIFF
--- a/src/cli/route-comm.ts
+++ b/src/cli/route-comm.ts
@@ -70,12 +70,23 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
     let approve = false;
     let trust = false;
     let noVerifySubmit = false;
+    // #maw-hey-flag-guard — ทุก token ที่ไม่ตรง flag ที่รู้จัก เคยตกลงไปเป็น "เนื้อข้อความ"
+    // แล้วคืน rc=0 ⇒ พิมพ์ `--file x` ผิด = ผู้รับได้บรรทัดเดียวว่า `--file x` โดยไม่มีอะไรเตือน
+    // (volt พลาดข้อนี้ 3 ครั้งใน 4 วัน · morse ชี้ว่าเป็น fail-open ⇒ วินัยคนพิมพ์กันไม่ได้)
+    // `--` = end-of-flags สำหรับคนที่ตั้งใจส่งข้อความขึ้นต้นด้วยขีดสองอัน
+    let endOfFlags = false;
     let from: string | undefined;
     let target: string | undefined;
     const msgArgs: string[] = [];
 
     for (let i = 0; i < rest.length; i += 1) {
       const arg = rest[i];
+      if (!endOfFlags && arg === "--") { endOfFlags = true; continue; }
+      if (endOfFlags) {
+        if (!target) target = arg;
+        else msgArgs.push(arg);
+        continue;
+      }
       if (arg === "--force") { force = true; continue; }
       if (arg === "--inbox") { inboxOnly = true; continue; }
       if (arg === "--approve") { approve = true; continue; }
@@ -94,6 +105,18 @@ export async function routeComm(cmd: string, args: string[]): Promise<boolean> {
       if (arg.startsWith("--from=")) {
         from = arg.slice("--from=".length);
         continue;
+      }
+      // ด่าน fail-closed: flag ที่ไม่รู้จักซึ่งโผล่ "ก่อนเนื้อข้อความเริ่ม" = พิมพ์ผิด ไม่ใช่ข้อความ
+      // ผูกกับ msgArgs.length === 0 เพื่อไม่ให้ข้อความที่มี `--` อยู่กลางประโยคพัง
+      // 📎 แม่ Labubu 18.08 (near-miss จาก traffic จริง 3,913 บรรทัด): `startsWith("--")` ยิงใส่ `---` ด้วย
+      //    ซึ่งคือบรรทัดแรกของ YAML frontmatter ⇒ เอกสาร markdown เต็มใบ **4 ใบที่เคยส่งสำเร็จ** จะถูกปฏิเสธ
+      //    (morse 2 · volt 1 · echo 1) · flag จริงมีตัวอักษรตามหลังขีดเสมอ ⇒ แคบด่านลงเป็น `--` + ตัวอักษร
+      if (/^--[A-Za-z]/.test(arg) && msgArgs.length === 0) {
+        console.error(`\x1b[31m✗\x1b[0m unknown flag: ${arg}`);
+        console.error(`  \x1b[33mhint\x1b[0m: maw ${cmd} รับเฉพาะ --from --inbox --force --approve --trust --no-verify-submit`);
+        console.error(`  ถ้าตั้งใจให้ข้อความขึ้นต้นด้วย ${arg} ให้คั่นด้วย -- ก่อน: maw ${cmd} <target> -- "${arg} ..."`);
+        printCommUsage(cmd, console.error);
+        throw new UserError(`unknown flag: ${arg}`);
       }
       if (!target) target = arg;
       else msgArgs.push(arg);

--- a/test/isolated/route-comm-send.test.ts
+++ b/test/isolated/route-comm-send.test.ts
@@ -157,3 +157,69 @@ describe("routeComm — top-level send uses core delivery (#1388)", () => {
     expect(calls).toEqual([]);
   });
 });
+
+/**
+ * ด่าน fail-closed สำหรับ flag ที่ไม่รู้จัก
+ *
+ * ก่อนแพตช์: token ใด ๆ ที่ไม่ตรง flag ที่รู้จัก ตกลงไปเป็น "เนื้อข้อความ" แล้วคืน rc=0
+ * ⇒ `maw hey morse --file /path/msg.md` ส่งบรรทัดเดียวว่า `--file /path/msg.md` ให้ผู้รับ
+ *   โดยพิมพ์ `delivered` และไม่มีอะไรเตือน (volt พลาดข้อนี้ 3 ครั้งใน 4 วัน)
+ * 📎 morse: นี่คือ fail-open ⇒ วินัยคนพิมพ์กันไม่ได้ ต้องให้เครื่องปฏิเสธ
+ */
+describe("routeComm — flag ที่ไม่รู้จักต้องถูกปฏิเสธ ไม่ใช่กลายเป็นข้อความ", () => {
+  test("flag แปลกหลัง target = พิมพ์ผิด ⇒ throw และไม่ส่งอะไรเลย", async () => {
+    await expect(routeComm("hey", ["hey", "local:mawjs", "--file", "/tmp/msg.md"]))
+      .rejects.toThrow("unknown flag: --file");
+    expect(calls).toEqual([]);
+    expect(errors.join("\n")).toContain("unknown flag: --file");
+  });
+
+  test("flag แปลกก่อน target ก็ถูกปฏิเสธเหมือนกัน", async () => {
+    await expect(routeComm("send", ["send", "--file", "local:mawjs", "hello"]))
+      .rejects.toThrow("unknown flag: --file");
+    expect(calls).toEqual([]);
+  });
+
+  test("`--` คั่นแล้ว ข้อความที่ขึ้นต้นด้วย -- ส่งได้ปกติ", async () => {
+    const handled = await routeComm("hey", ["hey", "local:mawjs", "--", "--file", "/tmp/msg.md"]);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual([
+      ["local:mawjs", "--file /tmp/msg.md", false, { approve: false, trust: false, inboxOnly: false }],
+    ]);
+  });
+
+  // 🔴 near-miss จาก traffic จริง (📎 แม่ Labubu 18.08 · กวาด inbox ทุกบ้าน 3,913 บรรทัด)
+  //    `---` = บรรทัดแรกของ YAML frontmatter · มีเอกสารเต็มใบ **4 ใบที่เคยส่งสำเร็จ** ขึ้นต้นแบบนี้
+  //    ด่านฉบับแรก (`startsWith("--")`) จะปฏิเสธทั้ง 4 ใบ ทั้งที่ไม่ใช่การพิมพ์ผิดเลย
+  //    เคสนี้คือสิ่งเดียวที่กันไม่ให้ใครแก้ด่านกลับไปกว้างเหมือนเดิม — ห้ามลบ
+  test("เอกสารที่ขึ้นต้นด้วย --- (frontmatter) ต้องส่งได้ ไม่ใช่ถูกปฏิเสธ", async () => {
+    const doc = "---\nfrom: volt\nto: morse\n---\n\nเนื้อความ";
+    const handled = await routeComm("hey", ["hey", "local:mawjs", doc]);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual([
+      ["local:mawjs", doc, false, { approve: false, trust: false, inboxOnly: false }],
+    ]);
+  });
+
+  test("`--` เปล่า ๆ ที่ไม่มีตัวอักษรตาม ไม่ถูกอ่านเป็น flag แปลก", async () => {
+    const handled = await routeComm("hey", ["hey", "local:mawjs", "--", "-- ขีดสองอันเฉย ๆ"]);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual([
+      ["local:mawjs", "-- ขีดสองอันเฉย ๆ", false, { approve: false, trust: false, inboxOnly: false }],
+    ]);
+  });
+
+  // negative control — ด่านต้องไม่กว้างเกินไป: `--` ที่โผล่ "หลังเนื้อข้อความเริ่มแล้ว"
+  // เป็นส่วนหนึ่งของประโยค ไม่ใช่ flag ⇒ พฤติกรรมเดิมต้องไม่เปลี่ยน
+  test("ข้อความที่มี --word อยู่กลางประโยค ยังส่งได้เหมือนเดิม", async () => {
+    const handled = await routeComm("hey", ["hey", "local:mawjs", "hello", "--world"]);
+
+    expect(handled).toBe(true);
+    expect(calls).toEqual([
+      ["local:mawjs", "hello --world", false, { approve: false, trust: false, inboxOnly: false }],
+    ]);
+  });
+});


### PR DESCRIPTION
## The bug

`maw hey <target> --file /path/msg.md` delivers the string `--file /path/msg.md` **as the message**, prints `delivered`, and returns `rc=0`. Nothing is reported on either side — the sender reads success, the receiver gets garbage.

Cause is the fallthrough at the end of the arg loop in `src/cli/route-comm.ts`: every token that is not one of the six known flags lands in `if (!target) target = arg; else msgArgs.push(arg)`.

This is fail-open, so typing discipline cannot defend against it: it was hit **3 times in 4 days** by one operator whose own notes already documented the correct usage.

## The fix

- an unrecognised flag-shaped token appearing **before the message has started** (`msgArgs.length === 0`) → `UserError` + usage, instead of silently becoming message content
- `--` is honoured as end-of-flags, for anyone who genuinely wants a message starting with two dashes
- the `args.includes(...)` lines above the loop are untouched

**Why the pattern is `/^--[A-Za-z]/` and not `startsWith("--")`:** a sweep of 3,913 delivered message lines on one node found two populations — 9 real `--word` sends (the bug) and 4 real documents whose first line is `---`, the opening of YAML frontmatter. A guard keyed on `startsWith("--")` refuses all four of those legitimate messages. A real flag always has a letter after the dashes.
⚠️ Scope of the 9/4 numbers: messages that landed as files in an inbox on **one** node. Grepping scripts on two nodes returned 0 for both shapes — a different population, not a contradiction.

## Receipts

Verdict is bound to `4bc2dcde` on base `5ee396a7`.

- **cherry-picked clean onto `alpha`**: `cb004647^:src/cli/route-comm.ts` and its test file are **byte-identical** to `origin/alpha` (`git diff` empty both files), so this applies verbatim
- **the exact bytes have been running live since 2026-08-18 22:59 GMT+7** on a 5-house node — `md5 5fc51075…` for `route-comm.ts`, `ab1b12e3…` for the test file, identical to this branch
- `test/isolated/route-comm-send.test.ts`: **20 pass · 0 fail** (6 cases added)
- **sabotage A** — source reverted, tests kept → **16 pass · 4 fail** (the four guard cases)
- **sabotage B** — guard widened to `startsWith("--")` → **19 pass · 1 fail** (the frontmatter case). The near-miss shape is asserted, not assumed.
- **`scripts/test-default-safe.sh`**: **0 fail**, `rc=0` (2,807 tests)
- **`scripts/test-isolated.sh`, both directions on the SAME worktree by swapping the two files** (a number measured on another clone is not a control):
  - patched → `Ran 4882 · 1 fail`
  - control → `Ran 4876 · 1 fail`
  - **Δ ran = 6** = exactly the six added cases (the denominator moved, so the new tests really ran)
  - **failure set identical**: `coverage-100b vendor/core direct gaps > token scan skips stat/read failures…` in both directions ⇒ pre-existing, not from this change

## Not checked — stated rather than implied

- **no typecheck claim**: this repo has no `tsc` gate wired that I ran; I did not run one
- I did not exercise an interactive human typing the flag at a real terminal — the evidence is the test suite plus live traffic
- **still broken, deliberately out of scope**: a flag placed **before** the target still becomes the target (`maw hey --inbox volt msg` → target `--inbox`), because `target` is assigned by the same fallthrough. Fixing it means reworking target resolution; it is broken prior to this change and is not made worse by it.
- CI on `alpha` was not read by me before opening this PR — the checks on this PR are the first signal

📎 The fix was written by Volt (srv1809016) in two patches; I gated it, broke it in both directions, and deployed it. The `/^--[A-Za-z]/` narrowing is mine, from the traffic sweep above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
