### PR TITLE
fix(tmux): don't false-"delivered" a message stuck above a status/HUD footer

### DIFF
--- a/src/commands/shared/comm-send.ts
+++ b/src/commands/shared/comm-send.ts
@@ -6,7 +6,7 @@ import {
   listSessions, capture, sendKeys, isAgentCommand, findPeerForTarget, resolveTarget,
   curlFetch, runHook,
 } from "../../sdk";
-import { Tmux } from "../../core/transport/tmux";
+import { Tmux, inputBoxRegion } from "../../core/transport/tmux";
 import { AmbiguousMatchError } from "../../core/runtime/find-window";
 import { detectWindowMismatch } from "../../core/routing";
 import { loadConfig, cfgLimit } from "../../config";
@@ -468,15 +468,21 @@ export interface VerifySubmitResult {
   warning?: string;
 }
 
+/** Lines to capture when verifying a submit — tall enough to include the input
+ * box even under a multi-row status/HUD/footer drawn below the prompt. */
+const SUBMIT_VERIFY_SCAN_LINES = 24;
+
 /**
  * #1907 — verify that the implicit Enter from `tmux send-keys` actually
  * submitted, by peeking the target pane and re-sending Enter if the message
  * text still sits in the input area. Up to 2 Enter retries before giving up.
  *
- * Heuristic: capture last 10 lines, search the last 3 for the first 80 chars
- * of the message. The input line is the bottommost; chat history scrolls up
- * and out of the 3-line tail under normal Claude TUI rendering. False-positive
- * cost is a benign extra Enter (no-op in most TUIs).
+ * Heuristic: capture the input box (via inputBoxRegion, which anchors at the
+ * bottom-most prompt line so a status/HUD/footer rendered BELOW the prompt does
+ * not hide the input line) and search it for the first 80 chars of the message.
+ * The message copy in the scrollback above the prompt is excluded, so a submitted
+ * message reads as delivered while one still stuck in the box reads as pending.
+ * False-positive cost is a benign extra Enter (no-op in most TUIs).
  */
 export async function verifySubmitDelivered(
   target: string,
@@ -498,14 +504,18 @@ export async function verifySubmitDelivered(
     await sleepFn(delayMs);
     let content: string;
     try {
-      content = await captureFn(target, 10, host);
+      content = await captureFn(target, SUBMIT_VERIFY_SCAN_LINES, host);
     } catch (e: unknown) {
       const reason = e instanceof Error ? e.message : String(e);
       return { delivered: false, retriesNeeded: attempt,
         warning: `submit unverified — capture-pane failed: ${reason}` };
     }
-    const tail = content.split("\n").slice(-3).join("\n");
-    if (!tail.includes(needle)) {
+    // The input box, not the last 3 lines: engines render a status/HUD/footer
+    // BELOW the prompt (Claude's "accept edits" bar, custom oracle statuslines),
+    // so an un-submitted message sits above the tail and a last-3-line search
+    // wrongly reports it delivered. inputBoxRegion anchors at the prompt line.
+    const region = inputBoxRegion(content);
+    if (!region.includes(needle)) {
       return { delivered: true, retriesNeeded: attempt };
     }
     if (attempt < maxRetries) {
@@ -945,8 +955,11 @@ export async function cmdSend(
     // for live use; opt out per-call with --no-verify-submit; auto-skip
     // under MAW_TEST_MODE so existing cmdSend mock harnesses (which don't
     // stub capture-pane) don't have to adopt the verify seam.
+    // submitVerified stays true when verification is skipped (opt-out / test).
+    let submitVerified = true;
     if (!opts.noVerifySubmit && process.env.MAW_TEST_MODE !== "1") {
       const verify = await verifySubmitDelivered(target, outboundMessage);
+      submitVerified = verify.delivered;
       if (verify.warning) {
         console.log(`  \x1b[33m⚠\x1b[0m ${verify.warning}`);
       } else if (verify.retriesNeeded > 0) {
@@ -961,7 +974,7 @@ export async function cmdSend(
     try { const content = await capture(target, 3); lastLine = content.split("\n").filter(l => l.trim()).pop() || ""; } catch {}
     emitMessageFeed({
       direction: "outbound",
-      state: "delivered",
+      state: submitVerified ? "delivered" : "queued",
       channel: "hey",
       route: "local",
       from: senderIdentity.display,
@@ -971,7 +984,15 @@ export async function cmdSend(
       lastLine,
       signed: true,
     }, config.port || 3456);
-    console.log(`\x1b[32mdelivered\x1b[0m → ${target}: ${outboundMessage}`);
+    if (submitVerified) {
+      console.log(`\x1b[32mdelivered\x1b[0m → ${target}: ${outboundMessage}`);
+    } else {
+      // The message was persisted to the receiver's ψ/inbox before injection
+      // (#1967), so it is not lost — but the live pane wake-up could not be
+      // confirmed, so don't print a green "delivered" the operator will trust.
+      console.log(`\x1b[33msent (submit unconfirmed)\x1b[0m → ${target}: ${outboundMessage}`);
+      console.log(`  \x1b[90mqueued in receiver inbox; live pane wake-up unconfirmed — check the target pane\x1b[0m`);
+    }
     if (lastLine) console.log(`\x1b[90m  ⤷ ${lastLine.slice(0, cfgLimit("messageTruncate"))}\x1b[0m`);
     await runPluginEventHooks("transport:after_send", {
       event: "transport:after_send",

--- a/src/core/transport/tmux-class.ts
+++ b/src/core/transport/tmux-class.ts
@@ -24,6 +24,54 @@ const MAX_SUBMIT_ATTEMPTS = 4;
 /** ANSI escape stripper — matches checkPaneIdle in comm-send.ts (#405). */
 const ANSI_RE = /\x1b\[[0-9;]*[mGKHFJA-Z]/g;
 
+/**
+ * How many lines to capture when locating the input box. Must be tall enough to
+ * clear any status/HUD/footer an engine renders BELOW the prompt (Claude Code's
+ * "accept edits" bar, custom oracle statuslines can be several lines) so the
+ * prompt line itself is inside the capture. The old 5-line window missed it.
+ */
+const INPUT_SCAN_LINES = 24;
+
+/**
+ * A TUI input/prompt line: an optional box border (`│`) then a prompt marker at
+ * the START of the line — Claude/Codex use `>` / `❯` / `›` / `»`, optionally
+ * wrapped as `│ > … │`. Anchored at line-start on purpose: HUD/footer rows put
+ * their content mid-line and can *end* in `%`, `>` etc. (a context percentage,
+ * an arrow), so a looser "marker anywhere / marker at end" pattern would anchor
+ * onto the status bar instead of the input box. Shell prompts (marker mid-line,
+ * e.g. `user@host:~$ `) are handled by the last-3-line fallback below and by the
+ * per-line marker check in the callers.
+ */
+const PROMPT_LINE_RE = /^\s*│?\s*[>❯›»]/;
+
+/**
+ * The slice of a captured pane from the prompt line to the bottom — i.e. the
+ * input box plus whatever status/HUD/footer is drawn under it.
+ *
+ * Why not just the last line / last 3 lines: many engines render a status bar
+ * BELOW the prompt (Claude Code's "⏵⏵ accept edits" footer, a custom oracle HUD
+ * with model/context rows, sometimes a stray artifact row). The line the user's
+ * un-submitted text actually sits on is then NOT the last line, so a last-line
+ * (or last-3-line) needle search reports "submitted" while the message is still
+ * stuck in the box. Anchoring at the bottom-most prompt line fixes that, and
+ * because we search from the prompt DOWNWARD the transcript above (which holds a
+ * copy of the message after it *is* submitted) is excluded — no false "pending".
+ *
+ * Falls back to the last 3 non-empty lines when no prompt marker is found
+ * (unknown engine / odd render), preserving the prior heuristic.
+ */
+export function inputBoxRegion(content: string): string {
+  const lines = content
+    .split("\n")
+    .map(l => l.replace(ANSI_RE, "").replace(/\r/g, ""));
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i].trim() && PROMPT_LINE_RE.test(lines[i])) {
+      return lines.slice(i).join("\n");
+    }
+  }
+  return lines.filter(l => l.trim()).slice(-3).join("\n");
+}
+
 function pendingInputNeedles(sentText: string): string[] {
   const normalized = sentText.replace(/\r/g, "").trim();
   if (!normalized) return [];
@@ -545,16 +593,19 @@ export class Tmux {
    */
   private async paneInputPending(target: string, sentText: string): Promise<boolean> {
     try {
-      const content = await this.capture(target, 5);
-      const lines = content.split("\n").filter(l => l.trim());
-      const last = (lines.at(-1) ?? "").replace(ANSI_RE, "").replace(/\r/g, "");
+      const content = await this.capture(target, INPUT_SCAN_LINES);
+      // The input box, not just the last line — an engine's status/HUD/footer
+      // can sit below the prompt, so the last line is often the footer.
+      const region = inputBoxRegion(content);
+      const promptLine = region.split("\n")[0] ?? "";
       const sentNeedles = pendingInputNeedles(sentText);
-      if (sentNeedles.some(needle => last.includes(needle))) return true;
+      if (sentNeedles.some(needle => region.includes(needle))) return true;
 
-      // Fallback: prompt marker followed by non-whitespace → user/command text
-      // still sitting on the input line. Includes Codex `›` for immediate #2380
-      // relief while sent-text detection handles unknown future engines.
-      return /[#$%>❯»›]\s+\S/.test(last);
+      // Fallback: prompt marker followed by non-whitespace on the prompt line →
+      // user/command text still sitting in the box. Checked per-line (not on the
+      // joined region) so an empty prompt above a border can't match across the
+      // newline. Includes Codex `›` (#2380) for engines with no needle match.
+      return /[#$%>❯»›]\s+\S/.test(promptLine);
     } catch {
       return false;
     }

--- a/src/core/transport/tmux.ts
+++ b/src/core/transport/tmux.ts
@@ -7,7 +7,7 @@
 
 export type { TmuxPane, TmuxWindow, TmuxSession } from "./tmux-types";
 export { resolveSocket, tmuxCmd } from "./tmux-types";
-export { Tmux, tmux } from "./tmux-class";
+export { Tmux, tmux, inputBoxRegion } from "./tmux-class";
 export type { SplitWindowLockedOpts } from "./tmux-pane-lock";
 export { withPaneLock, splitWindowLocked } from "./tmux-pane-lock";
 export type { TagPaneOpts, PaneTags } from "./tmux-pane-tags";

--- a/test/isolated/comm-send-verify-submit.test.ts
+++ b/test/isolated/comm-send-verify-submit.test.ts
@@ -190,4 +190,76 @@ describe("verifySubmitDelivered (#1907)", () => {
     expect(result.delivered).toBe(false);
     expect(result.retriesNeeded).toBe(2);
   });
+
+  // --- Claude-TUI layout: prompt line sits ABOVE a status/HUD/footer ---------
+  // A Claude Code pane (esp. with a custom oracle statusline) renders the input
+  // box, then several rows BELOW it: a separator, model/context HUD rows, the
+  // "⏵⏵ accept edits" footer, sometimes a stray artifact row. The un-submitted
+  // message is therefore NOT in the last 3 lines. The pre-fix last-3-line search
+  // reported these as delivered while the message sat stuck in the box — the
+  // exact silent-loss failure mode. inputBoxRegion anchors at the prompt line.
+  const stuckAboveHud = [
+    "  previous assistant output …",
+    "────────────────────────────────",
+    "❯ deploy the thing now",            // ← message stuck on the input line
+    "────────────────────────────────",
+    "  Model: Sonnet 5 | 5h:18%(2h47m)",
+    "  ctx:26%/1M | ↑260",
+    "  ⏵⏵ accept edits on (shift+tab to cycle) · 2 feedback dra…",
+    "                                   /rc", // stray artifact on the last line
+  ].join("\n");
+  const clearedAboveHud = [
+    "  previous assistant output …",
+    "❯ deploy the thing now",            // ← now in the transcript (submitted)
+    "────────────────────────────────",
+    "❯ ",                                 // ← input line empty
+    "────────────────────────────────",
+    "  Model: Sonnet 5 | 5h:18%(2h47m)",
+    "  ctx:26%/1M | ↑260",
+    "  ⏵⏵ accept edits on (shift+tab to cycle) · 2 feedback dra…",
+  ].join("\n");
+
+  test("stuck message above a HUD footer is caught (not falsely delivered)", async () => {
+    let enterCalls = 0;
+    const result = await verifySubmitDelivered("sess:0", "deploy the thing now", {
+      delayMs: 0,
+      captureFn: async () => stuckAboveHud, // never clears
+      sendKeysFn: async () => { enterCalls += 1; },
+      sleepFn: async () => {},
+    });
+    // Pre-fix this returned { delivered: true } — silently — because the message
+    // was outside the last-3-line tail.
+    expect(result.delivered).toBe(false);
+    expect(result.warning).toContain("submit unverified");
+    expect(enterCalls).toBe(2);
+  });
+
+  test("retry recovers a message stuck above a HUD footer", async () => {
+    let captureCalls = 0;
+    let enterCalls = 0;
+    const result = await verifySubmitDelivered("sess:0", "deploy the thing now", {
+      delayMs: 0,
+      captureFn: async () => {
+        captureCalls += 1;
+        return captureCalls === 1 ? stuckAboveHud : clearedAboveHud;
+      },
+      sendKeysFn: async () => { enterCalls += 1; },
+      sleepFn: async () => {},
+    });
+    expect(result).toEqual({ delivered: true, retriesNeeded: 1 });
+    expect(enterCalls).toBe(1);
+  });
+
+  test("submitted message in scrollback above an empty prompt is not false-pending", async () => {
+    // The transcript copy of the message is ABOVE the (empty) input line, so it
+    // must not be mistaken for un-submitted input — inputBoxRegion searches from
+    // the prompt DOWNWARD only.
+    const result = await verifySubmitDelivered("sess:0", "deploy the thing now", {
+      delayMs: 0,
+      captureFn: async () => clearedAboveHud,
+      sendKeysFn: async () => { throw new Error("must not retry — already submitted"); },
+      sleepFn: async () => {},
+    });
+    expect(result).toEqual({ delivered: true, retriesNeeded: 0 });
+  });
 });

--- a/test/tmux-class-command-builders.test.ts
+++ b/test/tmux-class-command-builders.test.ts
@@ -265,9 +265,11 @@ describe("Tmux command wrapper coverage", () => {
       "exitModeIfNeeded:s:main.0",
       "sendKeysLiteral:pending",
       "sendKeys:Enter",
-      "capture:5",
+      // capture depth widened (was 5) so the input box is included even when a
+      // status/HUD/footer is drawn below the prompt (INPUT_SCAN_LINES).
+      "capture:24",
       "sendKeys:Enter",
-      "capture:5",
+      "capture:24",
     ]);
   });
 

--- a/test/tmux-sendtext-submit.test.ts
+++ b/test/tmux-sendtext-submit.test.ts
@@ -14,7 +14,7 @@
  * tmux process, no module mock (safe for the main suite).
  */
 import { describe, test, expect } from "bun:test";
-import { Tmux } from "../src/core/transport/tmux-class";
+import { Tmux, inputBoxRegion } from "../src/core/transport/tmux-class";
 
 /** Tmux with the tmux-touching primitives stubbed + a scripted capture feed. */
 class FakeTmux extends Tmux {
@@ -159,4 +159,76 @@ describe("Tmux.sendText — confirmed submit (#6)", () => {
     },
     10_000,
   );
+
+  // Claude Code panes (esp. with a custom statusline) draw the input box, then
+  // several rows below it — a separator, model/context HUD rows, the "accept
+  // edits" footer, sometimes a stray artifact. The un-submitted message is then
+  // NOT the last line, so the old last-line check missed it and stopped after a
+  // single Enter. paneInputPending now inspects the input box region.
+  const TUI_STUCK = [
+    "  earlier assistant reply …",
+    "────────────────────────────",
+    "❯ run the deploy",              // input line, message still pending
+    "────────────────────────────",
+    "  Model: Sonnet 5 | 5h:18%",
+    "  ctx:26%/1M | ↑260",
+    "  ⏵⏵ accept edits on (shift+tab to cycle)",
+    "                        /rc",
+  ].join("\n");
+  const TUI_CLEARED = [
+    "  earlier assistant reply …",
+    "❯ run the deploy",              // moved into the transcript (submitted)
+    "────────────────────────────",
+    "❯ ",                            // input line empty
+    "────────────────────────────",
+    "  Model: Sonnet 5 | 5h:18%",
+    "  ⏵⏵ accept edits on (shift+tab to cycle)",
+  ].join("\n");
+
+  test(
+    "retries Enter for a message stuck above a Claude TUI HUD/footer",
+    async () => {
+      const t = new FakeTmux();
+      t.captureScript = [TUI_STUCK, TUI_CLEARED];
+      await t.sendText("sess:win", "run the deploy");
+
+      // pre-fix: last line was the "/rc" footer artifact → 1 blind Enter, no
+      // retry. Now the stuck input line above the HUD is seen → one retry.
+      expect(enterCount(t.calls)).toBe(2);
+      expect(t.calls.at(-1)).toBe("capture");
+    },
+    15_000,
+  );
+});
+
+describe("inputBoxRegion", () => {
+  test("anchors at the prompt line even with a HUD/footer drawn below it", () => {
+    const region = inputBoxRegion(
+      [
+        "  transcript line with the word deploy in it", // above prompt — excluded
+        "────────────",
+        "❯ deploy now",
+        "  Model: Sonnet 5",
+        "  ⏵⏵ accept edits on",
+        "                 /rc",
+      ].join("\n"),
+    );
+    expect(region.startsWith("❯ deploy now")).toBe(true);
+    expect(region.includes("deploy now")).toBe(true);
+    // the transcript copy above the prompt must not be in the region
+    expect(region.includes("transcript line")).toBe(false);
+  });
+
+  test("an empty prompt above a HUD yields a region with no pending text", () => {
+    const region = inputBoxRegion(
+      ["❯ submitted earlier", "────", "❯ ", "  Model: x", "  ⏵⏵ footer"].join("\n"),
+    );
+    expect(region.split("\n")[0]).toBe("❯ ");
+    expect(region.includes("submitted earlier")).toBe(false);
+  });
+
+  test("falls back to the last 3 non-empty lines when no prompt marker exists", () => {
+    const region = inputBoxRegion(["a", "b", "c", "d", "e"].join("\n"));
+    expect(region).toBe("c\nd\ne");
+  });
 });


### PR DESCRIPTION
## Problem

`maw hey <local target>` prints a green **`delivered`** for same-node sends, but the message sometimes never reaches the target session — while the CLI still says `delivered`. Seen repeatedly against Claude Code panes that carry a status bar / custom statusline.

Root cause: the submit confirmation from #1907 (`verifySubmitDelivered`) decides the message left the input box by searching the **last 3 captured lines** for it, assuming the input line is the bottom-most line. That holds for a bare shell or a vanilla TUI, but **not** for a Claude Code pane that renders a footer/HUD *below* the prompt:

```
❯ <the message still sitting unsent>       ← input line
────────────────────────────────
  Model: Sonnet 5 | 5h:18%(2h47m) …        ← HUD
  ctx:26%/1M | ↑260
  ⏵⏵ accept edits on (shift+tab to cycle)  ← footer
                                     /rc     ← stray artifact (last line)
```

The un-submitted message is several rows above the 3-line tail, so the needle search misses it and returns `delivered: true`. The green `delivered` prints even though the message is still stuck in the box. The same last-line assumption in `Tmux.paneInputPending` (#6) also lets `submitWithConfirm` stop retrying too early.

Live repro that confirmed it: capturing a real target pane showed an un-submitted `/rc` still in the box; the old `paneInputPending` regex, run against that pane's last line, returned `false` (i.e. "submitted") while the input clearly still held content.

## Fix

- Add `inputBoxRegion()` — anchors at the **bottom-most prompt line** (a TUI marker `>` / `❯` / `›` / `»` at line start, optionally inside a `│ … │` box) and returns the input box plus everything drawn below it. Scanning from the prompt **downward** keeps the scrollback copy of an already-submitted message excluded, so there is no false "pending" either. The marker is line-start anchored on purpose: a HUD row that merely *ends* in `%` / `>` (a context percentage, an arrow) must not be mistaken for the prompt.
- Widen the capture window (5 / 10 → 24 lines) so the prompt is inside the capture even under a multi-row footer.
- `verifySubmitDelivered` and `Tmux.paneInputPending` both use it.
- `cmdSend` no longer prints green `delivered` when the submit is unverified — it prints `sent (submit unconfirmed)` and notes the message is still queued in the receiver inbox (#1967), so the operator knows to check the pane instead of trusting a false green.

## Tests

- `inputBoxRegion` unit tests (prompt above HUD, empty prompt above HUD, no-marker fallback).
- `verifySubmitDelivered` and `Tmux.sendText` cases for the input-above-HUD layout — both **fail on the pre-fix** last-line / last-3-line logic and pass after.
- Existing suites stay green; the one builder assertion that pinned the capture depth (`capture:5`) is updated to the new depth.

## Not in this PR

`checkPaneIdle` (the pre-send idle guard) shares the same last-line assumption and can adopt `inputBoxRegion` in a focused follow-up.

---
🤖 ตอบโดย Dev จาก Toey → dev-oracle · 🤖 Generated with [Claude Code](https://claude.com/claude-code)
