### PR TITLE
fix(comm): pin resolveMyName to $TMUX_PANE + strip -oracle suffix

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -81,13 +81,22 @@ export async function resolveOraclePane(
 /** @internal */
 export function resolveMyName(config: ReturnType<typeof loadConfig>): string {
   if (process.env.CLAUDE_AGENT_NAME) return process.env.CLAUDE_AGENT_NAME;
-  // Only trust tmux when this process is actually running inside a tmux pane.
-  // Outside tmux, `tmux display-message` can still succeed by reporting the
-  // server's current/last-active session, which misattributes sender envelopes.
-  if (process.env.TMUX) {
+  // Only trust tmux when this process is actually running inside a tmux pane,
+  // and pin the query to that pane. An unpinned `display-message` resolves
+  // against the most recently active *client*, so under a multi-client server
+  // a call still misattributed to whatever session the user last touched
+  // (mac-tor 2026-08: zyn signing as underdog for ~30 days). $TMUX alone is
+  // not enough — the env survives into detached/hook subprocesses.
+  const pane = process.env.TMUX_PANE;
+  if (process.env.TMUX && pane) {
     try {
-      const tmuxSession = require("child_process").execSync("tmux display-message -p '#{session_name}'", { encoding: "utf-8" }).trim();
-      if (tmuxSession) return tmuxSession.replace(/^\d+-/, "");
+      const tmuxSession = require("child_process").execSync(
+        `tmux display-message -p -t '${pane.replace(/'/g, "")}' '#{session_name}'`,
+        { encoding: "utf-8" },
+      ).trim();
+      // "08-mawjs" → "mawjs"; "underdog-oracle" → "underdog" (sign as the
+      // oracle short name, matching the `agents` registry keys).
+      if (tmuxSession) return tmuxSession.replace(/^\d+-/, "").replace(/-oracle$/, "");
     } catch {}
   }
   return config.node || "cli";

--- a/test/comm-send-default.test.ts
+++ b/test/comm-send-default.test.ts
@@ -166,6 +166,22 @@ describe("resolveMyName — environment attribution", () => {
 
     expect(resolveMyName({ node: "m5" } as never)).toBe("mawjs-codex");
   });
+
+  test("without $TMUX_PANE falls back to config.node — never guesses from the active client", () => {
+    delete process.env.CLAUDE_AGENT_NAME;
+    const tmux = process.env.TMUX;
+    const pane = process.env.TMUX_PANE;
+    // $TMUX set but pane context lost (hook/detached subprocess) — the exact
+    // shape of the mac-tor 2026-08 misattribution. Must NOT shell out.
+    process.env.TMUX = "/tmp/tmux-501/default,1,0";
+    delete process.env.TMUX_PANE;
+    try {
+      expect(resolveMyName({ node: "m5" } as never)).toBe("m5");
+    } finally {
+      if (tmux === undefined) delete process.env.TMUX; else process.env.TMUX = tmux;
+      if (pane === undefined) delete process.env.TMUX_PANE; else process.env.TMUX_PANE = pane;
+    }
+  });
 });
 
 describe("formatSignedMessage — edge branches", () => {


### PR DESCRIPTION
## What & why

#2884 gated the tmux fallback on `$TMUX` — necessary but not sufficient. `$TMUX` survives into detached/hook subprocesses, and an **unpinned** `display-message` resolves against the most recently active *client*. Under a multi-client server (mac-tor runs 7+ attached clients) a `maw hey` that lost its pane context signed as whatever session the user last touched — **zyn signed as underdog for ~30 days** before the mechanism was isolated (full investigation trail in the fleet incident notes, 2026-08-27).

## The fix

`resolveMyName`:
1. Require `$TMUX_PANE` and pin the query: `display-message -p -t '<pane>'` — deterministic under multi-client
2. No pane context → **don't guess**; fall through to `config.node`
3. Strip `-oracle` so envelopes sign with the oracle short name (`[mac-tor:underdog]`, not `[mac-tor:underdog-oracle]`) matching the `agents` registry keys

`CLAUDE_AGENT_NAME` still wins when set (unchanged, first branch).

## Tests

Adds a regression to `comm-send-default.test.ts`: `$TMUX` set but `$TMUX_PANE` absent (the exact misattribution shape) → resolves to `config.node`, never shells out. Full file green — 18/18.

## Field validation

Deployed on mac-tor live install 2026-08-27 + `CLAUDE_AGENT_NAME` stamped into 37 live sessions: self-test signs `[mac-tor:zyn]` correctly; no-pane path returns `config.node`; zero misattribution since.

Companion note: a wake-side change stamping `CLAUDE_AGENT_NAME` per session (`setSessionEnv`) makes identity fully deterministic — kept out of this PR to stay single-concern; happy to follow up if wanted.

🤖 zyn Oracle · [mac-tor:zyn] — AI-generated (Rule 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)