### PR TITLE
fix(broadcast): use isClaudeLikePane for semver pane detection

### DIFF
--- a/src/commands/plugins/tmux/impl.ts
+++ b/src/commands/plugins/tmux/impl.ts
@@ -1017,6 +1017,6 @@ export function annotatePane(
   if (team) return `team: ${team}`;
   if (fleetSessions.has(session)) return `fleet: ${session.replace(/^\d+-/, "")}`;
   if (session === "maw-view" || /-view$/.test(session)) return `view: ${session}`;
-  if (p.command?.includes("claude")) return "orphan";
+  if (isClaudeLikePane(p.command)) return "orphan";
   return "";
 }

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -43,6 +43,7 @@ export {
   HostExecError,
 } from "../core/transport/ssh";
 export type { Session as SshSession, HostExecTransport } from "../core/transport/ssh";
+export { isClaudeLikePane } from "../commands/plugins/tmux/safety";
 export { curlFetch } from "../core/transport/curl-fetch";
 export {
   getPeers, getFederationStatus, findPeerForTarget,

--- a/src/vendor/mpr-plugins/broadcast/impl.ts
+++ b/src/vendor/mpr-plugins/broadcast/impl.ts
@@ -1,4 +1,4 @@
-import { tmux } from "maw-js/sdk";
+import { tmux, isClaudeLikePane } from "maw-js/sdk";
 
 /**
  * maw broadcast <message> — send to ALL Claude windows across ALL sessions
@@ -31,9 +31,8 @@ export async function cmdBroadcast(message: string) {
     for (const w of s.windows) {
       const target = `${s.name}:${w.index}`;
       try {
-        // Check if window is running claude
         const cmd = await tmux.run("display-message", "-t", target, "-p", "#{pane_current_command}");
-        if (!cmd.trim().includes("claude")) {
+        if (!isClaudeLikePane(cmd.trim())) {
           skipped++;
           continue;
         }

--- a/src/vendor/mpr-plugins/cleanup/internal/team-cleanup-zombies.ts
+++ b/src/vendor/mpr-plugins/cleanup/internal/team-cleanup-zombies.ts
@@ -1,6 +1,6 @@
 import { readdirSync, existsSync } from "fs";
 import { join } from "path";
-import { tmux } from "maw-js/sdk";
+import { tmux, isClaudeLikePane } from "maw-js/sdk";
 import type { TmuxPane } from "maw-js/sdk";
 import { loadFleetEntries } from "maw-js/commands/shared/fleet-load";
 import { TEAMS_DIR, loadTeam } from "./team-helpers";
@@ -157,7 +157,7 @@ export function findZombiePanes(allPanes: TmuxPane[]): ZombiePane[] {
   // session (window 1, pane 0).
   return allPanes
     .filter(p =>
-      p.command?.includes("claude") &&
+      isClaudeLikePane(p.command) &&
       !knownTeamPaneIds.has(p.id) &&
       !isFleetPane(p.target) &&
       !safePaneIds.has(p.id) &&

--- a/src/vendor/mpr-plugins/team/team-cleanup-zombies.ts
+++ b/src/vendor/mpr-plugins/team/team-cleanup-zombies.ts
@@ -1,6 +1,6 @@
 import { readdirSync, existsSync } from "fs";
 import { join } from "path";
-import { tmux } from "maw-js/sdk";
+import { tmux, isClaudeLikePane } from "maw-js/sdk";
 import type { TmuxPane } from "maw-js/sdk";
 import { loadFleetEntries } from "maw-js/commands/shared/fleet-load";
 import { TEAMS_DIR, loadTeam } from "./team-helpers";
@@ -103,7 +103,7 @@ export function findZombiePanes(allPanes: TmuxPane[]): ZombiePane[] {
   // (b) not in the fleet/view (by either target OR any other listing of the same pane)
   return allPanes
     .filter(p =>
-      p.command?.includes("claude") &&
+      isClaudeLikePane(p.command) &&
       !knownTeamPaneIds.has(p.id) &&
       !isFleetPane(p.target) &&
       !safePaneIds.has(p.id)

--- a/test/broadcast-claude-detect.test.ts
+++ b/test/broadcast-claude-detect.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "bun:test";
+import { isClaudeLikePane } from "../src/commands/plugins/tmux/safety";
+
+describe("isClaudeLikePane — Claude Code pane detection", () => {
+  test("matches 'claude'", () => {
+    expect(isClaudeLikePane("claude")).toBe(true);
+  });
+
+  test("matches 'Claude' (case-insensitive)", () => {
+    expect(isClaudeLikePane("Claude")).toBe(true);
+  });
+
+  test("matches version string '2.1.202' (Claude Code v2.1.202+)", () => {
+    expect(isClaudeLikePane("2.1.202")).toBe(true);
+  });
+
+  test("matches version with whitespace", () => {
+    expect(isClaudeLikePane("  2.1.202\n")).toBe(true);
+  });
+
+  test("matches other semver patterns", () => {
+    expect(isClaudeLikePane("3.0.0")).toBe(true);
+    expect(isClaudeLikePane("10.20.300")).toBe(true);
+  });
+
+  test("rejects shell commands", () => {
+    expect(isClaudeLikePane("zsh")).toBe(false);
+    expect(isClaudeLikePane("bash")).toBe(false);
+    expect(isClaudeLikePane("fish")).toBe(false);
+  });
+
+  test("rejects other programs", () => {
+    expect(isClaudeLikePane("vim")).toBe(false);
+    expect(isClaudeLikePane("node")).toBe(false);
+    expect(isClaudeLikePane("tmux")).toBe(false);
+  });
+
+  test("rejects undefined/empty", () => {
+    expect(isClaudeLikePane(undefined)).toBe(false);
+    expect(isClaudeLikePane("")).toBe(false);
+    expect(isClaudeLikePane("   ")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Claude Code v2.1.202+ reports `pane_current_command` as the bare version string `"2.1.202"` instead of `"claude"`, breaking all code that gates on `.includes("claude")`
- `maw broadcast` delivered to **0 of 18** oracle windows (100% skip rate)
- Refactored all 5 call sites to use the existing `isClaudeLikePane()` helper from `safety.ts` — single source of truth
- Exported `isClaudeLikePane` via `maw-js/sdk` so vendor plugins can import it

## Files changed (6)
| File | Change |
|------|--------|
| `src/sdk/index.ts` | Export `isClaudeLikePane` from safety.ts |
| `src/vendor/mpr-plugins/broadcast/impl.ts` | Import + use `isClaudeLikePane` |
| `src/commands/plugins/tmux/impl.ts` | Use already-imported `isClaudeLikePane` at L1020 |
| `src/vendor/mpr-plugins/cleanup/internal/team-cleanup-zombies.ts` | Import + use |
| `src/vendor/mpr-plugins/team/team-cleanup-zombies.ts` | Import + use |
| `test/broadcast-claude-detect.test.ts` | New: 8 test cases for detection logic |

## Root cause
```
# Before fix:
tmux display-message -p '#{pane_current_command}' → "2.1.202"
"2.1.202".includes("claude") → false → skip

# After fix (isClaudeLikePane):
"2.1.202" matches /^\d+\.\d+\.\d+$/ → true → deliver
```

## Test plan
- [x] `bun test broadcast-claude-detect.test.ts` — 8 pass, 0 fail
- [x] `grep -rn '.includes("claude")' src/` — 0 matches outside safety.ts
- [x] `maw broadcast` — 18/18 sent, 0 skipped (verified on live fleet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)