### PR TITLE
fix(locate,hey): source-owned recovery of window-seat locate + --inbox persist-only

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -641,7 +641,10 @@ export async function cmdSend(
     const isExplicitRemoteSession = parts.length === 2 && /-oracle$/i.test(bareAgent);
     const isCanonical = parts.length >= 3 || (parts.length === 2 && (isTmuxSessionIdTarget(bareAgent) || isExplicitRemoteSession));
     const isLocalScope = !targetNode || targetNode === config.node || targetNode === "local";
-    if (isLocalScope && bareAgent && !isCanonical) {
+    // #dept-roster: --inbox is a persist-only contract — it must never wake,
+    // create, or inject a session (a sandboxed sender cannot even touch the
+    // tmux socket; auto-wake here turned inbox-only into a hard failure).
+    if (isLocalScope && bareAgent && !isCanonical && !opts.inboxOnly) {
       const hasLocalSession = sessions.some(s =>
         s.name === bareAgent ||
         s.windows.some(w => w.name === `${bareAgent}-oracle` || w.name === bareAgent)
@@ -696,7 +699,7 @@ export async function cmdSend(
       // fall through. If the target is genuinely unreachable, the send attempt
       // surfaces its own clear "Remote fetch failed" error (#411 contract).
       const peer = (config.namedPeers || []).find(p => p.name === targetNode);
-      if (peer) {
+      if (peer && !opts.inboxOnly) {
         const { shouldAutoWake } = await import("./should-auto-wake");
         const decision = shouldAutoWake(bareAgent, {
           site: "hey",

--- a/src/vendor/mpr-plugins/locate/impl.ts
+++ b/src/vendor/mpr-plugins/locate/impl.ts
@@ -38,6 +38,9 @@ interface LocateResult {
   hasPsi: boolean;
   sessionName: string | null;
   windowCount: number;
+  /** Exact live tmux target (`session:window`) for a registered window
+   *  seat whose name matches a WINDOW, not a session. Null otherwise. */
+  windowTarget: string | null;
   fleetConfigPath: string | null;
   federationNode: string | null;
   inAgentsConfig: boolean;
@@ -136,16 +139,40 @@ async function gatherInfo(oracle: string, opts: { scanFederation?: boolean } = {
   // ψ/ presence
   const hasPsi = repoPath ? existsSync(join(repoPath, "ψ")) : false;
 
+  // Federation — config.agents map + node (loaded early: window-seat
+  // resolution below is gated on explicit config.agents registration).
+  const config = loadConfig();
+  const agents = config.agents ?? {};
+  const inAgentsConfig = oracle in agents;
+
   // tmux session — use the alpha.77 suffix-preferred resolver so bare
   // name resolves to the `NN-name` canonical session, not a `name-view`.
   let sessionName: string | null = null;
   let windowCount = 0;
+  let windowTarget: string | null = null;
   try {
     const sessions = await listSessions();
     const r = resolveSessionTarget(oracle, sessions);
     if (r.kind === "exact" || r.kind === "fuzzy") {
       sessionName = r.match.name;
       windowCount = r.match.windows?.length ?? 0;
+    }
+    // Window-seat resolution (#dept-roster): a department seat lives in a
+    // parent session's WINDOW (e.g. 05-nntn:cookbook) and never matches a
+    // session name. Only an EXPLICITLY REGISTERED identity (config.agents)
+    // resolves this way — unregistered utility panes stay non-authoritative
+    // and must not be elevated by discovery. Exact window-name match only;
+    // never fuzzy — a fuzzy hit here is how wrong-parent misroutes happen.
+    if (!sessionName && inAgentsConfig) {
+      for (const sess of sessions) {
+        const w = (sess.windows ?? []).find((win) => win.name === oracle);
+        if (w) {
+          sessionName = sess.name;
+          windowCount = sess.windows?.length ?? 0;
+          windowTarget = `${sess.name}:${w.name}`;
+          break;
+        }
+      }
     }
   } catch {
     /* tmux not running — leave session null */
@@ -160,10 +187,7 @@ async function gatherInfo(oracle: string, opts: { scanFederation?: boolean } = {
   // aligned with `maw oracle list` for registry-only oracles.
   const manifestEntry = lookupManifestEntry(oracle);
 
-  // Federation — config.agents map + node
-  const config = loadConfig();
-  const agents = config.agents ?? {};
-  const inAgentsConfig = oracle in agents;
+  // Federation node (config/agents already loaded above)
   const federationNode = inAgentsConfig
     ? agents[oracle]!
     : sessionName
@@ -178,6 +202,7 @@ async function gatherInfo(oracle: string, opts: { scanFederation?: boolean } = {
     hasPsi: repoPath ? hasPsi : (manifestEntry?.hasPsi ?? false),
     sessionName,
     windowCount,
+    windowTarget,
     fleetConfigPath,
     federationNode,
     inAgentsConfig,
@@ -225,6 +250,9 @@ export async function cmdLocate(oracle: string | undefined, opts: LocateOpts = {
   }
   if (info.sessionName) {
     console.log(`   session:  ${info.sessionName} (${info.windowCount} window${info.windowCount === 1 ? "" : "s"})`);
+  }
+  if (info.windowTarget) {
+    console.log(`   target:   ${info.windowTarget} (registered window seat)`);
   }
   if (info.fleetConfigPath) {
     console.log(`   fleet:    ${info.fleetConfigPath}`);

--- a/test/isolated/comm-send-thirteenth-pass-coverage.test.ts
+++ b/test/isolated/comm-send-thirteenth-pass-coverage.test.ts
@@ -466,6 +466,34 @@ describe("comm-send thirteenth-pass cmdSend branches", () => {
     expect(logs.join("\n")).toContain("target not live; persisted for receiver inbox polling");
   });
 
+  test("--inbox on a sleeping target never consults auto-wake and persists inbox-only (#dept-roster)", async () => {
+    config.node = "local";
+    resolveTargetReturn = { type: "error", reason: "not_live", detail: "'ghost' found but no active session", hint: "maw wake ghost" };
+    shouldWakeReturn = { wake: true }; // would wake if (wrongly) consulted
+    defaultInboxResult = { ok: true, oracle: "ghost", inboxDir: "/tmp/inbox", path: "/tmp/inbox/msg.md", filename: "msg.md" };
+
+    await runCmd(() => cmdSend("local:ghost", "cold message", false, { inboxOnly: true }));
+
+    expect(exitCode).toBeUndefined();
+    expect(shouldWakeCalls).toHaveLength(0);
+    expect(sendKeysCalls).toEqual([]);
+    expect(defaultInboxCalls.length).toBeGreaterThan(0);
+  });
+
+  test("--inbox on an ACTIVE target skips pane injection but still persists (#dept-roster)", async () => {
+    config.node = "local";
+    resolveTargetReturn = { type: "local", target: "session:oracle.0" };
+    defaultInboxResult = { ok: true, oracle: "oracle", inboxDir: "/tmp/inbox", path: "/tmp/inbox/msg.md", filename: "msg.md" };
+
+    await runCmd(() => cmdSend("local:oracle", "live but quiet", false, { inboxOnly: true }));
+
+    expect(exitCode).toBeUndefined();
+    expect(sendKeysCalls).toEqual([]);
+    expect(shouldWakeCalls).toHaveLength(0);
+    expect(defaultInboxCalls.length).toBeGreaterThan(0);
+    expect(logs.join("\n")).toContain("--inbox requested; pane injection skipped");
+  });
+
   test("local auto-wake helper errors are best-effort and fall through to normal delivery", async () => {
     config.node = "local";
     resolveTargetReturn = { type: "local", target: "session:oracle.0" };

--- a/test/isolated/locate-impl-coverage.test.ts
+++ b/test/isolated/locate-impl-coverage.test.ts
@@ -296,4 +296,57 @@ describe("locate command implementation coverage", () => {
     expect(text).toContain("node:     m5 (this node)");
     expect(text).not.toContain("stale-remote");
   });
+
+  test("registered window seat resolves to its exact live window target", async () => {
+    // #dept-roster: a department seat (05-nntn:cookbook) is a WINDOW inside
+    // a parent session; registration in config.agents makes it first-class.
+    ghqResults = [null, null];
+    sessions = [
+      { name: "05-nntn", windows: [{ name: "nntn" }, { name: "cookbook" }, { name: "cookbook-dev" }] },
+    ];
+    resolved = { kind: "none" };
+    config = { node: "local", agents: { cookbook: "local" } };
+
+    const output = await capture(() => cmdLocate("cookbook", {}));
+    const text = output.logs.join("\n");
+
+    expect(text).toContain("session:  05-nntn (3 windows)");
+    expect(text).toContain("target:   05-nntn:cookbook (registered window seat)");
+    expect(text).toContain("node:     local (from config.agents)");
+  });
+
+  test("unregistered utility-pane window stays non-authoritative (not-found)", async () => {
+    // #dept-roster: a live window alone is NOT an identity — without
+    // config.agents registration, locate must not elevate it.
+    ghqResults = [null, null];
+    sessions = [
+      { name: "05-nntn", windows: [{ name: "cookbook" }, { name: "cookbook-dev" }] },
+    ];
+    resolved = { kind: "none" };
+    config = { node: "local", agents: { cookbook: "local" } };
+
+    await expect(cmdLocate("cookbook-dev", {})).rejects.toThrow("no oracle named 'cookbook-dev'");
+  });
+
+  test("window-seat resolution is exact-match only — no wrong-parent fuzzy hit", async () => {
+    // #dept-roster misroute regression: 'cookbook' must never resolve via a
+    // partial window match in an unrelated session, and a registered name
+    // with no exact window anywhere resolves to nothing (not a parent).
+    ghqResults = [null, null];
+    sessions = [
+      { name: "05-nntn", windows: [{ name: "cookbook-view" }, { name: "nntn" }] },
+    ];
+    resolved = { kind: "none" };
+    config = { node: "local", agents: { cookbook: "local" } };
+    // config.agents feeds the manifest in the real loader — mirror that here
+    // so resolvability comes from registration, not from a window guess.
+    manifestEntries = [{ name: "cookbook", sources: ["agent"], node: "local", isLive: false }];
+
+    const output = await capture(() => cmdLocate("cookbook", {}));
+    const text = output.logs.join("\n");
+
+    // Registered (agent source keeps it resolvable) but NO live target claimed.
+    expect(text).not.toContain("target:");
+    expect(text).not.toContain("session:  05-nntn");
+  });
 });


### PR DESCRIPTION
## Summary

Source-owned recovery of two behaviors, replayed onto a freshly-resolved `alpha`
(`5ee396a7`). Both keep `src/cli.ts` as the real TypeScript entry so the change
reaches the built CLI through the normal `bun build src/cli.ts → dist/maw`
pipeline — no bundle overwrite.

- **`fix(locate)`** — resolve registered window seats to their exact live window
  target (`src/vendor/mpr-plugins/locate/impl.ts`).
- **`fix(hey) --inbox`** — `--inbox` is persist-only: never auto-wake or create a
  session (`src/commands/shared/comm-send.ts`).

These originate from same-day repairs (2026-08-19) that were applied as an
installed-copy patch to a live bundle and never committed as source. This PR
reconstructs them as proper source changes.

## Evidence

- **Source → built-CLI lineage proven** via mutation test: a marker edit in a
  source `wake-cmd` path changes the built `dist/maw`, and reverting restores the
  exact baseline artifact hash (deterministic, reversible).
- **Targeted behavior tests: 29/29 pass** — `test/isolated/locate-impl-coverage`
  (13) + `test/isolated/comm-send-thirteenth-pass-coverage` (16). (These live in
  `test/isolated/`, excluded from the default sweep by design; run explicitly.)
- **Default owner suite: no regression vs base.** The 3 failing tests in
  `test/core/consent` reproduce on the unmodified base and are
  environment-sensitive (legacy-config path resolution), not introduced by this
  change.

## Scope

This PR covers **2 of 3** behaviors from the 2026-08-19 work. The third —
**persistent fleet launch binding** — is intentionally left as a **separate
follow-up**: it depends on a `src/core/fleet/runtime-state.ts` foundation that
does not exist on `alpha`, so it needs an upstream-compatible redesign rather
than a replay. It is not a clean cherry-pick and is out of scope here.

Opened as **draft** for review.
