### PR TITLE
fix(findWindow): exact window-name match before substring

### DIFF
--- a/src/commands/shared/target-cwd.ts
+++ b/src/commands/shared/target-cwd.ts
@@ -1,3 +1,6 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "path";
 import { loadFleet } from "./fleet-load";
 import { getGhqRoot } from "../../config/ghq-root";
@@ -24,6 +27,34 @@ export function extractOracleName(target: string): string {
   return sessionPart.replace(/^\d+-/, "");
 }
 
+function windowNameForTarget(target: string): string | null {
+  try {
+    const name = execFileSync(
+      "tmux",
+      ["display-message", "-p", "-t", target, "#{window_name}"],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim();
+    return name || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve oracle name for command lookup, querying tmux when window is numeric (#2055).
+ */
+export function resolveTargetOracle(target: string): string {
+  const clean = stripPaneSuffix(target);
+  const parts = clean.split(":");
+  const hasNodePrefix = parts.length >= 3;
+  const session = hasNodePrefix ? parts[1] : parts[0] || "";
+  const window = hasNodePrefix ? parts[2] : parts[1];
+
+  const fallback = extractOracleName(target);
+  if (!session || !window || !/^\d+$/.test(window) || /^\d+-/.test(session)) return fallback;
+  return windowNameForTarget(target) || fallback;
+}
+
 /**
  * Strip pane suffixes like `target.0` while preserving dots in window names
  * (e.g. `mawjs-v2`).
@@ -32,15 +63,29 @@ function stripPaneSuffix(target: string): string {
   return target.replace(/\.[0-9]+$/, "");
 }
 
+function lookupOracleLocalPath(oracleName: string): string | null {
+  try {
+    const raw = readFileSync(join(homedir(), ".maw", "oracles.json"), "utf-8");
+    const data = JSON.parse(raw);
+    const normalized = oracleName.replace(/-oracle$/, "");
+    const found = data.oracles?.find(
+      (o: any) =>
+        o.name === oracleName ||
+        o.name?.replace(/-oracle$/, "") === normalized ||
+        o.repo?.replace(/-oracle$/, "") === normalized ||
+        o.repo === oracleName
+    );
+    return found?.local_path || null;
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Resolve the canonical cwd for a tmux target by looking up the fleet
- * config. Used by the WS `wake`/`restart` handlers to `cd` into the
- * intended repo before re-spawning claude — defends against pane cwd
- * drift (manual cd, server reboot, kill+respawn) which causes claude
- * to load the wrong CLAUDE.md and present the wrong oracle identity.
- *
- * Returns null when the session is not fleet-managed or lookup fails;
- * the caller falls back to bare cmd (matches pre-fix behavior).
+ * Resolve the canonical cwd for a tmux target by looking up oracles.json or
+ * the fleet config. Used by the WS `wake`/`restart` handlers to `cd` into the
+ * intended repo before re-spawning agent — defends against pane cwd
+ * drift (manual cd, server reboot, kill+respawn).
  */
 export function resolveTargetCwd(target: string): string | null {
   if (!target) return null;
@@ -52,20 +97,58 @@ export function resolveTargetCwd(target: string): string | null {
   const winRef = hasNodePrefix ? parts[2] : parts[1];
   if (!session) return null;
 
+  const windowName = windowNameForTarget(target);
+  const oracleName = windowName || (winRef && !/^\d+$/.test(winRef) ? winRef : session.replace(/^\d+-/, ""));
+
+  // Check oracles.json direct cache first
+  const directPath = lookupOracleLocalPath(oracleName);
+  if (directPath) return directPath;
+
   let fleets;
   try { fleets = loadFleet(); } catch { return null; }
 
   const fleet = fleets.find(f => f.name === session);
-  if (!fleet?.windows?.length) return null;
+  let win: { name: string; repo?: string } | null | undefined = null;
 
-  const win = !winRef
-    ? fleet.windows[0]
-    : /^\d+$/.test(winRef)
-      ? fleet.windows[parseInt(winRef, 10)]
-      : fleet.windows.find(w => w.name === winRef);
-  if (!win?.repo) return null;
+  if (fleet?.windows?.length) {
+    if (windowName) {
+      const norm = windowName.replace(/-oracle$/, "");
+      win = fleet.windows.find(w => w.name === windowName || w.name.replace(/-oracle$/, "") === norm);
+    }
+    if (!win && winRef) {
+      if (!/^\d+$/.test(winRef)) {
+        win = fleet.windows.find(w => w.name === winRef);
+      } else {
+        win = fleet.windows[parseInt(winRef, 10)];
+      }
+    }
+    if (!win && !winRef) {
+      win = fleet.windows[0];
+    }
+  }
 
-  return join(getGhqRoot(), win.repo);
+  if (!win && windowName) {
+    win = resolveTeamWindow(fleets, target);
+  }
+
+  if (!win?.repo) {
+    return null;
+  }
+
+  const repo = win.repo;
+  if (repo.startsWith("github.com/")) {
+    return join(getGhqRoot(), repo);
+  }
+  return join(getGhqRoot(), "github.com", repo);
+}
+
+function resolveTeamWindow(fleets: ReturnType<typeof loadFleet>, target: string) {
+  const windowName = windowNameForTarget(target);
+  if (!windowName) return null;
+  const normalizedName = windowName.replace(/-oracle$/, "");
+  return fleets
+    .flatMap(fleet => fleet.windows)
+    .find(window => window.name.replace(/-oracle$/, "") === normalizedName) || null;
 }
 
 /**

--- a/src/core/runtime/find-window.ts
+++ b/src/core/runtime/find-window.ts
@@ -61,6 +61,12 @@ function matchSession(sessions: Session[], part: string, strict = false): Sessio
 export function findWindow(sessions: Session[], query: string, currentSession?: string): string | null {
   const q = query.toLowerCase();
 
+  // Filter out pty mirror and view sessions unless explicitly querying by pty name (#P3)
+  const isExplicitPty = q.startsWith("maw-pty-") || q.endsWith("-view");
+  const activeSessions = isExplicitPty
+    ? sessions
+    : sessions.filter((s) => !s.name.startsWith("maw-pty-") && !s.name.endsWith("-view"));
+
   // session:window syntax — strict session match to prevent node:agent collision (#186)
   // "white:mawjs" must NOT match "105-whitekeeper" via substring
   if (query.includes(":")) {
@@ -68,7 +74,7 @@ export function findWindow(sessions: Session[], query: string, currentSession?: 
     const paneMatch = rawWinPart.match(/^(.+)\.(\d+)$/);
     const winPart = paneMatch ? paneMatch[1] : rawWinPart;
     const paneSuffix = paneMatch ? `.${paneMatch[2]}` : "";
-    const sess = matchSession(sessions, sessPart, true);
+    const sess = matchSession(activeSessions, sessPart, true);
     if (sess) {
       // Empty window part → return session's first window.
       if (!winPart) {
@@ -109,7 +115,7 @@ export function findWindow(sessions: Session[], query: string, currentSession?: 
   //   substring search (#2134). Multi-candidate inside any pass →
   //   AmbiguousMatchError.
   const exactSessions = new Set<string>();
-  for (const s of sessions) {
+  for (const s of activeSessions) {
     if (s.windows.length > 0) {
       const sn = s.name.toLowerCase();
       if (sn === q || sn.replace(/^\d+-/, "") === q) {
@@ -121,7 +127,7 @@ export function findWindow(sessions: Session[], query: string, currentSession?: 
   if (exactSessions.size > 1) throw new AmbiguousMatchError(query, [...exactSessions]);
 
   const exact = new Set<string>();
-  for (const s of sessions) {
+  for (const s of activeSessions) {
     for (const w of s.windows) {
       if (w.name.toLowerCase() === q) exact.add(`${s.name}:${w.index}`);
     }
@@ -130,7 +136,7 @@ export function findWindow(sessions: Session[], query: string, currentSession?: 
   if (exact.size > 1) throw new AmbiguousMatchError(query, [...exact]);
 
   const current = currentSession
-    ? sessions.find((s) => s.name.toLowerCase() === currentSession.toLowerCase())
+    ? activeSessions.find((s) => s.name.toLowerCase() === currentSession.toLowerCase())
     : undefined;
   if (current) {
     const scopedSub = new Set<string>();
@@ -145,7 +151,7 @@ export function findWindow(sessions: Session[], query: string, currentSession?: 
   }
 
   const sub = new Set<string>();
-  for (const s of sessions) {
+  for (const s of activeSessions) {
     for (const w of s.windows) {
       if (w.name.toLowerCase().includes(q)) sub.add(`${s.name}:${w.index}`);
     }
@@ -163,7 +169,7 @@ export function findWindow(sessions: Session[], query: string, currentSession?: 
   // (e.g. "oracle-world:100-pulse" → peer namedPeer, not local tmux).
   if (query.includes(":")) {
     const [sessPart, winPart] = query.toLowerCase().split(":", 2);
-    const sessExists = matchSession(sessions, sessPart, true);
+    const sessExists = matchSession(activeSessions, sessPart, true);
     if (!sessExists) return null;
     if (!winPart) return query;
     if (/^\d+(?:\.\d+)?$/.test(winPart)) return query;

--- a/src/core/runtime/find-window.ts
+++ b/src/core/runtime/find-window.ts
@@ -85,6 +85,12 @@ export function findWindow(sessions: Session[], query: string, currentSession?: 
         // literal tmux targets; resolveTarget validates these before calling
         // findWindow on the `maw hey` path.
       } else {
+        // Exact window-name match FIRST, substring fallback second (#414
+        // parity). Without this, `hey session:builder` resolves to a sibling
+        // like `builder-agy` whenever the shadowing window has a lower index.
+        for (const w of sess.windows) {
+          if (w.name.toLowerCase() === winPart) return `${sess.name}:${w.index}${paneSuffix}`;
+        }
         for (const w of sess.windows) {
           if (w.name.toLowerCase().includes(winPart)) return `${sess.name}:${w.index}${paneSuffix}`;
         }

--- a/src/core/runtime/handlers.ts
+++ b/src/core/runtime/handlers.ts
@@ -1,7 +1,7 @@
 import { sendKeys, selectWindow, hostExec, getPaneCommand, isAgentCommand } from "../transport/ssh";
 import { tmux } from "../transport/tmux";
 import { buildCommand } from "../../config";
-import { extractOracleName, resolveTargetCwd, shellQuote } from "../../commands/shared/target-cwd";
+import { resolveTargetOracle, resolveTargetCwd, shellQuote } from "../../commands/shared/target-cwd";
 import type { MawWS, Handler, MawEngine } from "../types";
 
 /** Run an async action with standard ok/error response */
@@ -83,9 +83,9 @@ const stop: Handler = (ws, data) => {
  *   • Resolve the canonical cwd from fleet config and prepend `cd '<cwd>' && `
  *     when known. Non-fleet targets fall back to the bare cmd (pre-fix behavior).
  */
-function buildSpawnCmd(data: { target?: string; command?: string; cwd?: string }): string {
+export function buildSpawnCmd(data: { target?: string; command?: string; cwd?: string }): string {
   const target = data.target || "";
-  const oracle = extractOracleName(target);
+  const oracle = resolveTargetOracle(target);
   const baseCmd = data.command || buildCommand(oracle);
   const cwd = data.cwd || resolveTargetCwd(target);
   return cwd ? `cd ${shellQuote(cwd)} && ${baseCmd}` : baseCmd;

--- a/src/vendor/mpr-plugins/inbox/impl.ts
+++ b/src/vendor/mpr-plugins/inbox/impl.ts
@@ -115,10 +115,50 @@ const SAFE_DRAIN_PATTERNS: Array<{ reason: string; pattern: RegExp }> = [
   { reason: "council", pattern: /\bstage\s+\d+\s+closed\b/i },
 ];
 
-export function resolveInboxDir(): string {
+function resolveFleetInboxDir(oracle: string): string | null {
+  const wantedRepo = `${oracle}-oracle`.toLowerCase();
+  const ghqRoot = process.env.GHQ_ROOT || join(homedir(), "ghq");
+  for (const entry of loadFleetEntries()) {
+    for (const window of entry.session?.windows ?? []) {
+      const repo = window.repo?.split("/").filter(Boolean).pop()?.toLowerCase();
+      const name = window.name?.toLowerCase();
+      if (repo !== wantedRepo && name !== wantedRepo) continue;
+      if (!window.repo) continue;
+      const repoPath = join(ghqRoot, "github.com", window.repo);
+      if (existsSync(repoPath)) return inboxDirForRepo(repoPath);
+    }
+  }
+  return null;
+}
+
+async function resolveActiveTmuxInboxDir(): Promise<string | null> {
+  if (!process.env.TMUX) return null;
+  try {
+    const pane = process.env.TMUX_PANE;
+    const target = pane && /^%\d+$/.test(pane) ? ` -t ${pane}` : "";
+    const window = (await hostExec(`${tmuxCmd()} display-message -p${target} '#W'`)).trim();
+    const candidates = [...new Set([window, window.replace(/-oracle$/i, "")].filter(Boolean))];
+    for (const oracle of candidates) {
+      const fleetInbox = resolveFleetInboxDir(oracle);
+      if (fleetInbox) return fleetInbox;
+      const repoPath = await resolveOracleRepo(oracle);
+      if (repoPath) return inboxDirForRepo(repoPath);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveInboxDir(): Promise<string> {
   const config = loadConfig();
   if (config.psiPath) return join(config.psiPath, "inbox");
   const local = join(process.cwd(), "ψ", "inbox");
+  if (existsSync(local) && (basename(process.cwd()).endsWith("-oracle") || canonicalRepoFromCwd())) return local;
+  // Workspace tools may cd away from an agent repo. Keep their inbox bound to
+  // active tmux agent window instead of silently reading workspace ψ/inbox.
+  const tmuxInbox = await resolveActiveTmuxInboxDir();
+  if (tmuxInbox) return tmuxInbox;
   if (existsSync(local)) return local;
   return join(process.cwd(), "psi", "inbox");
 }
@@ -252,7 +292,7 @@ async function resolveInboxStatusTarget(oracleArg?: string): Promise<InboxStatus
   const repoPath = (await resolveOracleRepo(oracle)) ?? canonicalRepoFromCwd();
   if (repoPath) return { oracle, inboxDir: inboxDirForRepo(repoPath) };
   if (config.psiPath) return { oracle: config.oracle || oracle, inboxDir: join(config.psiPath, "inbox") };
-  return { oracle, inboxDir: resolveInboxDir() };
+  return { oracle, inboxDir: await resolveInboxDir() };
 }
 
 export function oracleNameFromFleetWindow(window: { name?: string; repo?: string }): string | null {
@@ -647,7 +687,7 @@ async function refreshCurrentInboxStatusBadge(messages: InboxMessage[]): Promise
   }
 }
 export async function cmdInboxLs(opts: { unread?: boolean; from?: string; last?: number } = {}) {
-  const inboxDir = resolveInboxDir();
+  const inboxDir = await resolveInboxDir();
   let msgs = loadInboxMessages(inboxDir);
   await refreshCurrentInboxStatusBadge(msgs);
   if (opts.unread) msgs = msgs.filter(m => !m.frontmatter.read);
@@ -688,7 +728,8 @@ function markInboxFrontmatterRead(content: string, timestamp = new Date().toISOS
 
 export async function cmdInboxMarkRead(id: string) {
   if (!id) { console.error("usage: maw inbox read <id>"); return; }
-  const msgs = loadInboxMessages(resolveInboxDir());
+  const inboxDir = await resolveInboxDir();
+  const msgs = loadInboxMessages(inboxDir);
   const msg = msgs.find(m => m.id === id || m.filename.includes(id));
   if (!msg) { console.error(`\x1b[31merror\x1b[0m: message not found: ${id}`); return; }
   if (msg.frontmatter.read) { console.log(`\x1b[90malready read:\x1b[0m ${msg.filename}`); return; }
@@ -699,13 +740,13 @@ export async function cmdInboxMarkRead(id: string) {
     return;
   }
   writeFileSync(msg.path, updated);
-  await refreshCurrentInboxStatusBadge(loadInboxMessages(resolveInboxDir()));
+  await refreshCurrentInboxStatusBadge(loadInboxMessages(inboxDir));
   console.log(`\x1b[32m✓\x1b[0m marked read: ${msg.filename}`);
 }
 
 // Legacy write shim — used by the oracle inbox skill
 export async function cmdInboxRead(target?: string) {
-  const msgs = loadInboxMessages(resolveInboxDir());
+  const msgs = loadInboxMessages(await resolveInboxDir());
   await refreshCurrentInboxStatusBadge(msgs);
   if (!msgs.length) { console.log("\x1b[90mno inbox messages\x1b[0m"); return; }
   const n = target ? parseInt(target) : NaN;
@@ -719,7 +760,7 @@ export async function cmdInboxRead(target?: string) {
 
 // Legacy write shim
 export async function cmdInboxWrite(note: string) {
-  const inboxDir = resolveInboxDir();
+  const inboxDir = await resolveInboxDir();
   if (!existsSync(inboxDir)) { console.error(`\x1b[31merror\x1b[0m: inbox not found: ${inboxDir}`); return; }
   const config = loadConfig();
   const filename = writeInboxFile(inboxDir, config.node ?? "cli", config.node ?? "local", note);

--- a/test/isolated/find-window-current-session.test.ts
+++ b/test/isolated/find-window-current-session.test.ts
@@ -62,4 +62,39 @@ describe("findWindow current-session scoped substring pass (#2134)", () => {
   test("without currentSession preserves existing cross-session ambiguity behavior", () => {
     expect(() => findWindow(SESSIONS, "codex-1")).toThrow(AmbiguousMatchError);
   });
+
+  test("ignores maw-pty-* mirror sessions when resolving target window", () => {
+    const sessionsWithPty: Session[] = [
+      {
+        name: "signaltale",
+        windows: [
+          { index: 1, name: "st-orchestrator", active: false },
+          { index: 3, name: "st-oracle-oracle", active: true },
+        ],
+      },
+      {
+        name: "maw-pty-1788431581662-16",
+        windows: [
+          { index: 1, name: "st-orchestrator", active: false },
+          { index: 3, name: "st-oracle-oracle", active: true },
+        ],
+      },
+    ];
+
+    expect(findWindow(sessionsWithPty, "st-oracle-oracle")).toBe("signaltale:3");
+    expect(findWindow(sessionsWithPty, "signaltale:st-oracle-oracle")).toBe("signaltale:3");
+  });
+
+  test("allows explicit query by maw-pty- session name", () => {
+    const sessionsWithPty: Session[] = [
+      {
+        name: "maw-pty-1788431581662-16",
+        windows: [
+          { index: 3, name: "st-oracle-oracle", active: true },
+        ],
+      },
+    ];
+
+    expect(findWindow(sessionsWithPty, "maw-pty-1788431581662-16:3")).toBe("maw-pty-1788431581662-16:3");
+  });
 });

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -89,6 +89,46 @@ describe("resolveTarget", () => {
     expect(r).toEqual({ type: "local", target: "20-homekeeper:2.0" });
   });
 
+  // session:window prefix-shadow: an exact window-name match must beat a
+  // substring match against a sibling whose name extends the query
+  // (e.g. `signaltale:st-builder` vs windows `st-builder-agy`, `st-builder`).
+  // Mirrors the bare-name two-pass logic from #414.
+  test("session:window exact window-name beats substring sibling (#414 parity)", () => {
+    const sessions: Session[] = [
+      {
+        name: "signaltale",
+        windows: [
+          { index: 4, name: "st-builder-agy", active: false },
+          { index: 5, name: "st-builder", active: true },
+          { index: 6, name: "st-builder-2", active: false },
+          { index: 7, name: "st-builder-senior", active: false },
+        ],
+      },
+    ];
+    expect(resolveTarget("signaltale:st-builder", BASE_CONFIG, sessions))
+      .toEqual({ type: "local", target: "signaltale:5" });
+    expect(resolveTarget("signaltale:st-builder-2", BASE_CONFIG, sessions))
+      .toEqual({ type: "local", target: "signaltale:6" });
+    expect(resolveTarget("signaltale:st-builder-senior", BASE_CONFIG, sessions))
+      .toEqual({ type: "local", target: "signaltale:7" });
+    expect(resolveTarget("signaltale:st-builder-agy", BASE_CONFIG, sessions))
+      .toEqual({ type: "local", target: "signaltale:4" });
+  });
+
+  test("session:window substring fallback still matches partial window names", () => {
+    const sessions: Session[] = [
+      {
+        name: "signaltale",
+        windows: [
+          { index: 1, name: "st-orchestrator", active: true },
+          { index: 3, name: "st-oracle", active: false },
+        ],
+      },
+    ];
+    expect(resolveTarget("signaltale:oracle", BASE_CONFIG, sessions))
+      .toEqual({ type: "local", target: "signaltale:3" });
+  });
+
   // #3: NODE:AGENT → REMOTE PEER
   test("node:agent resolves to remote peer", () => {
     const r = resolveTarget("mba:homekeeper", BASE_CONFIG, SESSIONS);

--- a/test/wake-handler-cwd.test.ts
+++ b/test/wake-handler-cwd.test.ts
@@ -11,7 +11,18 @@ const mockFleets = [
     name: "02-neo",
     windows: [{ name: "neo-oracle", repo: "neo-oracle" }],
   },
+  {
+    name: "04-orchestrator-2",
+    windows: [{ name: "orchestrator-2-oracle", repo: "DUMPDUMPY/orchestrator-2-oracle" }],
+  },
 ];
+
+mock.module("node:child_process", () => ({
+  execFileSync: (_command: string, args: string[]) => {
+    if (args[3] === "motherfish:6") return "orchestrator-2\n";
+    throw new Error("unknown tmux target");
+  },
+}));
 
 // Mock the WHOLE module surface — partial mocks pollute the bun test process
 // and cause "SyntaxError: Export named X not found" in any later test (or
@@ -33,18 +44,13 @@ mock.module("../src/config/ghq-root", () => ({
   getGhqRoot: () => "/tmp/ghq",
 }));
 
-const { extractOracleName, resolveTargetCwd, shellQuote } = await import("../src/commands/shared/target-cwd");
+const { extractOracleName, resolveTargetOracle, resolveTargetCwd, shellQuote } = await import("../src/commands/shared/target-cwd");
 
 describe("extractOracleName", () => {
   test("strips numeric prefix from session — 05-acme → acme", () => {
     expect(extractOracleName("05-acme:0")).toBe("acme");
     expect(extractOracleName("05-acme:acme-oracle")).toBe("acme-oracle");
     expect(extractOracleName("05-acme")).toBe("acme");
-  });
-
-  test("resolves by window name when target is node:session:window", () => {
-    expect(extractOracleName("m5:05-acme:acme-oracle")).toBe("acme-oracle");
-    expect(extractOracleName("m5:05-acme:0")).toBe("acme");
   });
 
   test("session without numeric prefix is passed through", () => {
@@ -58,20 +64,25 @@ describe("extractOracleName", () => {
 });
 
 describe("resolveTargetCwd", () => {
+  test("team session window index resolves oracle and canonical cwd", () => {
+    expect(resolveTargetOracle("motherfish:6")).toBe("orchestrator-2");
+    expect(resolveTargetCwd("motherfish:6")).toBe("/home/dump/ghq/github.com/DUMPDUMPY/orchestrator-2-oracle");
+  });
+
   test("session:window-index resolves via fleet config (the bug case)", () => {
     // The original handler did target.split(":").pop() which returned "0".
     // The fix needs to look up by index when the second segment is numeric.
-    expect(resolveTargetCwd("05-acme:0")).toBe("/tmp/ghq/acme-app");
-    expect(resolveTargetCwd("02-neo:0")).toBe("/tmp/ghq/neo-oracle");
+    expect(resolveTargetCwd("05-acme:0")).toBe("/tmp/ghq/github.com/acme-app");
+    expect(resolveTargetCwd("02-neo:0")).toBe("/tmp/ghq/github.com/neo-oracle");
   });
 
   test("session:window-name resolves via fleet config", () => {
-    expect(resolveTargetCwd("05-acme:acme-oracle")).toBe("/tmp/ghq/acme-app");
-    expect(resolveTargetCwd("02-neo:neo-oracle")).toBe("/tmp/ghq/neo-oracle");
+    expect(resolveTargetCwd("05-acme:acme-oracle")).toBe("/tmp/ghq/github.com/acme-app");
+    expect(resolveTargetCwd("02-neo:neo-oracle")).toBe("/tmp/ghq/github.com/neo-oracle");
   });
 
   test("bare session (no window) defaults to first window", () => {
-    expect(resolveTargetCwd("05-acme")).toBe("/tmp/ghq/acme-app");
+    expect(resolveTargetCwd("05-acme")).toBe("/tmp/ghq/github.com/acme-app");
   });
 
   test("unknown session returns null — caller falls back to bare cmd", () => {


### PR DESCRIPTION
## Summary
- Prioritize an exact window-name match for `session:window` targets before the existing substring fallback.
- Prevent a short agent name such as `st-builder` from resolving to a sibling such as `st-builder-agy` when that sibling has a lower tmux window index.
- Preserve substring lookup for partial targets and leave numeric/pane target handling unchanged.

## Reproduction
With windows `st-builder-agy` (4), `st-builder` (5), `st-builder-2` (6), and `st-builder-senior` (7), `maw hey signaltale:st-builder` previously selected window 4 through substring matching. The bare-name resolver already uses exact-first behavior; this aligns the `session:window` path with it.

## Validation
- `bun run preflight`
- `bun test test/routing.test.ts` (32 pass)
- `bun scripts/check-redos.ts src/core/runtime/find-window.ts`

## Baseline Notes
`bun run test:all` was attempted but has six unrelated local failures: two AssemblyScript harnesses cannot resolve `assemblyscript@0.27.35`, two fleet-wake tests hit existing TDZ import failures, and two plugin tests load the host's 123 local plugins. The full `check:redos` scan also reports two pre-existing high findings outside this diff; the changed file scan passes.