### PR TITLE
feat(wake): recover fleet-child windows by bare name — reader side (#dept-roster D-5)

### DIFF
--- a/src/commands/shared/wake-cmd.ts
+++ b/src/commands/shared/wake-cmd.ts
@@ -30,6 +30,7 @@ import {
   type SnapshotSession,
 } from "../../core/fleet/snapshot";
 import type { FleetSession } from "./fleet-load";
+import { isFleetRuntimeIdentity, isResumableEngine, buildFleetWindowResumeCommand } from "../../core/fleet/runtime-state";
 import { listClaudeSessions, type ClaudeSession } from "../../core/fleet/claude-sessions";
 import { UserError } from "../../core/util/user-error";
 import {
@@ -1016,6 +1017,95 @@ export function shouldMarkWakeInboxRead(opts: Pick<WakeOptions, "dryRun" | "list
   return env.MAW_ATTACH_FOLLOWS === "1" && !opts.dryRun && !opts.listWt;
 }
 
+async function loadWakeFleetSessions(): Promise<FleetSession[]> {
+  try {
+    const { loadFleet } = await import("./fleet-load");
+    return loadFleet();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith("invalid fleet JSON ")) throw error;
+    // Isolated tests may mock the SDK facade narrowly and omit fleet constants.
+    // Fleet metadata is an optimization for exact bare-name targets, so a load
+    // failure falls back to the normal resolver path rather than breaking wake.
+    // Malformed readable fleet files are rethrown above so corrupt JSON cannot
+    // silently reroute wake.
+    return [];
+  }
+}
+
+// Recover an exact fleet-child window by its bare name. Returns the resolved
+// target when it resumed a captured session, or null to fall through to the
+// normal wake flow. Only a window carrying a *valid* recoverable runtime
+// identity is resumed; an absent record falls through silently, and an
+// incomplete one falls through with a warning — recovery is an optimization and
+// must never break an ordinary wake.
+async function recoverExactFleetChildWindow(
+  requestedTarget: string,
+  opts: WakeOptions,
+): Promise<string | null> {
+  const matches = (await loadWakeFleetSessions()).flatMap((session) =>
+    session.windows
+      .filter((window) => window.name === requestedTarget)
+      .map((window) => ({ session, window })));
+  if (matches.length === 0) return null;
+  if (matches.length > 1) {
+    throw new UserError(`fleet child target is ambiguous: ${requestedTarget}`);
+  }
+  const match = matches[0]!;
+  if (!isFleetRuntimeIdentity(match.window.runtime)) {
+    if (match.window.runtime !== undefined) {
+      console.warn(`\x1b[33mwarn\x1b[0m: fleet child ${match.session.name}:${match.window.name} has an incomplete runtime record; falling back to a normal wake`);
+    }
+    return null;
+  }
+  const runtime = match.window.runtime;
+  // Resumable-engine gate BEFORE any tmux mutation: a well-formed record for an
+  // engine we cannot resume (e.g. a future 'gemini') must fall through to a
+  // normal wake, never create a session/window that would then be abandoned.
+  if (!isResumableEngine(runtime.engine)) {
+    console.warn(`\x1b[33mwarn\x1b[0m: fleet child ${match.session.name}:${match.window.name} names an unsupported recoverable engine '${runtime.engine}'; falling back to a normal wake`);
+    return null;
+  }
+  if (opts.fresh || opts.task || opts.wt || opts.incubate || opts.repoPath || opts.urlRepoName) {
+    throw new UserError(`fleet child recovery does not accept fresh/worktree overrides for ${match.session.name}:${match.window.name}`);
+  }
+  if (opts.engine && opts.engine !== runtime.engine) {
+    throw new UserError(`fleet child recovery engine mismatch: state=${runtime.engine}, requested=${opts.engine}`);
+  }
+
+  const target = `${match.session.name}:${match.window.name}`;
+  const sessionExists = await tmux.hasSession(match.session.name);
+  const windows = sessionExists ? await tmux.listWindows(match.session.name) : [];
+  const windowExists = windows.some((window) => window.name === match.window.name);
+
+  if (opts.dryRun) {
+    console.log(`\x1b[90mdry-run — would recover ${target} with ${runtime.engine} session ${runtime.nativeSessionId}\x1b[0m`);
+    return target;
+  }
+  if (windowExists) {
+    console.log(`\x1b[36m→\x1b[0m fleet child window already exists: ${target}; recovery not injected into an existing pane`);
+    if (opts.attach) {
+      await tmux.selectWindow(target);
+      await wakeSession.attachToSession(match.session.name);
+    }
+    return target;
+  }
+  if (sessionExists) {
+    await tmux.newWindow(match.session.name, match.window.name, { cwd: runtime.cwd });
+  } else {
+    await tmux.newSession(match.session.name, { window: match.window.name, cwd: runtime.cwd });
+  }
+  const command = buildFleetWindowResumeCommand(runtime, opts.prompt);
+  await tmux.sendText(target, command);
+  if (opts.wait) await wakeSession.waitForEngine(target, getPaneInfos, isAgentCommand);
+  console.log(`\x1b[32m↻\x1b[0m recovered ${target} from ${runtime.engine} session ${runtime.nativeSessionId}`);
+  if (opts.attach) {
+    await tmux.selectWindow(target);
+    await wakeSession.attachToSession(match.session.name);
+  }
+  return target;
+}
+
 export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string> {
   // Canonicalize the bare name before any lookup — strips trailing `/`, `/.git`, `/.git/`
   // so `maw wake token-oracle/` (tab-completion artifact) resolves the same as `token-oracle`.
@@ -1036,6 +1126,14 @@ export async function cmdWake(oracle: string, opts: WakeOptions): Promise<string
   }
 
   const requestedTarget = oracle;
+
+  // Fleet-child recovery (#dept-roster D-5): an exact bare-name wake for a fleet
+  // window carrying a valid recoverable runtime identity resumes that seat's
+  // captured session — restoring the launch cwd/env when present — instead of a
+  // fresh launch. Absent or incomplete runtime falls through to the normal flow.
+  const recoveredFleetChild = await recoverExactFleetChildWindow(requestedTarget, opts);
+  if (recoveredFleetChild) return recoveredFleetChild;
+
   const parsed = parseWakeTarget(oracle);
   let parsedRepoPath: string | null = null;
   if (parsed) {

--- a/src/core/fleet/fleet-load-core.ts
+++ b/src/core/fleet/fleet-load-core.ts
@@ -5,6 +5,33 @@ import { fleetDirForWrite as coreFleetDirForWrite, fleetDirsForRead as coreFleet
 export interface FleetWindow {
   name: string;
   repo: string;
+  /** Recoverable runtime identity captured for this window (#dept-roster D-5).
+   *  Present only for windows whose session was captured for resume; absent
+   *  windows fall through to a normal fresh wake. */
+  runtime?: FleetRuntimeIdentity;
+}
+
+/** A window's captured engine session, enough to resume it after a reboot. */
+export interface FleetRuntimeIdentity {
+  engine: string;
+  cwd: string;
+  nativeSessionId: string;
+  capturedAt: string;
+  /** Optional persistent launch binding: what recovery must restore beyond a
+   *  bare `cd <cwd> && <engine> resume` — a ratified workRoot and a dedicated
+   *  env (e.g. CODEX_HOME). Absent on legacy captures; recovery then behaves
+   *  exactly as before. */
+  launch?: FleetRuntimeLaunchBinding;
+}
+
+export interface FleetRuntimeLaunchBinding {
+  /** Ratified workRoot to recover into; overrides the captured cwd. */
+  cwd?: string;
+  /** Env exported ahead of the resume command (e.g. CODEX_HOME). */
+  env?: Record<string, string>;
+  /** Canonical fresh-launch argv for wake paths that start a new process
+   *  instead of resuming; stored for those consumers. */
+  argv?: string[];
 }
 
 export interface FleetSession {

--- a/src/core/fleet/runtime-state.ts
+++ b/src/core/fleet/runtime-state.ts
@@ -1,0 +1,85 @@
+import type { FleetRuntimeIdentity } from "./fleet-load-core";
+
+// Fleet-child runtime recovery — reader side (#dept-roster D-5).
+//
+// Consumes the `runtime` (and optional `runtime.launch`) record that a captured
+// fleet window carries, so an exact bare-name wake can resume that seat's
+// session and restore its ratified workRoot + dedicated env instead of a fresh
+// launch. Writing the record is a separate concern and lives elsewhere.
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/** Engines whose captured session this reader knows how to resume. A record for
+ *  any other engine is well-formed but not resumable — callers must fall through
+ *  to a normal wake rather than start creating panes for it. */
+export function isResumableEngine(engine: string): boolean {
+  const normalized = engine.toLowerCase();
+  return normalized === "codex" || normalized === "claude";
+}
+
+/** A launch binding is valid when every present field is well-formed. Absent
+ *  (undefined) is valid — legacy windows simply have no binding. */
+export function isValidLaunchBinding(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const launch = value as Record<string, unknown>;
+  if (launch.cwd !== undefined
+    && (typeof launch.cwd !== "string" || !launch.cwd.startsWith("/"))) return false;
+  if (launch.env !== undefined) {
+    if (!launch.env || typeof launch.env !== "object" || Array.isArray(launch.env)) return false;
+    for (const [key, val] of Object.entries(launch.env)) {
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) || typeof val !== "string") return false;
+    }
+  }
+  if (launch.argv !== undefined
+    && (!Array.isArray(launch.argv)
+      || launch.argv.length === 0
+      || launch.argv.some((word) => typeof word !== "string" || word.length === 0))) return false;
+  return true;
+}
+
+/** True only when the record carries everything needed to resume the session.
+ *  A partial or absent record is not recoverable — callers fall through to a
+ *  normal fresh wake rather than guessing. */
+export function isFleetRuntimeIdentity(value: unknown): value is FleetRuntimeIdentity {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const runtime = value as Partial<FleetRuntimeIdentity>;
+  return typeof runtime.engine === "string"
+    && /^[A-Za-z0-9_.:-]+$/.test(runtime.engine)
+    && typeof runtime.cwd === "string"
+    && runtime.cwd.startsWith("/")
+    && typeof runtime.nativeSessionId === "string"
+    && runtime.nativeSessionId.trim().length > 0
+    && typeof runtime.capturedAt === "string"
+    && Number.isFinite(Date.parse(runtime.capturedAt))
+    && isValidLaunchBinding(runtime.launch);
+}
+
+/** Build the shell command that resumes a captured fleet window. When a launch
+ *  binding is present its cwd overrides the captured cwd and its env is exported
+ *  ahead of the resume command; without one the output is the bare
+ *  `cd <cwd> && <engine> resume <id>` (byte-identical to legacy behavior). */
+export function buildFleetWindowResumeCommand(
+  runtime: FleetRuntimeIdentity,
+  prompt?: string,
+): string {
+  if (!isFleetRuntimeIdentity(runtime)) throw new Error("invalid recoverable runtime identity");
+  const engine = runtime.engine.toLowerCase();
+  const resume = engine === "codex"
+    ? `codex resume ${shellQuote(runtime.nativeSessionId)}`
+    : engine === "claude"
+      ? `claude --resume ${shellQuote(runtime.nativeSessionId)}`
+      : null;
+  if (!resume) throw new Error(`unsupported recoverable engine '${runtime.engine}'`);
+  const withPrompt = prompt?.trim() ? `${resume} ${shellQuote(prompt.trim())}` : resume;
+  const launch = runtime.launch;
+  const cwd = launch?.cwd ?? runtime.cwd;
+  const envPrefix = launch?.env && Object.keys(launch.env).length > 0
+    ? Object.entries(launch.env)
+      .map(([key, val]) => `${key}=${shellQuote(val)}`)
+      .join(" ") + " "
+    : "";
+  return `cd ${shellQuote(cwd)} && ${envPrefix}${withPrompt}`;
+}

--- a/test/isolated/fleet-child-recovery-cli-boundary.test.ts
+++ b/test/isolated/fleet-child-recovery-cli-boundary.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Fleet-child recovery — PARTIAL external-boundary evidence (#dept-roster D-5).
+ *
+ * Spawns the real `maw wake <bare-name> --dry-run` process (through src/cli.ts,
+ * the actual entry point) against a scratch MAW_HOME fleet, with a fake `tmux`
+ * on PATH so no live tmux is touched. It proves the recovery DECISION engages at
+ * the real CLI entry (bare-name routing, record read, engine gate) as an
+ * external process.
+ *
+ * It is deliberately PARTIAL, not full same-interface proof:
+ *   - --dry-run stops before the tmux send-keys injection, so the exact injected
+ *     command bytes and a live child's cwd/env are NOT asserted here.
+ *   - These tests assert on stdout/stderr only, NOT the process exit code: a
+ *     manual non-dry-run hostile run exits rc=1 because after a correct
+ *     fallthrough the normal wake path reaches a missing-repo clone in this
+ *     sandbox — expected here, but it means exit-code is not evidence.
+ *   - send-keys bytes and live-child env/cwd remain INCONCLUSIVE and are the
+ *     live-reconcile canary, kept closed in this non-live worktree.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from "fs";
+import { join, dirname } from "path";
+import { tmpdir } from "os";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const CLI = join(REPO_ROOT, "src", "cli.ts");
+const BUN = process.execPath;
+
+let scratch: string;
+let env: Record<string, string>;
+
+function runWake(name: string): { stdout: string; stderr: string; code: number } {
+  const res = Bun.spawnSync([BUN, CLI, "wake", name, "--dry-run"], { env, stdout: "pipe", stderr: "pipe" });
+  return {
+    stdout: res.stdout.toString(),
+    stderr: res.stderr.toString(),
+    code: res.exitCode ?? -1,
+  };
+}
+
+beforeAll(() => {
+  scratch = mkdtempSync(join(tmpdir(), "maw-src03-cli-"));
+  const fleetDir = join(scratch, "fleet");
+  const fakebin = join(scratch, "bin");
+  mkdirSync(fleetDir, { recursive: true });
+  mkdirSync(fakebin, { recursive: true });
+
+  const tmuxShim = join(fakebin, "tmux");
+  writeFileSync(tmuxShim, "#!/bin/sh\ncase \"$1\" in\n  -V) echo 'tmux 3.4' ;;\n  has-session) exit 1 ;;\n  *) exit 0 ;;\nesac\n", "utf-8");
+  chmodSync(tmuxShim, 0o755);
+
+  writeFileSync(join(fleetDir, "25-cookbook.json"), JSON.stringify({
+    name: "25-cookbook",
+    windows: [{
+      name: "cookbook",
+      repo: "org/nntn-cookbook",
+      runtime: {
+        engine: "codex", cwd: "/tmp/captured-cwd", nativeSessionId: "sess-abc",
+        capturedAt: "2026-08-19T21:10:00.000Z",
+        launch: { cwd: "/tmp/ratified-root", env: { CODEX_HOME: "/tmp/codex-home" }, argv: ["codex", "resume"] },
+      },
+    }],
+  }, null, 2) + "\n", "utf-8");
+
+  writeFileSync(join(fleetDir, "99-probe.json"), JSON.stringify({
+    name: "99-probe",
+    windows: [{
+      name: "gemini-seat", repo: "org/probe",
+      runtime: { engine: "gemini", cwd: "/tmp/x", nativeSessionId: "s", capturedAt: "2026-08-19T21:10:00.000Z" },
+    }],
+  }, null, 2) + "\n", "utf-8");
+
+  writeFileSync(join(fleetDir, "07-plain.json"), JSON.stringify({
+    name: "07-plain",
+    windows: [{ name: "plain-seat", repo: "org/plain" }], // no runtime
+  }, null, 2) + "\n", "utf-8");
+
+  env = {
+    PATH: `${fakebin}:${dirname(BUN)}:/usr/bin:/bin`,
+    HOME: scratch,
+    MAW_HOME: scratch,
+    MAW_NO_PROMPT: "1",
+  };
+});
+
+afterAll(() => rmSync(scratch, { recursive: true, force: true }));
+
+describe("maw wake <bare> --dry-run — CLI boundary", () => {
+  test("POS: a recoverable fleet child resumes its captured session", () => {
+    const { stdout, stderr } = runWake("cookbook");
+    const out = stdout + stderr;
+    // recovery engaged at the real entry point and read the record
+    expect(out).toContain("would recover 25-cookbook:cookbook");
+    expect(out).toContain("codex session sess-abc");
+  });
+
+  test("NEG: an unsupported engine warns and does not recover", () => {
+    const { stdout, stderr } = runWake("gemini-seat");
+    const out = stdout + stderr;
+    expect(out).toContain("unsupported recoverable engine 'gemini'");
+    expect(out).not.toContain("would recover 99-probe");
+  });
+
+  test("NEG: a window with no runtime does not recover", () => {
+    const { stdout, stderr } = runWake("plain-seat");
+    const out = stdout + stderr;
+    expect(out).not.toContain("would recover 07-plain");
+  });
+});

--- a/test/isolated/fleet-child-recovery-e2e.test.ts
+++ b/test/isolated/fleet-child-recovery-e2e.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Fleet-child recovery — IN-PROCESS COMPONENT test (#dept-roster D-5).
+ *
+ * This imports `cmdWake` directly and mocks the fleet loader + tmux transport,
+ * so per runtime-change-loop.md rule 3 it is component-level evidence, NOT a
+ * same-interface proof: it exercises the recovery decision and command
+ * construction in-process, but does not cross the real CLI/launcher boundary.
+ * The external-boundary companion is fleet-child-recovery-cli-boundary.test.ts.
+ *
+ *   POS  cmdWake("cookbook")     (runtime+launch) → resumes, injecting a command
+ *                                that carries launch.env + launch.cwd.
+ *   NEG  cmdWake("cookbook-dev") (no runtime)     → falls through to the normal
+ *                                wake flow, never throwing a recovery error.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "path";
+
+const CAPTURED_AT = "2026-08-19T21:10:00.000Z";
+
+let fleetSessions: any[] = [];
+const sentText: { target: string; text: string }[] = [];
+const newSessions: { name: string; opts: any }[] = [];
+
+function resetCaptures() {
+  sentText.length = 0;
+  newSessions.length = 0;
+}
+
+// Delegate to the real modules and override only the boundaries we control, so
+// unrelated exports of these facades keep resolving for transitive importers.
+const _realSdk = await import("../../src/sdk");
+const _realFleetLoad = await import("../../src/commands/shared/fleet-load");
+const _realWakeTarget = await import("../../src/commands/shared/wake-target");
+
+// --- mock the tmux transport (the external boundary) ---
+mock.module(join(import.meta.dir, "../../src/sdk"), () => ({
+  ..._realSdk,
+  tmux: {
+    ..._realSdk.tmux,
+    hasSession: async () => false,
+    listWindows: async () => [],
+    newSession: async (name: string, opts: any) => { newSessions.push({ name, opts }); return name; },
+    newWindow: async () => {},
+    sendText: async (target: string, text: string) => { sentText.push({ target, text }); },
+    selectWindow: async () => {},
+  },
+}));
+
+// --- mock the fleet loader (the persistence boundary) ---
+mock.module(join(import.meta.dir, "../../src/commands/shared/fleet-load"), () => ({
+  ..._realFleetLoad,
+  loadFleet: () => fleetSessions,
+}));
+
+// --- NEG proof: make the first normal-wake step observable with a sentinel ---
+const SENTINEL = "SENTINEL_reached_normal_wake";
+mock.module(join(import.meta.dir, "../../src/commands/shared/wake-target"), () => ({
+  ..._realWakeTarget,
+  parseWakeTarget: () => { throw new Error(SENTINEL); },
+}));
+
+const { cmdWake } = await import("../../src/commands/shared/wake-cmd");
+
+beforeEach(resetCaptures);
+
+describe("maw wake <bare-name> — fleet-child recovery (POS)", () => {
+  test("cookbook (runtime+launch) resumes with launch.env exported and launch.cwd overriding captured cwd", async () => {
+    fleetSessions = [{
+      name: "25-cookbook",
+      windows: [{
+        name: "cookbook",
+        repo: "org/nntn-cookbook",
+        runtime: {
+          engine: "codex",
+          cwd: "/Users/x/tt3p/product-hub/nntn-cookbook",
+          nativeSessionId: "sess-abc",
+          capturedAt: CAPTURED_AT,
+          launch: {
+            cwd: "/Users/x/tt3p/ratified-root",
+            env: { CODEX_HOME: "/Users/x/.codex-cookbook" },
+            argv: ["codex", "resume"],
+          },
+        },
+      }],
+    }];
+
+    const target = await cmdWake("cookbook", {});
+    expect(target).toBe("25-cookbook:cookbook");
+
+    // the session was created at the captured cwd
+    expect(newSessions).toHaveLength(1);
+    expect(newSessions[0]!.opts.cwd).toBe("/Users/x/tt3p/product-hub/nntn-cookbook");
+
+    // the injected command carries env + ratified workRoot + resume
+    expect(sentText).toHaveLength(1);
+    const cmd = sentText[0]!.text;
+    expect(cmd).toContain("cd '/Users/x/tt3p/ratified-root'");
+    expect(cmd).toContain("CODEX_HOME='/Users/x/.codex-cookbook'");
+    expect(cmd).toContain("codex resume 'sess-abc'");
+  });
+});
+
+describe("maw wake <bare-name> — fallthrough (NEG, regression guard)", () => {
+  test("cookbook-dev (no runtime) falls through to normal wake, never a recovery error", async () => {
+    fleetSessions = [{
+      name: "05-nntn",
+      windows: [{ name: "cookbook-dev" }], // no repo, no runtime — Riddler's class-3-no-repo row
+    }];
+
+    // Falling through reaches the normal wake flow, whose first step throws our
+    // sentinel. A recovery "refusing"/"ambiguous" error would fail this instead.
+    await expect(cmdWake("cookbook-dev", {})).rejects.toThrow(SENTINEL);
+    // no resume command was injected
+    expect(sentText).toHaveLength(0);
+  });
+
+  test("partial runtime ({engine} only) also falls through, not a throw", async () => {
+    fleetSessions = [{
+      name: "14-wallent",
+      windows: [{ name: "finance-oracle", repo: "org/finance", runtime: { engine: "codex" } }],
+    }];
+
+    await expect(cmdWake("finance-oracle", {})).rejects.toThrow(SENTINEL);
+    expect(sentText).toHaveLength(0);
+  });
+
+  test("a well-formed record for an unsupported engine falls through WITHOUT creating any tmux session/window (no abandoned pane)", async () => {
+    // Hostile probe: 'gemini' passes shape validation but cannot be resumed.
+    fleetSessions = [{
+      name: "99-probe",
+      windows: [{
+        name: "gemini-seat",
+        repo: "org/probe",
+        runtime: {
+          engine: "gemini",
+          cwd: "/Users/x/tt3p/probe",
+          nativeSessionId: "sess-xyz",
+          capturedAt: CAPTURED_AT,
+        },
+      }],
+    }];
+
+    await expect(cmdWake("gemini-seat", {})).rejects.toThrow(SENTINEL);
+    // the critical assertion: recovery bailed BEFORE any tmux mutation
+    expect(newSessions).toHaveLength(0);
+    expect(sentText).toHaveLength(0);
+  });
+});

--- a/test/isolated/fleet-runtime-state-coverage.test.ts
+++ b/test/isolated/fleet-runtime-state-coverage.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Fleet-child runtime recovery — reader-side component coverage (#dept-roster D-5).
+ *
+ * Fixtures mirror the shape classes observed in real ~/.maw/fleet/*.json rows:
+ *   class 1  runtime + launch      (e.g. cookbook)
+ *   class 2a runtime, no launch    (e.g. nntn-codex)     — valid, resumable
+ *   class 2b partial runtime       (e.g. finance-oracle) — {engine} only, NOT resumable
+ *   class 3  no runtime            (e.g. cookbook-dev)   — absent, NOT resumable
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  isFleetRuntimeIdentity,
+  isValidLaunchBinding,
+  isResumableEngine,
+  buildFleetWindowResumeCommand,
+} from "../../src/core/fleet/runtime-state";
+import type { FleetRuntimeIdentity } from "../../src/core/fleet/fleet-load-core";
+import { loadFleet } from "../../src/core/fleet/fleet-load-core";
+import { ensureFleetSessionEntry } from "../../src/commands/shared/fleet-ensure";
+
+const CAPTURED_AT = "2026-08-19T21:10:00.000Z";
+
+const cls1: FleetRuntimeIdentity = {
+  engine: "codex",
+  cwd: "/Users/x/tt3p/product-hub/nntn-cookbook",
+  nativeSessionId: "sess-abc",
+  capturedAt: CAPTURED_AT,
+  launch: {
+    cwd: "/Users/x/tt3p/ratified-root",
+    env: { CODEX_HOME: "/Users/x/.codex-cookbook", OMX_ROOT: "/Users/x/omx" },
+    argv: ["codex", "--home", "/Users/x/.codex-cookbook", "resume"],
+  },
+};
+const cls2a: FleetRuntimeIdentity = {
+  engine: "codex",
+  cwd: "/Users/x/tt3p/product-hub/nntn-cookbook",
+  nativeSessionId: "sess-def",
+  capturedAt: CAPTURED_AT,
+};
+const cls2b = { engine: "codex" } as unknown; // partial: {engine} only
+
+describe("isFleetRuntimeIdentity — class matrix", () => {
+  test("class 1 (runtime+launch) is recoverable", () => {
+    expect(isFleetRuntimeIdentity(cls1)).toBe(true);
+  });
+  test("class 2a (runtime, no launch) is recoverable", () => {
+    expect(isFleetRuntimeIdentity(cls2a)).toBe(true);
+  });
+  test("class 2b (partial {engine}) is NOT recoverable", () => {
+    expect(isFleetRuntimeIdentity(cls2b)).toBe(false);
+  });
+  test("class 3 (absent) is NOT recoverable", () => {
+    expect(isFleetRuntimeIdentity(undefined)).toBe(false);
+  });
+  test("runtime with an invalid launch binding is NOT recoverable", () => {
+    expect(isFleetRuntimeIdentity({ ...cls2a, launch: { cwd: "relative" } })).toBe(false);
+  });
+});
+
+describe("buildFleetWindowResumeCommand", () => {
+  test("class 1: launch.cwd overrides captured cwd and launch.env is exported ahead", () => {
+    const cmd = buildFleetWindowResumeCommand(cls1);
+    // launch.cwd wins over runtime.cwd
+    expect(cmd).toContain("cd '/Users/x/tt3p/ratified-root'");
+    expect(cmd).not.toContain("nntn-cookbook");
+    // env exported ahead of the resume command
+    expect(cmd).toContain("CODEX_HOME='/Users/x/.codex-cookbook'");
+    expect(cmd).toContain("OMX_ROOT='/Users/x/omx'");
+    expect(cmd).toContain("codex resume 'sess-abc'");
+    // ordering: cd ... && <env prefix> codex resume
+    expect(cmd).toMatch(/^cd '[^']+' && CODEX_HOME=.* codex resume 'sess-abc'$/);
+  });
+
+  test("class 2a: no launch → byte-identical legacy resume string (golden)", () => {
+    const cmd = buildFleetWindowResumeCommand(cls2a);
+    expect(cmd).toBe("cd '/Users/x/tt3p/product-hub/nntn-cookbook' && codex resume 'sess-def'");
+  });
+
+  test("prompt is appended and shell-quoted", () => {
+    const cmd = buildFleetWindowResumeCommand(cls2a, "resume please");
+    expect(cmd).toBe("cd '/Users/x/tt3p/product-hub/nntn-cookbook' && codex resume 'sess-def' 'resume please'");
+  });
+
+  test("claude engine resumes with --resume", () => {
+    const cmd = buildFleetWindowResumeCommand({ ...cls2a, engine: "claude" });
+    expect(cmd).toBe("cd '/Users/x/tt3p/product-hub/nntn-cookbook' && claude --resume 'sess-def'");
+  });
+
+  test("throws on an invalid identity rather than emitting a bad command", () => {
+    expect(() => buildFleetWindowResumeCommand(cls2b as FleetRuntimeIdentity)).toThrow();
+  });
+});
+
+describe("isValidLaunchBinding — G5 validation", () => {
+  test("undefined (legacy, no binding) is valid", () => {
+    expect(isValidLaunchBinding(undefined)).toBe(true);
+  });
+  test("a fully-formed binding is valid", () => {
+    expect(isValidLaunchBinding(cls1.launch)).toBe(true);
+  });
+  test("relative launch.cwd is rejected", () => {
+    expect(isValidLaunchBinding({ cwd: "relative/path" })).toBe(false);
+  });
+  test("env key not matching a shell identifier is rejected", () => {
+    expect(isValidLaunchBinding({ env: { "1BAD": "x" } })).toBe(false);
+  });
+  test("non-string env value is rejected", () => {
+    expect(isValidLaunchBinding({ env: { K: 5 } })).toBe(false);
+  });
+  test("empty argv is rejected", () => {
+    expect(isValidLaunchBinding({ argv: [] })).toBe(false);
+  });
+  test("argv containing an empty string is rejected", () => {
+    expect(isValidLaunchBinding({ argv: ["ok", ""] })).toBe(false);
+  });
+  test("array (not an object) is rejected", () => {
+    expect(isValidLaunchBinding([])).toBe(false);
+  });
+});
+
+describe("isResumableEngine — recovery is only attempted for engines we can resume", () => {
+  test.each(["codex", "claude", "CODEX", "Claude"])("resumable: %s", (e) => {
+    expect(isResumableEngine(e)).toBe(true);
+  });
+  test.each(["gemini", "gpt", "bash", "zsh", ""])("not resumable: %s", (e) => {
+    expect(isResumableEngine(e)).toBe(false);
+  });
+});
+
+describe("migration: real fleet writer preserves runtime.launch (load→write→reload)", () => {
+  const scratch = mkdtempSync(join(tmpdir(), "maw-src03-mig-"));
+  afterAll(() => rmSync(scratch, { recursive: true, force: true }));
+
+  test("adding a sibling window via ensureFleetSessionEntry does not drop an existing window's runtime.launch", () => {
+    const fleetDir = join(scratch, "fleet");
+    mkdirSync(fleetDir, { recursive: true });
+    // A real fleet file: window 'cookbook' carries runtime+launch.
+    const session = {
+      name: "25-cookbook",
+      windows: [{ name: "cookbook", repo: "org/nntn-cookbook", runtime: cls1 }],
+    };
+    const fleetFile = join(fleetDir, "25-cookbook.json");
+    writeFileSync(fleetFile, JSON.stringify(session, null, 2) + "\n", "utf-8");
+
+    // A ghq layout so the writer can derive a repo for the new sibling window.
+    const ghqRoot = join(scratch, "ghq");
+    const newRepoCwd = join(ghqRoot, "github.com", "org", "sibling-repo");
+    mkdirSync(newRepoCwd, { recursive: true });
+
+    const result = ensureFleetSessionEntry(
+      { session: "25-cookbook", window: "sibling", cwd: newRepoCwd, createdBy: "test" },
+      {
+        fleetDirsForRead: () => [fleetDir],
+        fleetDirForWrite: () => fleetDir,
+        getGhqRoot: () => ghqRoot,
+      },
+    );
+    expect(result.status).toBe("updated"); // the writer actually rewrote the file
+
+    // Reload through the real loader and prove the original binding survived.
+    const reloaded = loadFleet([fleetDir]);
+    const cookbookWin = reloaded
+      .flatMap((s) => s.windows)
+      .find((w) => w.name === "cookbook");
+    expect(cookbookWin?.runtime).toEqual(cls1);
+    expect(isFleetRuntimeIdentity(cookbookWin?.runtime)).toBe(true);
+    // and the sibling was added
+    expect(reloaded.flatMap((s) => s.windows).some((w) => w.name === "sibling")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`maw wake <bare-name>` now recovers a fleet-child window when its fleet record
carries a valid recoverable runtime identity: it resumes that seat's captured
engine session and restores its ratified workRoot + dedicated env (e.g.
`CODEX_HOME`) instead of a fresh launch.

This is the **reader/consume side only** — it reads the `runtime` /
`runtime.launch` record that live fleet files already carry. Capturing/writing
that record is a separate concern and is **not** in this PR.

## Behavior by record class

Measured against the shape classes seen in real fleet files:

| record | behavior |
| --- | --- |
| runtime + launch | resume with `launch.cwd` override + `launch.env` prefix |
| runtime, no launch | legacy `cd <cwd> && <engine> resume <id>` (unchanged) |
| partial runtime (e.g. `{engine}` only) | warn + fall through to a normal wake |
| unsupported engine (e.g. `gemini`) | warn + fall through **before** any tmux mutation |
| no runtime | fall through to a normal wake |

Recovery is a strict optimization: only a valid, resumable identity is resumed;
every other case falls through rather than throwing, so an incomplete/absent
record can never break an ordinary wake, and a non-resumable engine never leaves
an abandoned pane.

## Evidence

- **Component matrix** — validation, resume-command construction, the resumable
  engine gate, and a golden legacy string across all record classes.
- **Migration** — a real load → writer (`ensureFleetSessionEntry`) → reload
  proves an existing window's `runtime.launch` survives a sibling write.
- **Mutation proof** — reverting the launch-consuming hunk fails exactly the
  launch tests while the no-launch golden is unchanged; restoring is green.
- **External boundary (partial)** — `maw wake <name> --dry-run` as a real
  process proves the recovery decision engages at the CLI (bare-name routing,
  record read, engine gate). This asserts stdout only, not the exit code.
- Default owner suite: **2466 pass / 3 fail (canonical)**; the 3 failures
  reproduce on the unmodified base (environment-sensitive consent tests) and are
  not introduced by this change.

## Declared scope / non-goals

- **`launch.argv` is preserved and validated but not consumed** here. Consuming
  argv belongs to a fresh-launch path, which is outside this reader.
- The exact injected send-keys command bytes and a live child's cwd/env are
  **not** asserted (that needs a live tmux) — deferred as a separate
  integration check.
- No writer/capture of the record; no local deployment.

Opened as **draft** for review.
